### PR TITLE
Bolei/bytes per sec metrics

### DIFF
--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3/S3Flusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3/S3Flusher.java
@@ -55,7 +55,8 @@ public class S3Flusher implements SimpleSinkCommand.Flusher<RecordFleakData> {
         PutObjectRequest.builder().bucket(bucketName).key(fileKey).build();
     s3Client.putObject(putObjectRequest, RequestBody.fromBytes(serializedEvent.value()));
 
-    return new SimpleSinkCommand.FlushResult(events.size(), List.of());
+    return new SimpleSinkCommand.FlushResult(
+        events.size(), serializedEvent.value().length, List.of());
   }
 
   @Override

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SimpleSinkCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SimpleSinkCommand.java
@@ -90,10 +90,11 @@ public abstract class SimpleSinkCommand<T> extends ScalarSinkCommand {
           preparedInputEvents.rawAndPreparedList().stream()
               .map(pair -> new ErrorOutput(pair.getKey(), e.getMessage()))
               .toList();
-      flushResult = new FlushResult(0, error);
+      flushResult = new FlushResult(0, 0, error);
     }
     errorOutputs.addAll(flushResult.errorOutputList);
     sinkInitializedConfig.sinkOutputCounter().increase(flushResult.successCount, callingUserTag);
+    sinkInitializedConfig.outputSizeCounter().increase(flushResult.flushedDataSize, callingUserTag);
     SinkResult sinkResult = new SinkResult(batch.size(), flushResult.successCount, errorOutputs);
     sinkInitializedConfig.sinkErrorCounter().increase(sinkResult.errorCount(), callingUserTag);
     return sinkResult;
@@ -129,5 +130,6 @@ public abstract class SimpleSinkCommand<T> extends ScalarSinkCommand {
     }
   }
 
-  public record FlushResult(int successCount, List<ErrorOutput> errorOutputList) {}
+  public record FlushResult(
+      int successCount, long flushedDataSize, List<ErrorOutput> errorOutputList) {}
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SinkInitializedConfig.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SinkInitializedConfig.java
@@ -29,6 +29,7 @@ public record SinkInitializedConfig<T>(
     FleakCounter inputMessageCounter,
     FleakCounter errorCounter,
     FleakCounter sinkOutputCounter,
+    FleakCounter outputSizeCounter,
     FleakCounter sinkErrorCounter)
     implements InitializedConfig {
 

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SinkInitializer.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SinkInitializer.java
@@ -41,6 +41,10 @@ public class SinkInitializer<T> extends CommandInitializer {
         partsFactory.getMetricClientProvider().counter(METRIC_NAME_ERROR_EVENT_COUNT, metricTags);
     FleakCounter sinkOutputCounter =
         partsFactory.getMetricClientProvider().counter(METRIC_NAME_SINK_OUTPUT_COUNT, metricTags);
+    FleakCounter outputSizeCounter =
+        partsFactory
+            .getMetricClientProvider()
+            .counter(METRIC_NAME_OUTPUT_EVENT_SIZE_COUNT, metricTags);
     FleakCounter sinkErrorCounter = // error count during flushing phase
         partsFactory.getMetricClientProvider().counter(METRIC_NAME_SINK_ERROR_COUNT, metricTags);
 
@@ -54,6 +58,7 @@ public class SinkInitializer<T> extends CommandInitializer {
         inputMessageCounter,
         errorCounter,
         sinkOutputCounter,
+        outputSizeCounter,
         sinkErrorCounter);
   }
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/source/RawDataConverter.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/source/RawDataConverter.java
@@ -22,5 +22,5 @@ public interface RawDataConverter<T> {
    * @param sourceRecord The original record from the source
    * @return Transformed result containing either success with data or failure with original record
    */
-  ConvertedResult<T> convert(T sourceRecord);
+  ConvertedResult<T> convert(T sourceRecord, SourceInitializedConfig<?> sourceInitializedConfig);
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/source/SimpleSourceCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/source/SimpleSourceCommand.java
@@ -86,7 +86,7 @@ public abstract class SimpleSourceCommand<T> extends SourceCommand {
         }
         // 2. Convert raw input into internal data structure
         List<ConvertedResult<T>> convertedResults =
-            fetchedData.stream().map(converter::convert).toList();
+            fetchedData.stream().map(fd -> converter.convert(fd, sourceInitializedConfig)).toList();
 
         processFetchedData(convertedResults, sourceEventAcceptor, committer, dlqWriter, encoder);
       }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/source/SourceInitializedConfig.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/source/SourceInitializedConfig.java
@@ -14,6 +14,7 @@
 package io.fleak.zephflow.lib.commands.source;
 
 import io.fleak.zephflow.api.InitializedConfig;
+import io.fleak.zephflow.api.metric.FleakCounter;
 import io.fleak.zephflow.lib.dlq.DlqWriter;
 import java.io.IOException;
 
@@ -22,6 +23,9 @@ public record SourceInitializedConfig<T>(
     Fetcher<T> fetcher,
     RawDataConverter<T> converter,
     RawDataEncoder<T> encoder,
+    FleakCounter dataSizeCounter,
+    FleakCounter inputEventCounter,
+    FleakCounter deserializeFailureCounter,
     DlqWriter dlqWriter)
     implements InitializedConfig {
   @Override

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/stdout/StdOutSinkFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/stdout/StdOutSinkFlusher.java
@@ -35,16 +35,18 @@ public class StdOutSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakD
   public SimpleSinkCommand.FlushResult flush(
       SimpleSinkCommand.PreparedInputEvents<RecordFleakData> preparedInputEvents) {
     int successCount = 0;
+    long flushedDataSize = 0;
     for (RecordFleakData event : preparedInputEvents.preparedList()) {
       try {
         var serializedEvent = fleakSerializer.serialize(List.of(event));
         System.out.println(new String(serializedEvent.value()));
         successCount++;
+        flushedDataSize += serializedEvent.value().length;
       } catch (Exception e) {
         log.error("failed to write to stdout. event: {}", toJsonPayload(event), e);
       }
     }
-    return new SimpleSinkCommand.FlushResult(successCount, List.of());
+    return new SimpleSinkCommand.FlushResult(successCount, flushedDataSize, List.of());
   }
 
   @Override

--- a/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
@@ -73,6 +73,8 @@ public interface MiscUtils {
   String COMMAND_NAME_FILE_SOURCE = "filesource";
 
   String METRIC_NAME_INPUT_EVENT_COUNT = "input_event_count";
+  String METRIC_NAME_INPUT_EVENT_SIZE_COUNT = "input_event_size";
+  String METRIC_NAME_INPUT_DESER_ERR_COUNT = "input_deser_err_count";
   String METRIC_NAME_OUTPUT_EVENT_COUNT = "output_event_count";
   String METRIC_NAME_ERROR_EVENT_COUNT = "error_event_count";
   String METRIC_NAME_SINK_OUTPUT_COUNT = "sink_output_count";

--- a/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
@@ -76,6 +76,7 @@ public interface MiscUtils {
   String METRIC_NAME_INPUT_EVENT_SIZE_COUNT = "input_event_size";
   String METRIC_NAME_INPUT_DESER_ERR_COUNT = "input_deser_err_count";
   String METRIC_NAME_OUTPUT_EVENT_COUNT = "output_event_count";
+  String METRIC_NAME_OUTPUT_EVENT_SIZE_COUNT = "output_event_size";
   String METRIC_NAME_ERROR_EVENT_COUNT = "error_event_count";
   String METRIC_NAME_SINK_OUTPUT_COUNT = "sink_output_count";
   String METRIC_NAME_SINK_ERROR_COUNT = "sink_error_count";

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkFlusherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkFlusherTest.java
@@ -71,9 +71,11 @@ class KafkaSinkFlusherTest {
 
     assertEquals("test-topic", capturedRecord.topic());
     assertEquals("user123", new String(capturedRecord.key()));
-    assertNotNull(capturedRecord.value());
+    byte[] value = capturedRecord.value();
+    assertNotNull(value);
 
     assertEquals(1, result.successCount());
+    assertEquals(value.length, result.flushedDataSize());
     assertTrue(result.errorOutputList().isEmpty());
   }
 
@@ -103,6 +105,7 @@ class KafkaSinkFlusherTest {
     verify(mockProducer).send(any(ProducerRecord.class));
 
     assertEquals(0, result.successCount());
+    assertEquals(0, result.flushedDataSize());
     assertEquals(1, errorOutputs.size());
     assertEquals("Send failed", errorOutputs.getFirst().errorMessage());
     assertEquals(testEvent, errorOutputs.getFirst().inputEvent());

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaSourceFetcherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaSourceFetcherTest.java
@@ -20,7 +20,9 @@ import static org.mockito.Mockito.*;
 import com.google.common.collect.ImmutableMap;
 import io.fleak.zephflow.api.structure.FleakData;
 import io.fleak.zephflow.lib.commands.source.BytesRawDataConverter;
+import io.fleak.zephflow.lib.commands.source.SourceInitializedConfig;
 import io.fleak.zephflow.lib.serdes.EncodingType;
+import io.fleak.zephflow.lib.serdes.SerializedEvent;
 import io.fleak.zephflow.lib.serdes.des.DeserializerFactory;
 import io.fleak.zephflow.lib.serdes.des.FleakDeserializer;
 import java.time.Duration;
@@ -108,10 +110,15 @@ class KafkaSourceFetcherTest {
 
     BytesRawDataConverter converter = new BytesRawDataConverter(deserializer);
 
+    SourceInitializedConfig<SerializedEvent> sourceInitializedConfig = mock();
+    when(sourceInitializedConfig.dataSizeCounter()).thenReturn(mock());
+    when(sourceInitializedConfig.inputEventCounter()).thenReturn(mock());
+    when(sourceInitializedConfig.deserializeFailureCounter()).thenReturn(mock());
     var fetchedData = fetcher.fetch();
     var result =
         fetchedData.stream()
-            .flatMap(x -> converter.convert(x).getTransformedData().stream())
+            .flatMap(
+                x -> converter.convert(x, sourceInitializedConfig).getTransformedData().stream())
             .toList();
     // Verify that the result contains the deserialized data
     assertNotNull(result);

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/SimpleSinkCommandTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/SimpleSinkCommandTest.java
@@ -51,6 +51,7 @@ class SimpleSinkCommandTest {
   private FleakCounter inputMessageCounter;
   private FleakCounter errorCounter;
   private FleakCounter sinkOutputCounter;
+  private FleakCounter outputSizeCounter;
   private FleakCounter sinkErrorCounter;
 
   @BeforeEach
@@ -59,6 +60,7 @@ class SimpleSinkCommandTest {
     inputMessageCounter = mock();
     errorCounter = mock();
     sinkOutputCounter = mock();
+    outputSizeCounter = mock();
     sinkErrorCounter = mock();
     when(metricClientProvider.counter(eq(METRIC_NAME_INPUT_EVENT_COUNT), any()))
         .thenReturn(inputMessageCounter);
@@ -66,6 +68,8 @@ class SimpleSinkCommandTest {
         .thenReturn(errorCounter);
     when(metricClientProvider.counter(eq(METRIC_NAME_SINK_OUTPUT_COUNT), any()))
         .thenReturn(sinkOutputCounter);
+    when(metricClientProvider.counter(eq(METRIC_NAME_OUTPUT_EVENT_SIZE_COUNT), any()))
+        .thenReturn(outputSizeCounter);
     when(metricClientProvider.counter(eq(METRIC_NAME_SINK_ERROR_COUNT), any()))
         .thenReturn(sinkErrorCounter);
   }
@@ -128,6 +132,7 @@ class SimpleSinkCommandTest {
     assertEquals(List.of(3L, 2L), inputMessageCounterCaptor.getAllValues());
     verify(errorCounter, times(2)).increase(any());
     verify(sinkOutputCounter, times(2)).increase(eq(1L), any());
+    verify(outputSizeCounter, times(2)).increase(eq(100L), anyMap());
     verify(sinkErrorCounter).increase(eq(1L), any());
   }
 
@@ -166,6 +171,7 @@ class SimpleSinkCommandTest {
                     "process error")));
     assertEquals(expected, sinkResult);
     verify(errorCounter, times(2)).increase(any());
+    verify(outputSizeCounter, never()).increase(anyLong(), any());
   }
 
   private static class FakeSimpleSinkCommandFactory extends CommandFactory {
@@ -248,7 +254,7 @@ class SimpleSinkCommandTest {
         }
         successSize++;
       }
-      return new SimpleSinkCommand.FlushResult(successSize, errorOutputList);
+      return new SimpleSinkCommand.FlushResult(successSize, 100, errorOutputList);
     }
 
     @Override

--- a/runner/src/test/java/io/fleak/zephflow/runner/dag/DagExecutorTest.java
+++ b/runner/src/test/java/io/fleak/zephflow/runner/dag/DagExecutorTest.java
@@ -239,7 +239,7 @@ public class DagExecutorTest {
                               .map(RecordFleakData::unwrap)
                               .toList());
                       return new SimpleSinkCommand.FlushResult(
-                          preparedInputEvents.preparedList().size(), List.of());
+                          preparedInputEvents.preparedList().size(), 0, List.of());
                     }
 
                     @Override

--- a/runner/src/test/java/io/fleak/zephflow/runner/dag/DagExecutorTest.java
+++ b/runner/src/test/java/io/fleak/zephflow/runner/dag/DagExecutorTest.java
@@ -155,7 +155,7 @@ public class DagExecutorTest {
                 @Override
                 public RawDataConverter<RecordFleakData> createRawDataConverter(
                     CommandConfig commandConfig) {
-                  return sourceRecord ->
+                  return (sourceRecord, config) ->
                       ConvertedResult.success(List.of(sourceRecord), sourceRecord);
                 }
 

--- a/sdk/src/test/java/io/fleak/zephflow/sdk/ZephFlowTest.java
+++ b/sdk/src/test/java/io/fleak/zephflow/sdk/ZephFlowTest.java
@@ -289,8 +289,7 @@ public class ZephFlowTest {
               } else if (COMMAND_NAME_STDOUT.equals(cmdName)) {
                 return stdoutInputMessageCounter;
               } else {
-                fail();
-                return null;
+                return mock(FleakCounter.class);
               }
             });
     FleakCounter assertionOutputMessageCounter = mock();
@@ -307,6 +306,10 @@ public class ZephFlowTest {
                 return null;
               }
             });
+    when(metricClientProvider.counter(eq(METRIC_NAME_INPUT_EVENT_SIZE_COUNT), any()))
+        .thenReturn(mock());
+    when(metricClientProvider.counter(eq(METRIC_NAME_INPUT_DESER_ERR_COUNT), any()))
+        .thenReturn(mock());
     FleakCounter assertionErrorCounter = mock();
     FleakCounter stdoutErrorMessageCounter = mock();
     when(metricClientProvider.counter(eq(METRIC_NAME_ERROR_EVENT_COUNT), any()))

--- a/sdk/src/test/java/io/fleak/zephflow/sdk/ZephFlowTest.java
+++ b/sdk/src/test/java/io/fleak/zephflow/sdk/ZephFlowTest.java
@@ -339,6 +339,11 @@ public class ZephFlowTest {
     FleakCounter outputEventCounter = mock();
     when(metricClientProvider.counter(eq(METRIC_NAME_PIPELINE_OUTPUT_EVENT), any()))
         .thenReturn(outputEventCounter);
+
+    FleakCounter outputSizeCounter = mock();
+    when(metricClientProvider.counter(eq(METRIC_NAME_OUTPUT_EVENT_SIZE_COUNT), any()))
+        .thenReturn(outputSizeCounter);
+
     FleakCounter errorEventCounter = mock();
     when(metricClientProvider.counter(eq(METRIC_NAME_PIPELINE_ERROR_EVENT), any()))
         .thenReturn(errorEventCounter);


### PR DESCRIPTION
@gerrit-fleak :

source reports input data size via FleakCounter with metric name `input_event_size`;
sink reports output data size via FleakCounter with metric name `output_event_size` .

In order for the counter to work, we may need to provide a FleakCounter concrete implementation.  