### PR TITLE
downgraded jvm to java 17 for deployment target

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,12 +22,11 @@ jobs:
         with:
           fetch-depth: 0  # Important for nebula-release
 
-      - name: Set up GraalVM JDK 21
-        uses: graalvm/setup-graalvm@v1 # Check for the latest version of this action too
+      - name: Set up Oracle JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'graalvm'
-          github-token: ${{ secrets.GITHUB_TOKEN }} # Required for rate limiting
+          java-version: '17'
+          distribution: 'oracle'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
     licenseName = 'Apache License, Version 2.0'
     licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
 
-    javaVersion = '21'
+    javaVersion = '17'
     avroVersion = '1.12.0'
     junitVersion = '5.10.2' // make sure the version is the same as spring boot
     guavaVersion = '33.4.0-jre'

--- a/httpstarter/src/main/java/io/fleak/zephflow/httpstarter/WebConfig.java
+++ b/httpstarter/src/main/java/io/fleak/zephflow/httpstarter/WebConfig.java
@@ -45,13 +45,16 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
     // always addFirst to make sure these converters take precedence over default ones.
-    converters.addFirst(
+    converters.add(
+        0,
         new EventsReqHttpMessageConverter(
             APPLICATION_JSON, jsonArrayDeserializerFactory.createDeserializer()));
-    converters.addFirst(
+    converters.add(
+        0,
         new EventsReqHttpMessageConverter(
             new MediaType("text", "csv"), csvDeserializerFactory.createDeserializer()));
-    converters.addFirst(
+    converters.add(
+        0,
         new EventsReqHttpMessageConverter(
             new MediaType("text", "plain"), stringLineDeserializerFactory.createDeserializer()));
   }

--- a/httpstarter/src/test/java/io/fleak/zephflow/httpstarter/api/v1/HttpStarterIntegrationTest.java
+++ b/httpstarter/src/test/java/io/fleak/zephflow/httpstarter/api/v1/HttpStarterIntegrationTest.java
@@ -103,7 +103,7 @@ class HttpStarterIntegrationTest {
     List<WorkflowDto.Response> listWorkflowResp =
         fromJsonString(result.getResponse().getContentAsString(), new TypeReference<>() {});
     assertEquals(1, Objects.requireNonNull(listWorkflowResp).size());
-    assertEquals(createWorkflowResp, listWorkflowResp.getFirst());
+    assertEquals(createWorkflowResp, listWorkflowResp.get(0));
 
     // send event to workflow
     int eventCount = 10;

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/ExpressionValueVisitor.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/ExpressionValueVisitor.java
@@ -758,7 +758,7 @@ public class ExpressionValueVisitor extends EvalExpressionBaseVisitor<FleakData>
 
     if (argExprs.size() == 1) {
       // range(count) => equivalent to range(0, count, 1)
-      end = evalArgAsInt(argExprs.getFirst(), "count");
+      end = evalArgAsInt(argExprs.get(0), "count");
       // If count is negative, end will be negative. Start is 0, step is 1.
       // Loop condition `i < end` (e.g. `0 < -5`) will be false, resulting in empty list. Correct.
     } else if (argExprs.size() == 2) {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/python/PythonFunctionCollector.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/python/PythonFunctionCollector.java
@@ -97,10 +97,9 @@ public class PythonFunctionCollector extends EvalExpressionBaseListener {
       // 5. Validate discovery results based on DEFINED functions
       if (definedFunctions.size() == 1) {
         System.out.println(
-            "Found function defined by script: "
-                + definedFunctionNames.getFirst()); // Optional logging
+            "Found function defined by script: " + definedFunctionNames.get(0)); // Optional logging
         return new CompiledPythonFunction(
-            definedFunctionNames.getFirst(), definedFunctions.getFirst(), pythonContext);
+            definedFunctionNames.get(0), definedFunctions.get(0), pythonContext);
       }
 
       // Log or handle error: 0 or >1 functions *defined by the script* found

--- a/lib/src/main/java/io/fleak/zephflow/lib/dlq/DeadLetterS3CommiterSerializer.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/dlq/DeadLetterS3CommiterSerializer.java
@@ -29,7 +29,7 @@ public class DeadLetterS3CommiterSerializer implements S3CommiterSerializer<Dead
     SpecificDatumWriter<DeadLetter> datumWriter = new SpecificDatumWriter<>(DeadLetter.class);
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     try (DataFileWriter<DeadLetter> dataFileWriter = new DataFileWriter<>(datumWriter)) {
-      dataFileWriter.create(events.getFirst().getSchema(), outputStream);
+      dataFileWriter.create(events.get(0).getSchema(), outputStream);
       for (DeadLetter deadLetter : events) {
         dataFileWriter.append(deadLetter);
       }

--- a/lib/src/main/java/io/fleak/zephflow/lib/utils/JsonUtils.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/utils/JsonUtils.java
@@ -198,18 +198,31 @@ public abstract class JsonUtils {
   }
 
   public static JsonNode toJsonNode(FleakData data) {
-    return switch (data) {
-      case null -> null;
-      case RecordFleakData recordFleakData -> toJsonPayload(recordFleakData);
-      case ArrayFleakData arrayFleakData -> toArrayNode(arrayFleakData);
-      case StringPrimitiveFleakData ignored -> new TextNode(data.getStringValue());
-      case BooleanPrimitiveFleakData ignored -> BooleanNode.valueOf(data.isTrueValue());
-      case NumberPrimitiveFleakData numberPrimitiveFleakData ->
-          toJsonNumber(numberPrimitiveFleakData);
-      default ->
-          throw new RuntimeException(
-              String.format("value (%s) is unsupported fleak data type", data));
-    };
+    if (data == null) {
+      return null;
+    }
+
+    if (data instanceof RecordFleakData recordFleakData) {
+      return toJsonPayload(recordFleakData);
+    }
+
+    if (data instanceof ArrayFleakData arrayFleakData) {
+      return toArrayNode(arrayFleakData);
+    }
+
+    if (data instanceof StringPrimitiveFleakData) {
+      return new TextNode(data.getStringValue());
+    }
+
+    if (data instanceof BooleanPrimitiveFleakData) {
+      return BooleanNode.valueOf(data.isTrueValue());
+    }
+
+    if (data instanceof NumberPrimitiveFleakData numberPrimitiveFleakData) {
+      return toJsonNumber(numberPrimitiveFleakData);
+    }
+
+    throw new RuntimeException(String.format("value (%s) is unsupported fleak data type", data));
   }
 
   static NumericNode toJsonNumber(NumberPrimitiveFleakData data) {

--- a/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
@@ -118,9 +118,9 @@ public interface MiscUtils {
   static <T> T getOneValueFromMapEnsureExactlyOne(Map<?, T> map) {
     Preconditions.checkArgument(
         MapUtils.isNotEmpty(map)
-            && (map.size() == 1 && new ArrayList<>(map.values()).getFirst() != null),
+            && (map.size() == 1 && new ArrayList<>(map.values()).get(0) != null),
         "The map doesn't contain exactly one entry");
-    return new ArrayList<>(map.values()).getFirst();
+    return new ArrayList<>(map.values()).get(0);
   }
 
   static <T> T getOneValueFromCollectionEnsureExactlyOne(Collection<T> c) {

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/EvalCommandTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/EvalCommandTest.java
@@ -1045,12 +1045,12 @@ dict(
             List.of(inputEvent), "test_user", new MetricClientProvider.NoopMetricClientProvider());
     System.out.println(
         processResult.getFailureEvents().stream().map(ErrorOutput::errorMessage).toList());
-    System.out.println(toJsonString(processResult.getOutput().getFirst().unwrap()));
+    System.out.println(toJsonString(processResult.getOutput().get(0).unwrap()));
     assertTrue(processResult.getFailureEvents().isEmpty());
     assertEquals(1, processResult.getOutput().size());
 
     assertEquals(
         toJsonString(expected.unwrap()),
-        toJsonString(processResult.getOutput().getFirst().unwrap()));
+        toJsonString(processResult.getOutput().get(0).unwrap()));
   }
 }

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkFlusherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkFlusherTest.java
@@ -107,7 +107,7 @@ class KafkaSinkFlusherTest {
     assertEquals(0, result.successCount());
     assertEquals(0, result.flushedDataSize());
     assertEquals(1, errorOutputs.size());
-    assertEquals("Send failed", errorOutputs.getFirst().errorMessage());
-    assertEquals(testEvent, errorOutputs.getFirst().inputEvent());
+    assertEquals("Send failed", errorOutputs.get(0).errorMessage());
+    assertEquals(testEvent, errorOutputs.get(0).inputEvent());
   }
 }

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaSourceCommandTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaSourceCommandTest.java
@@ -49,7 +49,8 @@ public class KafkaSourceCommandTest {
   private static final String TOPIC_NAME = "test_topic";
 
   @Container
-  private static final KafkaContainer KAFKA_CONTAINER = new KafkaContainer("apache/kafka-native:3.8.0");
+  private static final KafkaContainer KAFKA_CONTAINER =
+      new KafkaContainer("apache/kafka-native:3.8.0");
 
   private static AdminClient adminClient;
   private static KafkaProducer<byte[], byte[]> producer;
@@ -146,7 +147,7 @@ public class KafkaSourceCommandTest {
 
       // Verify that messages were consumed
       assertEquals(3, eventConsumer.getReceivedEvents().size());
-      assertEquals(2, eventConsumer.getReceivedEvents().getFirst().unwrap().get("batch"));
+      assertEquals(2, eventConsumer.getReceivedEvents().get(0).unwrap().get("batch"));
     } finally {
       executor.shutdownNow();
       //noinspection ResultOfMethodCallIgnored

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaSourceFetcherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaSourceFetcherTest.java
@@ -144,6 +144,6 @@ class KafkaSourceFetcherTest {
             .put(METADATA_KEY, toBase64String(key))
             .build();
 
-    assertEquals(FleakData.wrap(payload), result.getFirst());
+    assertEquals(FleakData.wrap(payload), result.get(0));
   }
 }

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kinesis/KinesisFlusherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kinesis/KinesisFlusherTest.java
@@ -150,7 +150,7 @@ class KinesisFlusherTest {
 
     assertEquals(1, result.successCount());
     assertEquals(1, result.errorOutputList().size());
-    assertEquals("Internal error", result.errorOutputList().getFirst().errorMessage());
+    assertEquals("Internal error", result.errorOutputList().get(0).errorMessage());
   }
 
   @Test
@@ -177,11 +177,11 @@ class KinesisFlusherTest {
 
     assertEquals(0, result.successCount());
     assertEquals(1, result.errorOutputList().size());
-    assertTrue(result.errorOutputList().getFirst().errorMessage().contains("Kinesis client error"));
+    assertTrue(result.errorOutputList().get(0).errorMessage().contains("Kinesis client error"));
     assertTrue(
         result
             .errorOutputList()
-            .getFirst()
+            .get(0)
             .errorMessage()
             .contains("Received null response from Kinesis client"));
 

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3/S3SinkCommandTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3/S3SinkCommandTest.java
@@ -116,10 +116,7 @@ public class S3SinkCommandTest {
     assertEquals(1, resp.contents().size());
 
     GetObjectRequest getObjectRequest =
-        GetObjectRequest.builder()
-            .bucket(BUCKET_NAME)
-            .key(resp.contents().getFirst().key())
-            .build();
+        GetObjectRequest.builder().bucket(BUCKET_NAME).key(resp.contents().get(0).key()).build();
 
     ResponseBytes<GetObjectResponse> s3ObjectBytes = s3Client.getObjectAsBytes(getObjectRequest);
     byte[] data = s3ObjectBytes.asByteArray();

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/stdin/StdInSourceFetcherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/stdin/StdInSourceFetcherTest.java
@@ -64,7 +64,7 @@ class StdInSourceFetcherTest {
     assertNotNull(result);
     assertEquals(1, result.size());
 
-    var firstResult = result.getFirst();
+    var firstResult = result.get(0);
     assertNotNull(firstResult);
 
     // Verify the raw data in serialized event

--- a/lib/src/test/java/io/fleak/zephflow/lib/dlq/S3DlqWriterTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/dlq/S3DlqWriterTest.java
@@ -116,7 +116,7 @@ public class S3DlqWriterTest {
     List<String> objectKeys = listS3Objects(dlqWriter.s3Commiter.getS3Client());
     assertEquals(1, objectKeys.size(), "Expected one object in S3.");
 
-    String objectKey = objectKeys.getFirst();
+    String objectKey = objectKeys.get(0);
     String regex = "\\d{4}/\\d{2}/\\d{2}/\\d{2}/dead-letters-\\d+\\.avro";
     assertTrue(objectKey.matches(regex), "Object key does not match expected format.");
   }
@@ -135,7 +135,7 @@ public class S3DlqWriterTest {
     assertEquals(1, objectKeys.size(), "Expected one object in S3 after batch size reached.");
 
     List<SerializedEvent> readDeadLetters =
-        readDeadLettersFromS3(dlqWriter.s3Commiter.getS3Client(), objectKeys.getFirst());
+        readDeadLettersFromS3(dlqWriter.s3Commiter.getS3Client(), objectKeys.get(0));
 
     assertEquals(
         writtenDeadLetters.size(), readDeadLetters.size(), "Mismatch in number of dead letters.");

--- a/lib/src/test/java/io/fleak/zephflow/lib/sql/exec/GrokTests.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/sql/exec/GrokTests.java
@@ -15,66 +15,75 @@ package io.fleak.zephflow.lib.sql.exec;
 
 import io.fleak.zephflow.lib.sql.SQLInterpreter;
 import io.fleak.zephflow.lib.sql.TestSQLUtils;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class GrokTests {
 
-    @Test
-    public void testExtractIpAddress() {
-        var rows = runSQL("SELECT grok('%{IPV4:client_ip}', '192.168.1.1 - - [26/Mar/2023:10:00:00 +0000]') AS col1").toList();
-        Assertions.assertEquals(1, rows.size());
-        Assertions.assertEquals(Map.of("client_ip", "192.168.1.1"), rows.getFirst().asMap().get("col1"));
-    }
+  @Test
+  public void testExtractIpAddress() {
+    var rows =
+        runSQL(
+                "SELECT grok('%{IPV4:client_ip}', '192.168.1.1 - - [26/Mar/2023:10:00:00 +0000]') AS col1")
+            .toList();
+    Assertions.assertEquals(1, rows.size());
+    Assertions.assertEquals(Map.of("client_ip", "192.168.1.1"), rows.get(0).asMap().get("col1"));
+  }
 
-    @Test
-    public void testExtractEmail() {
-        var rows = runSQL("SELECT grok('%{EMAILADDRESS:email}', 'Contact us at support@example.com for assistance')->'email' AS col1").toList();
-        Assertions.assertEquals(1, rows.size());
-        Assertions.assertEquals("support@example.com", rows.getFirst().asMap().get("col1"));
-    }
+  @Test
+  public void testExtractEmail() {
+    var rows =
+        runSQL(
+                "SELECT grok('%{EMAILADDRESS:email}', 'Contact us at support@example.com for assistance')->'email' AS col1")
+            .toList();
+    Assertions.assertEquals(1, rows.size());
+    Assertions.assertEquals("support@example.com", rows.get(0).asMap().get("col1"));
+  }
 
-    @Test
-    public void testExtractDate() {
-        var rows = runSQL("SELECT grok('%{DATESTAMP:timestamp}', '2024-08-29 14:25:30,000 - INFO - User logged in')->'timestamp' AS col1").toList();
-        Assertions.assertEquals(1, rows.size());
-        Assertions.assertEquals("24-08-29 14:25:30,000", rows.getFirst().asMap().get("col1"));
-    }
+  @Test
+  public void testExtractDate() {
+    var rows =
+        runSQL(
+                "SELECT grok('%{DATESTAMP:timestamp}', '2024-08-29 14:25:30,000 - INFO - User logged in')->'timestamp' AS col1")
+            .toList();
+    Assertions.assertEquals(1, rows.size());
+    Assertions.assertEquals("24-08-29 14:25:30,000", rows.get(0).asMap().get("col1"));
+  }
 
-    @Test
-    public void testComplexLogEntry() {
-        var rows = runSQL("SELECT grok('%{IPV4:client_ip} - %{WORD:method} %{URIPATHPARAM:request} HTTP/%{NUMBER:http_version}', '127.0.0.1 - GET /index.html HTTP/1.1') AS col1").toList();
-        Assertions.assertEquals(1, rows.size());
-      //noinspection unchecked
-      var resultMap = (Map<String, Object>) rows.getFirst().asMap().get("col1");
-        Assertions.assertEquals("127.0.0.1", resultMap.get("client_ip"));
-        Assertions.assertEquals("GET", resultMap.get("method"));
-        Assertions.assertEquals("/index.html", resultMap.get("request"));
-        Assertions.assertEquals("1.1", resultMap.get("http_version"));
-    }
+  @Test
+  public void testComplexLogEntry() {
+    var rows =
+        runSQL(
+                "SELECT grok('%{IPV4:client_ip} - %{WORD:method} %{URIPATHPARAM:request} HTTP/%{NUMBER:http_version}', '127.0.0.1 - GET /index.html HTTP/1.1') AS col1")
+            .toList();
+    Assertions.assertEquals(1, rows.size());
+    //noinspection unchecked
+    var resultMap = (Map<String, Object>) rows.get(0).asMap().get("col1");
+    Assertions.assertEquals("127.0.0.1", resultMap.get("client_ip"));
+    Assertions.assertEquals("GET", resultMap.get("method"));
+    Assertions.assertEquals("/index.html", resultMap.get("request"));
+    Assertions.assertEquals("1.1", resultMap.get("http_version"));
+  }
 
-    private static Stream<Row> runSQL(String sql) {
-        var sqlInterpreter = SQLInterpreter.defaultInterpreter();
-        var typeSystem = sqlInterpreter.getTypeSystem();
+  private static Stream<Row> runSQL(String sql) {
+    var sqlInterpreter = SQLInterpreter.defaultInterpreter();
+    var typeSystem = sqlInterpreter.getTypeSystem();
 
-        return TestSQLUtils.runSQL(
-                Catalog.fromMap(
-                        Map.of(
-                                "events",
-                                Table.ofListOfMaps(
-                                        typeSystem,
-                                        "events",
-                                        List.of(
-                                                Map.of("log_entry", "127.0.0.1 - GET /index.html HTTP/1.1"),
-                                                Map.of("log_entry", "192.168.1.1 - - [26/Mar/2023:10:00:00 +0000]"),
-                                                Map.of("log_entry", "Contact us at support@example.com for assistance"),
-                                                Map.of("log_entry", "2024-08-29 14:25:30,000 - INFO - User logged in")
-                                        ))
-                        )),
-                sql);
-    }
+    return TestSQLUtils.runSQL(
+        Catalog.fromMap(
+            Map.of(
+                "events",
+                Table.ofListOfMaps(
+                    typeSystem,
+                    "events",
+                    List.of(
+                        Map.of("log_entry", "127.0.0.1 - GET /index.html HTTP/1.1"),
+                        Map.of("log_entry", "192.168.1.1 - - [26/Mar/2023:10:00:00 +0000]"),
+                        Map.of("log_entry", "Contact us at support@example.com for assistance"),
+                        Map.of("log_entry", "2024-08-29 14:25:30,000 - INFO - User logged in"))))),
+        sql);
+  }
 }

--- a/lib/src/test/java/io/fleak/zephflow/lib/utils/JsonUtilsTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/utils/JsonUtilsTest.java
@@ -153,10 +153,10 @@ class JsonUtilsTest {
             JsonUtils.fromJsonResource("/json/arr_num_event.json", new TypeReference<>() {}));
     Assertions.assertNotNull(arrayFleakData);
     Assertions.assertEquals(4, arrayFleakData.getArrayPayload().size());
-    Assertions.assertEquals(100, arrayFleakData.getArrayPayload().getFirst().getNumberValue());
+    Assertions.assertEquals(100, arrayFleakData.getArrayPayload().get(0).getNumberValue());
     Assertions.assertEquals(
         NumberPrimitiveFleakData.NumberType.INT,
-        arrayFleakData.getArrayPayload().getFirst().getNumberType());
+        arrayFleakData.getArrayPayload().get(0).getNumberType());
   }
 
   @Test

--- a/runner/src/main/java/io/fleak/zephflow/runner/DagExecutor.java
+++ b/runner/src/main/java/io/fleak/zephflow/runner/DagExecutor.java
@@ -104,7 +104,7 @@ public class DagExecutor {
         CollectionUtils.size(entryNodesDagAndRest.getKey().getNodes()) == 1,
         "dag executor only supports dag with exactly one entry node");
     OperatorCommand command =
-        new ArrayList<>(entryNodesDagAndRest.getKey().getNodes()).getFirst().getNodeContent();
+        new ArrayList<>(entryNodesDagAndRest.getKey().getNodes()).get(0).getNodeContent();
     Preconditions.checkArgument(command instanceof SourceCommand);
     SimpleSourceCommand<?> sourceCommand = (SimpleSourceCommand<?>) command;
     List<Edge> edgesFromSource = new ArrayList<>(entryNodesDagAndRest.getKey().getEdges());

--- a/runner/src/main/java/io/fleak/zephflow/runner/DagResult.java
+++ b/runner/src/main/java/io/fleak/zephflow/runner/DagResult.java
@@ -57,7 +57,7 @@ public class DagResult {
       boolean useDlq) {
     if (CollectionUtils.isNotEmpty(failureEvents)) {
       if (useDlq) {
-        throw new IllegalArgumentException(failureEvents.getFirst().errorMessage());
+        throw new IllegalArgumentException(failureEvents.get(0).errorMessage());
       }
       Map<String, String> tags = new HashMap<>(callingUserTag);
       tags.put(METRIC_TAG_NODE_ID, nodeId);

--- a/runner/src/main/java/io/fleak/zephflow/runner/NoSourceDagRunner.java
+++ b/runner/src/main/java/io/fleak/zephflow/runner/NoSourceDagRunner.java
@@ -53,7 +53,7 @@ public record NoSourceDagRunner(
         sourceNodeIds.size() == 1,
         String.format(
             "Only single source DAG is supported but found %d sources", sourceNodeIds.size()));
-    var sourceNodeId = sourceNodeIds.getFirst();
+    var sourceNodeId = sourceNodeIds.get(0);
     String commandName = "source_node";
 
     Map<String, String> callingUserTag = getCallingUserTag(callingUser);

--- a/runner/src/main/java/io/fleak/zephflow/runner/dag/Dag.java
+++ b/runner/src/main/java/io/fleak/zephflow/runner/dag/Dag.java
@@ -195,7 +195,7 @@ public class Dag<T> {
       if (outgoingEdges.isEmpty()) {
         continue;
       }
-      String downstream = outgoingEdges.getFirst().getTo();
+      String downstream = outgoingEdges.get(0).getTo();
       throw new IllegalStateException(
           "Invalid DAG: Sink node '"
               + node.getId()
@@ -213,7 +213,7 @@ public class Dag<T> {
       if (incomingEdges.isEmpty()) {
         continue;
       }
-      String upstream = incomingEdges.getFirst().getFrom();
+      String upstream = incomingEdges.get(0).getFrom();
       throw new IllegalStateException(
           "Invalid DAG: Source node '"
               + node.getId()
@@ -257,7 +257,7 @@ public class Dag<T> {
       if (cyclePath != null) return cyclePath;
     }
 
-    path.removeLast(); // Remove the last element, which is nodeId
+    path.remove(path.size() - 1); // Remove the last element, which is nodeId
     return null;
   }
 

--- a/runner/src/test/java/io/fleak/zephflow/runner/dag/DagTest.java
+++ b/runner/src/test/java/io/fleak/zephflow/runner/dag/DagTest.java
@@ -185,7 +185,7 @@ class DagTest {
     List<Node<String>> entryNodes = testDag.getEntryNodes();
 
     assertEquals(1, entryNodes.size());
-    assertEquals("A", entryNodes.getFirst().getId());
+    assertEquals("A", entryNodes.get(0).getId());
   }
 
   @Test
@@ -292,7 +292,7 @@ class DagTest {
     // Verify edge
     List<Edge> downstreamEdgesA = dag.downstreamEdges("A");
     assertEquals(1, downstreamEdgesA.size());
-    Edge edgeAB = downstreamEdgesA.getFirst();
+    Edge edgeAB = downstreamEdgesA.get(0);
     assertEquals("B", edgeAB.getTo());
   }
 

--- a/sdk/src/test/java/io/fleak/zephflow/sdk/S3IntegrationTest.java
+++ b/sdk/src/test/java/io/fleak/zephflow/sdk/S3IntegrationTest.java
@@ -87,10 +87,7 @@ public class S3IntegrationTest {
     assertEquals(1, resp.contents().size());
 
     GetObjectRequest getObjectRequest =
-        GetObjectRequest.builder()
-            .bucket(BUCKET_NAME)
-            .key(resp.contents().getFirst().key())
-            .build();
+        GetObjectRequest.builder().bucket(BUCKET_NAME).key(resp.contents().get(0).key()).build();
 
     ResponseBytes<GetObjectResponse> s3ObjectBytes = s3Client.getObjectAsBytes(getObjectRequest);
     byte[] data = s3ObjectBytes.asByteArray();

--- a/sdk/src/test/java/io/fleak/zephflow/sdk/ZephFlowParserNodeTest.java
+++ b/sdk/src/test/java/io/fleak/zephflow/sdk/ZephFlowParserNodeTest.java
@@ -118,7 +118,7 @@ public class ZephFlowParserNodeTest {
     assertEquals(1, objects.size());
 
     var parsedStr =
-        """
+"""
   {
     "level": "6",
     "message_number": "305011",
@@ -138,6 +138,6 @@ public class ZephFlowParserNodeTest {
   }
 """;
     Map<String, Object> expected = fromJsonString(parsedStr, new TypeReference<>() {});
-    assertEquals(expected, objects.getFirst());
+    assertEquals(expected, objects.get(0));
   }
 }

--- a/sdk/src/test/java/io/fleak/zephflow/sdk/ZephFlowTest.java
+++ b/sdk/src/test/java/io/fleak/zephflow/sdk/ZephFlowTest.java
@@ -434,8 +434,8 @@ public class ZephFlowTest {
     assertEquals(1, oddFilterNode.getOutputs().size());
 
     // Get the eval nodes that each filter connects to
-    String evenEvalId = evenFilterNode.getOutputs().getFirst();
-    String oddEvalId = oddFilterNode.getOutputs().getFirst();
+    String evenEvalId = evenFilterNode.getOutputs().get(0);
+    String oddEvalId = oddFilterNode.getOutputs().get(0);
 
     AdjacencyListDagDefinition.DagNode evenEvalNode = nodeMap.get(evenEvalId);
     AdjacencyListDagDefinition.DagNode oddEvalNode = nodeMap.get(oddEvalId);


### PR DESCRIPTION
Using java 17 so that this can be run on Databricks runtime.

In order to continue to support eval python function, we need to use Oracle JDK 17