### PR TITLE
log error messages on processing failure or kafka producer failure

### DIFF
--- a/lib/src/main/resources/log4j2.xml
+++ b/lib/src/main/resources/log4j2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="io.fleak.zephflow" level="info" additivity="false">
+      <AppenderRef ref="Console"/>
+    </Logger>
+
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/runner/src/main/java/io/fleak/zephflow/runner/NoSourceDagRunner.java
+++ b/runner/src/main/java/io/fleak/zephflow/runner/NoSourceDagRunner.java
@@ -13,6 +13,7 @@
  */
 package io.fleak.zephflow.runner;
 
+import static io.fleak.zephflow.lib.utils.JsonUtils.toJsonString;
 import static io.fleak.zephflow.lib.utils.MiscUtils.*;
 import static io.fleak.zephflow.runner.DagResult.sinkResultToOutputEvent;
 
@@ -33,6 +34,7 @@ import lombok.Builder;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.slf4j.MDC;
 
 /** Created by bolei on 3/4/25 */
@@ -75,6 +77,9 @@ public record NoSourceDagRunner(
     counters.stopStopWatch(callingUserTag);
     MDC.clear();
     dagResult.consolidateSinkResult(); // merge all sinkResults and put them into outputEvents
+    if (MapUtils.isNotEmpty(dagResult.getErrorByStep())) {
+      log.error("failed to process events: {}", toJsonString(dagResult.errorByStep));
+    }
     return dagResult;
   }
 


### PR DESCRIPTION
By default, all processing failures are printed out using log4j console appender. This helps debugging the ZephFlow SDK

- log errors on all failure events
- Kafka producer should log errors on producing failure 