### PR TITLE
upgrade delta kernal to 4.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,8 @@ allprojects {
     graalvmVersion = '24.2.1'
     influxDBClientVersion = '2.23'
     clickHouseVersion = '0.9.0'
-    hadoopVersion = '3.4.1'
-    deltaKernelVersion = '3.3.1'
+    hadoopVersion = '3.4.0'
+    deltaKernelVersion = '4.0.0'
   }
 
   sourceCompatibility = javaVersion

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/deltalakesink/DeltaLakeWriter.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/deltalakesink/DeltaLakeWriter.java
@@ -144,7 +144,7 @@ public class DeltaLakeWriter implements SimpleSinkCommand.Flusher<Map<String, Ob
     log.debug("Starting Delta Lake write operation for {} records", dataToWrite.size());
 
     // Table existence already validated during initialization - use the existing table
-    StructType tableSchema = table.getLatestSnapshot(engine).getSchema(engine);
+    StructType tableSchema = table.getLatestSnapshot(engine).getSchema();
     log.debug("Using table schema: {}", tableSchema);
 
     // Step 2: Create transaction


### PR DESCRIPTION
deltaKernel `3.3.1` brings in hadoop-client-runtime `3.3.4`, which includes shaded kerb-admin 1.0.1, that contains https://www.cve.org/CVERecord?id=CVE-2023-25613

delta kernel 4.0.0 uses hadoop-client-runtime `3.4.0` that contains the fix. 