### PR TITLE
GCS DLQ support for ADC

### DIFF
--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/deltalakesink/DeltaLakeStorageCredentialUtils.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/deltalakesink/DeltaLakeStorageCredentialUtils.java
@@ -100,7 +100,9 @@ public interface DeltaLakeStorageCredentialUtils {
         Configuration hadoopConf, String tablePath, Object credentialObj, String credentialId) {
       GcpCredential credential = (GcpCredential) credentialObj;
       // Set project ID
-      hadoopConf.set("fs.gs.project.id", credential.getProjectId());
+      if (credential.getProjectId() != null) {
+        hadoopConf.set("fs.gs.project.id", credential.getProjectId());
+      }
 
       switch (credential.getAuthType()) {
         case SERVICE_ACCOUNT_JSON_KEYFILE -> {
@@ -150,6 +152,14 @@ public interface DeltaLakeStorageCredentialUtils {
           // Set access token - this might require custom token provider implementation
           hadoopConf.set("google.cloud.auth.access.token", credential.getAccessToken());
           log.debug("Applied GCS access token authentication");
+        }
+        case APPLICATION_DEFAULT -> {
+          // Let the GCS Hadoop connector use its default credential chain (ADC).
+          // No explicit auth configuration needed — the connector will resolve
+          // credentials from: GKE Workload Identity, Compute Engine metadata,
+          // GOOGLE_APPLICATION_CREDENTIALS env var, or gcloud CLI login.
+          log.info(
+              "Using Application Default Credentials for GCS (credentialId: {})", credentialId);
         }
       }
     }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/deltalakesink/DeltaLakeStorageCredentialUtils.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/deltalakesink/DeltaLakeStorageCredentialUtils.java
@@ -99,7 +99,6 @@ public interface DeltaLakeStorageCredentialUtils {
     public void applyCredentials(
         Configuration hadoopConf, String tablePath, Object credentialObj, String credentialId) {
       GcpCredential credential = (GcpCredential) credentialObj;
-      // Set project ID
       if (credential.getProjectId() != null) {
         hadoopConf.set("fs.gs.project.id", credential.getProjectId());
       }
@@ -153,14 +152,9 @@ public interface DeltaLakeStorageCredentialUtils {
           hadoopConf.set("google.cloud.auth.access.token", credential.getAccessToken());
           log.debug("Applied GCS access token authentication");
         }
-        case APPLICATION_DEFAULT -> {
-          // Let the GCS Hadoop connector use its default credential chain (ADC).
-          // No explicit auth configuration needed — the connector will resolve
-          // credentials from: GKE Workload Identity, Compute Engine metadata,
-          // GOOGLE_APPLICATION_CREDENTIALS env var, or gcloud CLI login.
-          log.info(
-              "Using Application Default Credentials for GCS (credentialId: {})", credentialId);
-        }
+        case APPLICATION_DEFAULT ->
+            log.info(
+                "Using Application Default Credentials for GCS (credentialId: {})", credentialId);
       }
     }
   }

--- a/lib/src/main/java/io/fleak/zephflow/lib/credentials/GcpCredential.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/credentials/GcpCredential.java
@@ -26,6 +26,8 @@ import lombok.NonNull;
  * <p>Supported authentication methods:
  *
  * <ul>
+ *   <li>Application Default Credentials - Recommended (uses GCP's default credential chain:
+ *       environment variables, workload identity, GCE metadata, gcloud CLI)
  *   <li>OAuth Access Token - Recommended (keeps credentials in memory only)
  *   <li>Service Account JSON keyfile - Supported but NOT recommended (writes credentials to temp
  *       file on disk)
@@ -34,6 +36,12 @@ import lombok.NonNull;
  * <p>Usage examples:
  *
  * <pre>
+ * // Application Default Credentials (recommended - no key management needed)
+ * GcpCredential credential = GcpCredential.builder()
+ *     .authType(AuthType.APPLICATION_DEFAULT)
+ *     .projectId("my-project-123")  // optional, can be inferred from environment
+ *     .build();
+ *
  * // OAuth Access Token (recommended - secure in-memory auth)
  * GcpCredential credential = GcpCredential.builder()
  *     .authType(AuthType.ACCESS_TOKEN)
@@ -60,7 +68,13 @@ public class GcpCredential implements Serializable {
     /** Use service account JSON keyfile for authentication */
     SERVICE_ACCOUNT_JSON_KEYFILE,
     /** Use OAuth access token for authentication */
-    ACCESS_TOKEN
+    ACCESS_TOKEN,
+    /**
+     * Use Application Default Credentials (ADC). Automatically resolves credentials from: GKE
+     * Workload Identity, Compute Engine metadata, GOOGLE_APPLICATION_CREDENTIALS env var, gcloud
+     * CLI login, and OIDC Workload Identity Federation.
+     */
+    APPLICATION_DEFAULT
   }
 
   /** Authentication type */
@@ -78,6 +92,6 @@ public class GcpCredential implements Serializable {
    */
   String accessToken;
 
-  /** GCP project ID associated with this credential */
-  @NonNull String projectId;
+  /** GCP project ID associated with this credential. May be null for APPLICATION_DEFAULT. */
+  String projectId;
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/credentials/GcpCredential.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/credentials/GcpCredential.java
@@ -20,43 +20,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
-/**
- * Credential for Google Cloud Platform services (GCS, BigQuery, etc.)
- *
- * <p>Supported authentication methods:
- *
- * <ul>
- *   <li>Application Default Credentials - Recommended (uses GCP's default credential chain:
- *       environment variables, workload identity, GCE metadata, gcloud CLI)
- *   <li>OAuth Access Token - Recommended (keeps credentials in memory only)
- *   <li>Service Account JSON keyfile - Supported but NOT recommended (writes credentials to temp
- *       file on disk)
- * </ul>
- *
- * <p>Usage examples:
- *
- * <pre>
- * // Application Default Credentials (recommended - no key management needed)
- * GcpCredential credential = GcpCredential.builder()
- *     .authType(AuthType.APPLICATION_DEFAULT)
- *     .projectId("my-project-123")  // optional, can be inferred from environment
- *     .build();
- *
- * // OAuth Access Token (recommended - secure in-memory auth)
- * GcpCredential credential = GcpCredential.builder()
- *     .authType(AuthType.ACCESS_TOKEN)
- *     .accessToken("ya29.c.ElqKB...")
- *     .projectId("my-project-123")
- *     .build();
- *
- * // Service Account JSON (supported but NOT recommended - security risk)
- * GcpCredential credential = GcpCredential.builder()
- *     .authType(AuthType.SERVICE_ACCOUNT_JSON_KEYFILE)
- *     .jsonKeyContent("{\"type\":\"service_account\",...}")
- *     .projectId("my-project-123")
- *     .build();
- * </pre>
- */
+/** Credential for Google Cloud Platform services (GCS, BigQuery, etc.) */
 @Data
 @Builder
 @NoArgsConstructor
@@ -69,11 +33,7 @@ public class GcpCredential implements Serializable {
     SERVICE_ACCOUNT_JSON_KEYFILE,
     /** Use OAuth access token for authentication */
     ACCESS_TOKEN,
-    /**
-     * Use Application Default Credentials (ADC). Automatically resolves credentials from: GKE
-     * Workload Identity, Compute Engine metadata, GOOGLE_APPLICATION_CREDENTIALS env var, gcloud
-     * CLI login, and OIDC Workload Identity Federation.
-     */
+    /** Use Application Default Credentials for authentication */
     APPLICATION_DEFAULT
   }
 

--- a/lib/src/main/java/io/fleak/zephflow/lib/gcp/GcsClientFactory.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/gcp/GcsClientFactory.java
@@ -32,7 +32,6 @@ public class GcsClientFactory implements Serializable {
   public Storage createStorageClient() {
     try {
       GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
-      log.info("Creating GCS client using Application Default Credentials");
       return StorageOptions.newBuilder().setCredentials(credentials).build().getService();
     } catch (IOException e) {
       throw new RuntimeException(
@@ -48,7 +47,6 @@ public class GcsClientFactory implements Serializable {
       ServiceAccountCredentials credentials =
           ServiceAccountCredentials.fromStream(
               new ByteArrayInputStream(serviceAccountJson.getBytes(StandardCharsets.UTF_8)));
-      log.info("Creating GCS client using service account JSON keyfile");
       return StorageOptions.newBuilder().setCredentials(credentials).build().getService();
     } catch (IOException e) {
       throw new RuntimeException(

--- a/lib/src/main/java/io/fleak/zephflow/lib/gcp/GcsClientFactory.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/gcp/GcsClientFactory.java
@@ -13,25 +13,79 @@
  */
 package io.fleak.zephflow.lib.gcp;
 
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import io.fleak.zephflow.lib.credentials.GcpCredential;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
+@Slf4j
 public class GcsClientFactory implements Serializable {
 
+  public Storage createStorageClient() {
+    try {
+      GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
+      log.info("Creating GCS client using Application Default Credentials");
+      return StorageOptions.newBuilder().setCredentials(credentials).build().getService();
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Failed to create GCS storage client from Application Default Credentials", e);
+    }
+  }
+
   public Storage createStorageClient(String serviceAccountJson) {
+    if (StringUtils.isBlank(serviceAccountJson)) {
+      return createStorageClient();
+    }
     try {
       ServiceAccountCredentials credentials =
           ServiceAccountCredentials.fromStream(
               new ByteArrayInputStream(serviceAccountJson.getBytes(StandardCharsets.UTF_8)));
+      log.info("Creating GCS client using service account JSON keyfile");
       return StorageOptions.newBuilder().setCredentials(credentials).build().getService();
     } catch (IOException e) {
       throw new RuntimeException(
           "Failed to create GCS storage client from service account JSON", e);
     }
+  }
+
+  public Storage createStorageClient(GcpCredential credential) {
+    try {
+      GoogleCredentials googleCredentials = resolveCredentials(credential);
+      StorageOptions.Builder builder =
+          StorageOptions.newBuilder().setCredentials(googleCredentials);
+      if (credential.getProjectId() != null) {
+        builder.setProjectId(credential.getProjectId());
+      }
+      return builder.build().getService();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to create GCS storage client", e);
+    }
+  }
+
+  private GoogleCredentials resolveCredentials(GcpCredential credential) throws IOException {
+    return switch (credential.getAuthType()) {
+      case SERVICE_ACCOUNT_JSON_KEYFILE -> {
+        log.info("Creating GCS client using service account JSON keyfile");
+        yield ServiceAccountCredentials.fromStream(
+            new ByteArrayInputStream(
+                credential.getJsonKeyContent().getBytes(StandardCharsets.UTF_8)));
+      }
+      case ACCESS_TOKEN -> {
+        log.info("Creating GCS client using OAuth access token");
+        yield GoogleCredentials.create(new AccessToken(credential.getAccessToken(), null));
+      }
+      case APPLICATION_DEFAULT -> {
+        log.info("Creating GCS client using Application Default Credentials");
+        yield GoogleCredentials.getApplicationDefault();
+      }
+    };
   }
 }

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/deltalakesink/DeltaLakeStorageCredentialUtilsTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/deltalakesink/DeltaLakeStorageCredentialUtilsTest.java
@@ -268,6 +268,40 @@ class DeltaLakeStorageCredentialUtilsTest {
   }
 
   @Test
+  void testGcsCredentialApplierWithApplicationDefault() {
+    DeltaLakeStorageCredentialUtils.GcsCredentialApplier applier =
+        new DeltaLakeStorageCredentialUtils.GcsCredentialApplier();
+    GcpCredential credential =
+        GcpCredential.builder()
+            .authType(GcpCredential.AuthType.APPLICATION_DEFAULT)
+            .projectId("test-project")
+            .build();
+
+    applier.applyCredentials(hadoopConf, "gs://bucket/path", credential, "gcs-cred");
+
+    // ADC mode should set project ID but no explicit auth properties
+    assertEquals("test-project", hadoopConf.get("fs.gs.project.id"));
+    assertNull(hadoopConf.get("google.cloud.auth.type"));
+    assertNull(hadoopConf.get("fs.gs.auth.service.account.enable"));
+    assertNull(hadoopConf.get("google.cloud.auth.access.token"));
+  }
+
+  @Test
+  void testGcsCredentialApplierWithApplicationDefaultNullProjectId() {
+    DeltaLakeStorageCredentialUtils.GcsCredentialApplier applier =
+        new DeltaLakeStorageCredentialUtils.GcsCredentialApplier();
+    GcpCredential credential =
+        GcpCredential.builder().authType(GcpCredential.AuthType.APPLICATION_DEFAULT).build();
+
+    assertDoesNotThrow(
+        () -> applier.applyCredentials(hadoopConf, "gs://bucket/path", credential, "gcs-cred"));
+
+    // No properties should be set at all
+    assertNull(hadoopConf.get("fs.gs.project.id"));
+    assertNull(hadoopConf.get("google.cloud.auth.type"));
+  }
+
+  @Test
   void testGcsCredentialApplierWithInvalidJson() {
     DeltaLakeStorageCredentialUtils.GcsCredentialApplier applier =
         new DeltaLakeStorageCredentialUtils.GcsCredentialApplier();

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/deltalakesink/DeltaLakeStorageCredentialUtilsTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/deltalakesink/DeltaLakeStorageCredentialUtilsTest.java
@@ -279,7 +279,6 @@ class DeltaLakeStorageCredentialUtilsTest {
 
     applier.applyCredentials(hadoopConf, "gs://bucket/path", credential, "gcs-cred");
 
-    // ADC mode should set project ID but no explicit auth properties
     assertEquals("test-project", hadoopConf.get("fs.gs.project.id"));
     assertNull(hadoopConf.get("google.cloud.auth.type"));
     assertNull(hadoopConf.get("fs.gs.auth.service.account.enable"));
@@ -296,7 +295,6 @@ class DeltaLakeStorageCredentialUtilsTest {
     assertDoesNotThrow(
         () -> applier.applyCredentials(hadoopConf, "gs://bucket/path", credential, "gcs-cred"));
 
-    // No properties should be set at all
     assertNull(hadoopConf.get("fs.gs.project.id"));
     assertNull(hadoopConf.get("google.cloud.auth.type"));
   }

--- a/lib/src/test/java/io/fleak/zephflow/lib/gcp/GcsClientFactoryTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/gcp/GcsClientFactoryTest.java
@@ -35,8 +35,6 @@ class GcsClientFactoryTest {
   @Test
   void testCreateStorageClientWithNullFallsBackToAdc() {
     GcsClientFactory factory = new GcsClientFactory();
-    // In CI without GCP credentials, ADC will throw. Verify we enter the ADC path
-    // by checking the exception message indicates Application Default Credentials.
     RuntimeException ex =
         assertThrows(RuntimeException.class, () -> factory.createStorageClient((String) null));
     assertTrue(
@@ -71,7 +69,6 @@ class GcsClientFactoryTest {
             .authType(GcpCredential.AuthType.APPLICATION_DEFAULT)
             .projectId("test-project")
             .build();
-    // ADC will throw in CI without GCP credentials — verify the ADC path is entered
     RuntimeException ex =
         assertThrows(RuntimeException.class, () -> factory.createStorageClient(credential));
     assertTrue(
@@ -84,7 +81,6 @@ class GcsClientFactoryTest {
     GcsClientFactory factory = new GcsClientFactory();
     GcpCredential credential =
         GcpCredential.builder().authType(GcpCredential.AuthType.APPLICATION_DEFAULT).build();
-    // Verify null projectId does not cause NPE — should still reach ADC path
     RuntimeException ex =
         assertThrows(RuntimeException.class, () -> factory.createStorageClient(credential));
     assertTrue(
@@ -101,7 +97,6 @@ class GcsClientFactoryTest {
             .accessToken("ya29.test-token")
             .projectId("test-project")
             .build();
-    // Access token credentials don't need network — this should succeed
     assertDoesNotThrow(() -> factory.createStorageClient(credential));
   }
 

--- a/lib/src/test/java/io/fleak/zephflow/lib/gcp/GcsClientFactoryTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/gcp/GcsClientFactoryTest.java
@@ -15,6 +15,7 @@ package io.fleak.zephflow.lib.gcp;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.fleak.zephflow.lib.credentials.GcpCredential;
 import org.junit.jupiter.api.Test;
 
 class GcsClientFactoryTest {
@@ -29,5 +30,90 @@ class GcsClientFactoryTest {
   void testCreateStorageClientWithEmptyJson() {
     GcsClientFactory factory = new GcsClientFactory();
     assertThrows(RuntimeException.class, () -> factory.createStorageClient("{}"));
+  }
+
+  @Test
+  void testCreateStorageClientWithNullFallsBackToAdc() {
+    GcsClientFactory factory = new GcsClientFactory();
+    // In CI without GCP credentials, ADC will throw. Verify we enter the ADC path
+    // by checking the exception message indicates Application Default Credentials.
+    RuntimeException ex =
+        assertThrows(RuntimeException.class, () -> factory.createStorageClient((String) null));
+    assertTrue(
+        ex.getMessage().contains("Application Default Credentials"),
+        "Expected ADC error but got: " + ex.getMessage());
+  }
+
+  @Test
+  void testCreateStorageClientWithBlankFallsBackToAdc() {
+    GcsClientFactory factory = new GcsClientFactory();
+    RuntimeException ex =
+        assertThrows(RuntimeException.class, () -> factory.createStorageClient("   "));
+    assertTrue(
+        ex.getMessage().contains("Application Default Credentials"),
+        "Expected ADC error but got: " + ex.getMessage());
+  }
+
+  @Test
+  void testCreateStorageClientNoArgFallsBackToAdc() {
+    GcsClientFactory factory = new GcsClientFactory();
+    RuntimeException ex = assertThrows(RuntimeException.class, factory::createStorageClient);
+    assertTrue(
+        ex.getMessage().contains("Application Default Credentials"),
+        "Expected ADC error but got: " + ex.getMessage());
+  }
+
+  @Test
+  void testCreateStorageClientWithGcpCredentialAdc() {
+    GcsClientFactory factory = new GcsClientFactory();
+    GcpCredential credential =
+        GcpCredential.builder()
+            .authType(GcpCredential.AuthType.APPLICATION_DEFAULT)
+            .projectId("test-project")
+            .build();
+    // ADC will throw in CI without GCP credentials — verify the ADC path is entered
+    RuntimeException ex =
+        assertThrows(RuntimeException.class, () -> factory.createStorageClient(credential));
+    assertTrue(
+        ex.getMessage().contains("Failed to create GCS storage client"),
+        "Expected GCS client creation error but got: " + ex.getMessage());
+  }
+
+  @Test
+  void testCreateStorageClientWithGcpCredentialAdcNullProjectId() {
+    GcsClientFactory factory = new GcsClientFactory();
+    GcpCredential credential =
+        GcpCredential.builder().authType(GcpCredential.AuthType.APPLICATION_DEFAULT).build();
+    // Verify null projectId does not cause NPE — should still reach ADC path
+    RuntimeException ex =
+        assertThrows(RuntimeException.class, () -> factory.createStorageClient(credential));
+    assertTrue(
+        ex.getMessage().contains("Failed to create GCS storage client"),
+        "Expected GCS client creation error but got: " + ex.getMessage());
+  }
+
+  @Test
+  void testCreateStorageClientWithGcpCredentialAccessToken() {
+    GcsClientFactory factory = new GcsClientFactory();
+    GcpCredential credential =
+        GcpCredential.builder()
+            .authType(GcpCredential.AuthType.ACCESS_TOKEN)
+            .accessToken("ya29.test-token")
+            .projectId("test-project")
+            .build();
+    // Access token credentials don't need network — this should succeed
+    assertDoesNotThrow(() -> factory.createStorageClient(credential));
+  }
+
+  @Test
+  void testCreateStorageClientWithGcpCredentialServiceAccountJson() {
+    GcsClientFactory factory = new GcsClientFactory();
+    GcpCredential credential =
+        GcpCredential.builder()
+            .authType(GcpCredential.AuthType.SERVICE_ACCOUNT_JSON_KEYFILE)
+            .jsonKeyContent("not-valid-json")
+            .projectId("test-project")
+            .build();
+    assertThrows(RuntimeException.class, () -> factory.createStorageClient(credential));
   }
 }


### PR DESCRIPTION
To use ADC, simply omit the `serviceAccountJson` field from your GCS DLQ config. 

It will automatically discover credentials from the environment — supporting GKE Workload Identity, Compute Engine metadata, OIDC Workload Identity Federation, GOOGLE_APPLICATION_CREDENTIALS env var, and gcloud CLI login.