### PR TITLE
Add SQS source and sink connectors

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,6 +86,7 @@ aws-s3-transfer-manager = { module = "software.amazon.awssdk:s3-transfer-manager
 aws-kinesis-client = { module = "software.amazon.kinesis:amazon-kinesis-client", version.ref = "awsKinesis" }
 aws-dynamodb = { module = "software.amazon.awssdk:dynamodb", version.ref = "aws" }
 aws-cloudwatch = { module = "software.amazon.awssdk:cloudwatch", version.ref = "aws" }
+aws-sqs = { module = "software.amazon.awssdk:sqs", version.ref = "aws" }
 
 kafka-clients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafka" }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -16,6 +16,7 @@ dependencies {
   implementation libs.aws.kinesis.client
   implementation libs.aws.dynamodb
   implementation libs.aws.cloudwatch
+  implementation libs.aws.sqs
 
   implementation libs.kafka.clients
   implementation libs.clickhouse.client

--- a/lib/src/main/java/io/fleak/zephflow/lib/aws/AwsClientFactory.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/aws/AwsClientFactory.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.awssdk.services.kinesis.KinesisClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 
 /** Created by bolei on 8/6/24 */
@@ -86,6 +87,13 @@ public class AwsClientFactory implements Serializable {
   public KinesisClient createKinesisClient(
       String regionStr, UsernamePasswordCredential usernamePasswordCredential) {
     var builder = KinesisClient.builder();
+    builder = setupClientBuilder(builder, regionStr, usernamePasswordCredential);
+    return builder.build();
+  }
+
+  public SqsClient createSqsClient(
+      String regionStr, UsernamePasswordCredential usernamePasswordCredential) {
+    var builder = SqsClient.builder();
     builder = setupClientBuilder(builder, regionStr, usernamePasswordCredential);
     return builder.build();
   }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/OperatorCommandRegistry.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/OperatorCommandRegistry.java
@@ -34,6 +34,8 @@ import io.fleak.zephflow.lib.commands.reader.ReaderCommandFactory;
 import io.fleak.zephflow.lib.commands.s3.S3SinkCommandFactory;
 import io.fleak.zephflow.lib.commands.splunksource.SplunkSourceCommandFactory;
 import io.fleak.zephflow.lib.commands.sql.SqlCommandFactory;
+import io.fleak.zephflow.lib.commands.sqssink.SqsSinkCommandFactory;
+import io.fleak.zephflow.lib.commands.sqssource.SqsSourceCommandFactory;
 import io.fleak.zephflow.lib.commands.stdin.StdInCommandFactory;
 import io.fleak.zephflow.lib.commands.stdout.StdOutSinkCommandFactory;
 import io.fleak.zephflow.lib.commands.syslogudp.SyslogUdpCommandFactory;
@@ -64,5 +66,7 @@ public interface OperatorCommandRegistry {
           .put(COMMAND_NAME_DATABRICKS_SINK, new DatabricksSinkCommandFactory())
           .put(COMMAND_NAME_SYSLOG_UDP, new SyslogUdpCommandFactory())
           .put(COMMAND_NAME_ACTIVEMQ_SOURCE, new ActiveMqSourceCommandFactory())
+          .put(COMMAND_NAME_SQS_SOURCE, new SqsSourceCommandFactory())
+          .put(COMMAND_NAME_SQS_SINK, new SqsSinkCommandFactory())
           .build();
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssink/SqsOutboundMessage.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssink/SqsOutboundMessage.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssink;
+
+public record SqsOutboundMessage(String body, String messageGroupId, String deduplicationId) {}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkCommand.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssink;
+
+import static io.fleak.zephflow.lib.utils.MiscUtils.*;
+
+import io.fleak.zephflow.api.*;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.lib.aws.AwsClientFactory;
+import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
+import io.fleak.zephflow.lib.commands.sink.SinkExecutionContext;
+import io.fleak.zephflow.lib.credentials.UsernamePasswordCredential;
+import io.fleak.zephflow.lib.pathselect.PathExpression;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.services.sqs.SqsClient;
+
+public class SqsSinkCommand extends SimpleSinkCommand<SqsOutboundMessage> {
+
+  private final AwsClientFactory awsClientFactory;
+
+  protected SqsSinkCommand(
+      String nodeId,
+      JobContext jobContext,
+      ConfigParser configParser,
+      ConfigValidator configValidator,
+      AwsClientFactory awsClientFactory) {
+    super(nodeId, jobContext, configParser, configValidator);
+    this.awsClientFactory = awsClientFactory;
+  }
+
+  @Override
+  public String commandName() {
+    return COMMAND_NAME_SQS_SINK;
+  }
+
+  @Override
+  protected ExecutionContext createExecutionContext(
+      MetricClientProvider metricClientProvider,
+      JobContext jobContext,
+      CommandConfig commandConfig,
+      String nodeId) {
+    SinkCounters counters =
+        createSinkCounters(metricClientProvider, jobContext, commandName(), nodeId);
+
+    SqsSinkDto.Config config = (SqsSinkDto.Config) commandConfig;
+    SimpleSinkCommand.Flusher<SqsOutboundMessage> flusher = createSqsFlusher(config, jobContext);
+    SimpleSinkCommand.SinkMessagePreProcessor<SqsOutboundMessage> messagePreProcessor =
+        createMessagePreProcessor(config);
+
+    return new SinkExecutionContext<>(
+        flusher,
+        messagePreProcessor,
+        counters.inputMessageCounter(),
+        counters.errorCounter(),
+        counters.sinkOutputCounter(),
+        counters.outputSizeCounter(),
+        counters.sinkErrorCounter());
+  }
+
+  private SimpleSinkCommand.Flusher<SqsOutboundMessage> createSqsFlusher(
+      SqsSinkDto.Config config, JobContext jobContext) {
+    Optional<UsernamePasswordCredential> credentialOpt =
+        lookupUsernamePasswordCredentialOpt(jobContext, config.getCredentialId());
+
+    SqsClient sqsClient =
+        awsClientFactory.createSqsClient(config.getRegionStr(), credentialOpt.orElse(null));
+
+    return new SqsSinkFlusher(sqsClient, config.getQueueUrl());
+  }
+
+  private SimpleSinkCommand.SinkMessagePreProcessor<SqsOutboundMessage> createMessagePreProcessor(
+      SqsSinkDto.Config config) {
+    PathExpression messageGroupIdExpression =
+        StringUtils.isNotBlank(config.getMessageGroupIdExpression())
+            ? PathExpression.fromString(config.getMessageGroupIdExpression())
+            : null;
+    PathExpression deduplicationIdExpression =
+        StringUtils.isNotBlank(config.getDeduplicationIdExpression())
+            ? PathExpression.fromString(config.getDeduplicationIdExpression())
+            : null;
+
+    return new SqsSinkMessageProcessor(messageGroupIdExpression, deduplicationIdExpression);
+  }
+
+  @Override
+  protected int batchSize() {
+    return SqsSinkDto.MAX_BATCH_SIZE;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkCommandFactory.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkCommandFactory.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssink;
+
+import io.fleak.zephflow.api.CommandFactory;
+import io.fleak.zephflow.api.CommandType;
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.api.OperatorCommand;
+import io.fleak.zephflow.lib.aws.AwsClientFactory;
+import io.fleak.zephflow.lib.commands.JsonConfigParser;
+
+public class SqsSinkCommandFactory extends CommandFactory {
+  @Override
+  public OperatorCommand createCommand(String nodeId, JobContext jobContext) {
+    JsonConfigParser<SqsSinkDto.Config> configParser =
+        new JsonConfigParser<>(SqsSinkDto.Config.class);
+    SqsSinkConfigValidator validator = new SqsSinkConfigValidator();
+    AwsClientFactory awsClientFactory = new AwsClientFactory();
+    return new SqsSinkCommand(nodeId, jobContext, configParser, validator, awsClientFactory);
+  }
+
+  @Override
+  public CommandType commandType() {
+    return CommandType.SINK;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkConfigValidator.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkConfigValidator.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssink;
+
+import static io.fleak.zephflow.lib.utils.MiscUtils.*;
+
+import com.google.common.base.Preconditions;
+import io.fleak.zephflow.api.CommandConfig;
+import io.fleak.zephflow.api.ConfigValidator;
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.lib.pathselect.PathExpression;
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import io.fleak.zephflow.lib.serdes.ser.SerializerFactory;
+import org.apache.commons.lang3.StringUtils;
+
+public class SqsSinkConfigValidator implements ConfigValidator {
+  @Override
+  public void validateConfig(CommandConfig commandConfig, String nodeId, JobContext jobContext) {
+    SqsSinkDto.Config config = (SqsSinkDto.Config) commandConfig;
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.getQueueUrl()), "no queue URL is provided");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.getRegionStr()), "no region is provided");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.getEncodingType()), "no encoding type is provided");
+
+    EncodingType encodingType = parseEnum(EncodingType.class, config.getEncodingType());
+    SerializerFactory.validateEncodingType(encodingType);
+
+    if (config.getBatchSize() != null) {
+      Preconditions.checkArgument(
+          config.getBatchSize() >= 1 && config.getBatchSize() <= SqsSinkDto.MAX_BATCH_SIZE,
+          "batchSize must be between 1 and %s",
+          SqsSinkDto.MAX_BATCH_SIZE);
+    }
+
+    boolean isFifoQueue = config.getQueueUrl().endsWith(".fifo");
+    if (isFifoQueue) {
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(config.getMessageGroupIdExpression()),
+          "messageGroupIdExpression is required for FIFO queues");
+    }
+
+    if (StringUtils.isNotBlank(config.getMessageGroupIdExpression())) {
+      PathExpression.fromString(config.getMessageGroupIdExpression());
+    }
+    if (StringUtils.isNotBlank(config.getDeduplicationIdExpression())) {
+      PathExpression.fromString(config.getDeduplicationIdExpression());
+    }
+
+    if (StringUtils.trimToNull(config.getCredentialId()) != null
+        && enforceCredentials(jobContext)) {
+      lookupUsernamePasswordCredential(jobContext, config.getCredentialId());
+    }
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkDto.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssink;
+
+import io.fleak.zephflow.api.CommandConfig;
+import lombok.*;
+
+public interface SqsSinkDto {
+
+  int DEFAULT_BATCH_SIZE = 10;
+  int MAX_BATCH_SIZE = 10;
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  class Config implements CommandConfig {
+    @NonNull private String queueUrl;
+    @NonNull private String regionStr;
+    @NonNull private String encodingType;
+    private String credentialId;
+    private String messageGroupIdExpression;
+    private String deduplicationIdExpression;
+    @Builder.Default private Integer batchSize = DEFAULT_BATCH_SIZE;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkFlusher.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssink;
+
+import io.fleak.zephflow.api.ErrorOutput;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.BatchResultErrorEntry;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+
+@Slf4j
+public class SqsSinkFlusher implements SimpleSinkCommand.Flusher<SqsOutboundMessage> {
+
+  private final SqsClient sqsClient;
+  private final String queueUrl;
+
+  public SqsSinkFlusher(SqsClient sqsClient, String queueUrl) {
+    this.sqsClient = sqsClient;
+    this.queueUrl = queueUrl;
+  }
+
+  @Override
+  public SimpleSinkCommand.FlushResult flush(
+      SimpleSinkCommand.PreparedInputEvents<SqsOutboundMessage> preparedInputEvents,
+      Map<String, String> metricTags)
+      throws Exception {
+
+    List<SqsOutboundMessage> messages = preparedInputEvents.preparedList();
+    if (messages.isEmpty()) {
+      return new SimpleSinkCommand.FlushResult(0, 0, List.of());
+    }
+
+    List<SendMessageBatchRequestEntry> entries = new ArrayList<>(messages.size());
+    List<ErrorOutput> errorOutputs = new ArrayList<>();
+    List<Integer> messageSizes = new ArrayList<>();
+
+    for (int i = 0; i < messages.size(); i++) {
+      SqsOutboundMessage message = messages.get(i);
+      RecordFleakData rawEvent = preparedInputEvents.rawAndPreparedList().get(i).getLeft();
+
+      try {
+        SendMessageBatchRequestEntry.Builder entryBuilder =
+            SendMessageBatchRequestEntry.builder()
+                .id(String.valueOf(i))
+                .messageBody(message.body());
+
+        if (message.messageGroupId() != null) {
+          entryBuilder.messageGroupId(message.messageGroupId());
+        }
+        if (message.deduplicationId() != null) {
+          entryBuilder.messageDeduplicationId(message.deduplicationId());
+        }
+
+        entries.add(entryBuilder.build());
+        messageSizes.add(message.body().getBytes(StandardCharsets.UTF_8).length);
+      } catch (Exception e) {
+        errorOutputs.add(
+            new ErrorOutput(rawEvent, "Failed to prepare SQS message: " + e.getMessage()));
+        messageSizes.add(0);
+      }
+    }
+
+    if (entries.isEmpty()) {
+      return new SimpleSinkCommand.FlushResult(0, 0, errorOutputs);
+    }
+
+    SendMessageBatchRequest batchRequest =
+        SendMessageBatchRequest.builder().queueUrl(queueUrl).entries(entries).build();
+
+    try {
+      SendMessageBatchResponse response = sqsClient.sendMessageBatch(batchRequest);
+
+      int successCount = response.successful() != null ? response.successful().size() : 0;
+      long flushedDataSize = 0;
+
+      if (response.successful() != null) {
+        for (var success : response.successful()) {
+          int index = Integer.parseInt(success.id());
+          flushedDataSize += messageSizes.get(index);
+        }
+      }
+
+      if (response.failed() != null) {
+        for (BatchResultErrorEntry failed : response.failed()) {
+          int index = Integer.parseInt(failed.id());
+          RecordFleakData rawEvent = preparedInputEvents.rawAndPreparedList().get(index).getLeft();
+          errorOutputs.add(
+              new ErrorOutput(
+                  rawEvent,
+                  String.format(
+                      "SQS batch send failed: %s - %s", failed.code(), failed.message())));
+        }
+      }
+
+      log.debug(
+          "SQS flush completed: {} successful, {} failed",
+          successCount,
+          response.failed() != null ? response.failed().size() : 0);
+
+      return new SimpleSinkCommand.FlushResult(successCount, flushedDataSize, errorOutputs);
+    } catch (Exception e) {
+      for (Pair<RecordFleakData, SqsOutboundMessage> pair :
+          preparedInputEvents.rawAndPreparedList()) {
+        errorOutputs.add(new ErrorOutput(pair.getLeft(), "SQS client error: " + e.getMessage()));
+      }
+      return new SimpleSinkCommand.FlushResult(0, 0, errorOutputs);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (sqsClient != null) {
+      sqsClient.close();
+    }
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkMessageProcessor.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkMessageProcessor.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssink;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.toJsonString;
+
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
+import io.fleak.zephflow.lib.pathselect.PathExpression;
+import javax.annotation.Nullable;
+
+public class SqsSinkMessageProcessor
+    implements SimpleSinkCommand.SinkMessagePreProcessor<SqsOutboundMessage> {
+
+  private final PathExpression messageGroupIdExpression;
+  private final PathExpression deduplicationIdExpression;
+
+  public SqsSinkMessageProcessor(
+      @Nullable PathExpression messageGroupIdExpression,
+      @Nullable PathExpression deduplicationIdExpression) {
+    this.messageGroupIdExpression = messageGroupIdExpression;
+    this.deduplicationIdExpression = deduplicationIdExpression;
+  }
+
+  @Override
+  public SqsOutboundMessage preprocess(RecordFleakData event, long ts) {
+    String body = toJsonString(event);
+
+    String messageGroupId = null;
+    if (messageGroupIdExpression != null) {
+      messageGroupId = messageGroupIdExpression.getStringValueFromEventOrDefault(event, null);
+    }
+
+    String deduplicationId = null;
+    if (deduplicationIdExpression != null) {
+      deduplicationId = deduplicationIdExpression.getStringValueFromEventOrDefault(event, null);
+    }
+
+    return new SqsOutboundMessage(body, messageGroupId, deduplicationId);
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsRawDataConverter.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsRawDataConverter.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssource;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.toJsonString;
+import static io.fleak.zephflow.lib.utils.MiscUtils.getCallingUserTagAndEventTags;
+
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.source.ConvertedResult;
+import io.fleak.zephflow.lib.commands.source.RawDataConverter;
+import io.fleak.zephflow.lib.commands.source.SourceExecutionContext;
+import io.fleak.zephflow.lib.serdes.SerializedEvent;
+import io.fleak.zephflow.lib.serdes.des.FleakDeserializer;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SqsRawDataConverter implements RawDataConverter<SqsReceivedMessage> {
+
+  private final FleakDeserializer<?> fleakDeserializer;
+
+  public SqsRawDataConverter(FleakDeserializer<?> fleakDeserializer) {
+    this.fleakDeserializer = fleakDeserializer;
+  }
+
+  @Override
+  public ConvertedResult<SqsReceivedMessage> convert(
+      SqsReceivedMessage sourceRecord, SourceExecutionContext<?> sourceInitializedConfig) {
+    try {
+      SerializedEvent serializedEvent =
+          new SerializedEvent(null, sourceRecord.body(), sourceRecord.attributes());
+      List<RecordFleakData> events = fleakDeserializer.deserialize(serializedEvent);
+
+      Map<String, String> eventTags =
+          getCallingUserTagAndEventTags(null, events.isEmpty() ? null : events.getFirst());
+
+      sourceInitializedConfig.dataSizeCounter().increase(sourceRecord.body().length, eventTags);
+      sourceInitializedConfig.inputEventCounter().increase(events.size(), eventTags);
+      if (log.isDebugEnabled()) {
+        events.forEach(e -> log.debug("got message: {}", toJsonString(e)));
+      }
+      return ConvertedResult.success(events, sourceRecord);
+    } catch (Exception e) {
+      sourceInitializedConfig.dataSizeCounter().increase(sourceRecord.body().length, Map.of());
+      sourceInitializedConfig.deserializeFailureCounter().increase(Map.of());
+      log.error("failed to deserialize SQS event for messageId: {}", sourceRecord.messageId());
+      return ConvertedResult.failure(e, sourceRecord);
+    }
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsRawDataEncoder.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsRawDataEncoder.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssource;
+
+import io.fleak.zephflow.lib.commands.source.RawDataEncoder;
+import io.fleak.zephflow.lib.serdes.SerializedEvent;
+
+public class SqsRawDataEncoder implements RawDataEncoder<SqsReceivedMessage> {
+  @Override
+  public SerializedEvent serialize(SqsReceivedMessage sourceRecord) {
+    return new SerializedEvent(null, sourceRecord.body(), sourceRecord.attributes());
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsReceivedMessage.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsReceivedMessage.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssource;
+
+import java.util.Map;
+
+public record SqsReceivedMessage(
+    byte[] body, String messageId, String receiptHandle, Map<String, String> attributes) {}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceCommand.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssource;
+
+import static io.fleak.zephflow.lib.utils.MiscUtils.*;
+
+import io.fleak.zephflow.api.*;
+import io.fleak.zephflow.api.metric.FleakCounter;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.lib.aws.AwsClientFactory;
+import io.fleak.zephflow.lib.commands.source.*;
+import io.fleak.zephflow.lib.credentials.UsernamePasswordCredential;
+import io.fleak.zephflow.lib.dlq.DlqWriter;
+import io.fleak.zephflow.lib.dlq.DlqWriterFactory;
+import io.fleak.zephflow.lib.serdes.des.DeserializerFactory;
+import io.fleak.zephflow.lib.serdes.des.FleakDeserializer;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.services.sqs.SqsClient;
+
+public class SqsSourceCommand extends SimpleSourceCommand<SqsReceivedMessage> {
+
+  private final AwsClientFactory awsClientFactory;
+
+  public SqsSourceCommand(
+      String nodeId,
+      JobContext jobContext,
+      ConfigParser configParser,
+      ConfigValidator configValidator,
+      AwsClientFactory awsClientFactory) {
+    super(nodeId, jobContext, configParser, configValidator);
+    this.awsClientFactory = awsClientFactory;
+  }
+
+  @Override
+  protected ExecutionContext createExecutionContext(
+      MetricClientProvider metricClientProvider,
+      JobContext jobContext,
+      CommandConfig commandConfig,
+      String nodeId) {
+    SqsSourceDto.Config config = (SqsSourceDto.Config) commandConfig;
+
+    Fetcher<SqsReceivedMessage> fetcher = createSqsFetcher(config, jobContext);
+    RawDataEncoder<SqsReceivedMessage> encoder = new SqsRawDataEncoder();
+    RawDataConverter<SqsReceivedMessage> converter = createRawDataConverter(config);
+
+    Map<String, String> metricTags =
+        basicCommandMetricTags(jobContext.getMetricTags(), commandName(), nodeId);
+    FleakCounter dataSizeCounter =
+        metricClientProvider.counter(METRIC_NAME_INPUT_EVENT_SIZE_COUNT, metricTags);
+    FleakCounter inputEventCounter =
+        metricClientProvider.counter(METRIC_NAME_INPUT_EVENT_COUNT, metricTags);
+    FleakCounter deserializeFailureCounter =
+        metricClientProvider.counter(METRIC_NAME_INPUT_DESER_ERR_COUNT, metricTags);
+
+    String keyPrefix = (String) jobContext.getOtherProperties().get(JobContext.DATA_KEY_PREFIX);
+    DlqWriter dlqWriter =
+        Optional.of(jobContext)
+            .map(JobContext::getDlqConfig)
+            .map(c -> DlqWriterFactory.createDlqWriter(c, keyPrefix))
+            .orElse(null);
+    if (dlqWriter != null) {
+      dlqWriter.open();
+    }
+
+    return new SourceExecutionContext<>(
+        fetcher,
+        converter,
+        encoder,
+        dataSizeCounter,
+        inputEventCounter,
+        deserializeFailureCounter,
+        dlqWriter);
+  }
+
+  private Fetcher<SqsReceivedMessage> createSqsFetcher(
+      SqsSourceDto.Config config, JobContext jobContext) {
+    UsernamePasswordCredential credential = null;
+    if (StringUtils.trimToNull(config.getCredentialId()) != null) {
+      Optional<UsernamePasswordCredential> credentialOpt =
+          lookupUsernamePasswordCredentialOpt(jobContext, config.getCredentialId());
+      credential = credentialOpt.orElse(null);
+    }
+
+    SqsClient sqsClient = awsClientFactory.createSqsClient(config.getRegionStr(), credential);
+
+    int maxMessages =
+        config.getMaxNumberOfMessages() != null
+            ? config.getMaxNumberOfMessages()
+            : SqsSourceDto.DEFAULT_MAX_NUMBER_OF_MESSAGES;
+    int waitTime =
+        config.getWaitTimeSeconds() != null
+            ? config.getWaitTimeSeconds()
+            : SqsSourceDto.DEFAULT_WAIT_TIME_SECONDS;
+    int visibilityTimeout =
+        config.getVisibilityTimeoutSeconds() != null
+            ? config.getVisibilityTimeoutSeconds()
+            : SqsSourceDto.DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
+
+    return new SqsSourceFetcher(
+        sqsClient, config.getQueueUrl(), maxMessages, waitTime, visibilityTimeout);
+  }
+
+  private RawDataConverter<SqsReceivedMessage> createRawDataConverter(SqsSourceDto.Config config) {
+    FleakDeserializer<?> deserializer =
+        DeserializerFactory.createDeserializerFactory(config.getEncodingType())
+            .createDeserializer();
+    return new SqsRawDataConverter(deserializer);
+  }
+
+  @Override
+  public SourceType sourceType() {
+    return SourceType.STREAMING;
+  }
+
+  @Override
+  public String commandName() {
+    return COMMAND_NAME_SQS_SOURCE;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceCommandFactory.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceCommandFactory.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssource;
+
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.lib.aws.AwsClientFactory;
+import io.fleak.zephflow.lib.commands.JsonConfigParser;
+import io.fleak.zephflow.lib.commands.source.SourceCommandFactory;
+
+public class SqsSourceCommandFactory extends SourceCommandFactory {
+  @Override
+  public SqsSourceCommand createCommand(String nodeId, JobContext jobContext) {
+    return new SqsSourceCommand(
+        nodeId,
+        jobContext,
+        new JsonConfigParser<>(SqsSourceDto.Config.class),
+        new SqsSourceConfigValidator(),
+        new AwsClientFactory());
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceConfigValidator.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceConfigValidator.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssource;
+
+import static io.fleak.zephflow.lib.utils.MiscUtils.enforceCredentials;
+import static io.fleak.zephflow.lib.utils.MiscUtils.lookupUsernamePasswordCredential;
+
+import com.google.common.base.Preconditions;
+import io.fleak.zephflow.api.CommandConfig;
+import io.fleak.zephflow.api.ConfigValidator;
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.lib.serdes.des.DeserializerFactory;
+import org.apache.commons.lang3.StringUtils;
+
+public class SqsSourceConfigValidator implements ConfigValidator {
+  @Override
+  public void validateConfig(CommandConfig commandConfig, String nodeId, JobContext jobContext) {
+    SqsSourceDto.Config config = (SqsSourceDto.Config) commandConfig;
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.getQueueUrl()), "no queue URL is provided");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.getRegionStr()), "no region is provided");
+    Preconditions.checkNotNull(config.getEncodingType(), "no encoding type is provided");
+    DeserializerFactory.validateEncodingType(config.getEncodingType());
+
+    if (config.getMaxNumberOfMessages() != null) {
+      Preconditions.checkArgument(
+          config.getMaxNumberOfMessages() >= 1
+              && config.getMaxNumberOfMessages() <= SqsSourceDto.MAX_MAX_NUMBER_OF_MESSAGES,
+          "maxNumberOfMessages must be between 1 and %s",
+          SqsSourceDto.MAX_MAX_NUMBER_OF_MESSAGES);
+    }
+
+    if (config.getWaitTimeSeconds() != null) {
+      Preconditions.checkArgument(
+          config.getWaitTimeSeconds() >= 0
+              && config.getWaitTimeSeconds() <= SqsSourceDto.MAX_WAIT_TIME_SECONDS,
+          "waitTimeSeconds must be between 0 and %s",
+          SqsSourceDto.MAX_WAIT_TIME_SECONDS);
+    }
+
+    if (config.getVisibilityTimeoutSeconds() != null) {
+      Preconditions.checkArgument(
+          config.getVisibilityTimeoutSeconds() >= 0,
+          "visibilityTimeoutSeconds must be non-negative");
+    }
+
+    if (StringUtils.trimToNull(config.getCredentialId()) != null
+        && enforceCredentials(jobContext)) {
+      lookupUsernamePasswordCredential(jobContext, config.getCredentialId());
+    }
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceDto.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssource;
+
+import io.fleak.zephflow.api.CommandConfig;
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import lombok.*;
+
+public interface SqsSourceDto {
+
+  int DEFAULT_MAX_NUMBER_OF_MESSAGES = 10;
+  int MAX_MAX_NUMBER_OF_MESSAGES = 10;
+  int DEFAULT_WAIT_TIME_SECONDS = 20;
+  int MAX_WAIT_TIME_SECONDS = 20;
+  int DEFAULT_VISIBILITY_TIMEOUT_SECONDS = 30;
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  class Config implements CommandConfig {
+    @NonNull private String queueUrl;
+    @NonNull private String regionStr;
+    @NonNull private EncodingType encodingType;
+    private String credentialId;
+    @Builder.Default private Integer maxNumberOfMessages = DEFAULT_MAX_NUMBER_OF_MESSAGES;
+    @Builder.Default private Integer waitTimeSeconds = DEFAULT_WAIT_TIME_SECONDS;
+    @Builder.Default private Integer visibilityTimeoutSeconds = DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceFetcher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceFetcher.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssource;
+
+import io.fleak.zephflow.lib.commands.source.CommitStrategy;
+import io.fleak.zephflow.lib.commands.source.Fetcher;
+import io.fleak.zephflow.lib.commands.source.PerRecordCommitStrategy;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+
+@Slf4j
+public class SqsSourceFetcher implements Fetcher<SqsReceivedMessage> {
+
+  private final SqsClient sqsClient;
+  private final String queueUrl;
+  private final int maxNumberOfMessages;
+  private final int waitTimeSeconds;
+  private final int visibilityTimeoutSeconds;
+  private final ConcurrentLinkedQueue<String> pendingReceiptHandles = new ConcurrentLinkedQueue<>();
+
+  public SqsSourceFetcher(
+      SqsClient sqsClient,
+      String queueUrl,
+      int maxNumberOfMessages,
+      int waitTimeSeconds,
+      int visibilityTimeoutSeconds) {
+    this.sqsClient = sqsClient;
+    this.queueUrl = queueUrl;
+    this.maxNumberOfMessages = maxNumberOfMessages;
+    this.waitTimeSeconds = waitTimeSeconds;
+    this.visibilityTimeoutSeconds = visibilityTimeoutSeconds;
+  }
+
+  @Override
+  public List<SqsReceivedMessage> fetch() {
+    ReceiveMessageRequest request =
+        ReceiveMessageRequest.builder()
+            .queueUrl(queueUrl)
+            .maxNumberOfMessages(maxNumberOfMessages)
+            .waitTimeSeconds(waitTimeSeconds)
+            .visibilityTimeout(visibilityTimeoutSeconds)
+            .attributeNamesWithStrings("All")
+            .messageAttributeNames("All")
+            .build();
+
+    ReceiveMessageResponse response = sqsClient.receiveMessage(request);
+    List<Message> messages = response.messages();
+
+    if (messages == null || messages.isEmpty()) {
+      log.debug("No messages received from SQS queue: {}", queueUrl);
+      return List.of();
+    }
+
+    List<SqsReceivedMessage> result = new ArrayList<>(messages.size());
+    for (Message message : messages) {
+      Map<String, String> attributes = new HashMap<>();
+      if (message.attributesAsStrings() != null) {
+        attributes.putAll(message.attributesAsStrings());
+      }
+      if (message.messageAttributes() != null) {
+        message
+            .messageAttributes()
+            .forEach(
+                (key, value) -> {
+                  if (value.stringValue() != null) {
+                    attributes.put(key, value.stringValue());
+                  }
+                });
+      }
+
+      SqsReceivedMessage receivedMessage =
+          new SqsReceivedMessage(
+              message.body().getBytes(StandardCharsets.UTF_8),
+              message.messageId(),
+              message.receiptHandle(),
+              attributes);
+      pendingReceiptHandles.add(message.receiptHandle());
+      result.add(receivedMessage);
+    }
+
+    log.debug("Fetched {} messages from SQS queue: {}", result.size(), queueUrl);
+    return result;
+  }
+
+  @Override
+  public boolean isExhausted() {
+    return false;
+  }
+
+  @Override
+  public Committer committer() {
+    return () -> {
+      String receiptHandle;
+      while ((receiptHandle = pendingReceiptHandles.poll()) != null) {
+        try {
+          DeleteMessageRequest deleteRequest =
+              DeleteMessageRequest.builder()
+                  .queueUrl(queueUrl)
+                  .receiptHandle(receiptHandle)
+                  .build();
+          sqsClient.deleteMessage(deleteRequest);
+        } catch (Exception e) {
+          log.error("Failed to delete SQS message with receiptHandle: {}", receiptHandle, e);
+        }
+      }
+    };
+  }
+
+  @Override
+  public CommitStrategy commitStrategy() {
+    return PerRecordCommitStrategy.INSTANCE;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (sqsClient != null) {
+      sqsClient.close();
+    }
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
@@ -91,6 +91,8 @@ public interface MiscUtils {
   String COMMAND_NAME_DATABRICKS_SINK = "databrickssink";
   String COMMAND_NAME_SYSLOG_UDP = "syslogudp";
   String COMMAND_NAME_ACTIVEMQ_SOURCE = "activemqsource";
+  String COMMAND_NAME_SQS_SOURCE = "sqssource";
+  String COMMAND_NAME_SQS_SINK = "sqssink";
   String METRIC_NAME_INPUT_EVENT_COUNT = "input_event_count";
   String METRIC_NAME_INPUT_EVENT_SIZE_COUNT = "input_event_size";
   String METRIC_NAME_INPUT_DESER_ERR_COUNT = "input_deser_err_count";

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/OperatorCommandRegistryTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/OperatorCommandRegistryTest.java
@@ -47,6 +47,8 @@ class OperatorCommandRegistryTest {
             .add(COMMAND_NAME_DATABRICKS_SINK)
             .add(COMMAND_NAME_SYSLOG_UDP)
             .add(COMMAND_NAME_ACTIVEMQ_SOURCE)
+            .add(COMMAND_NAME_SQS_SINK)
+            .add(COMMAND_NAME_SQS_SOURCE)
             .build(),
         OPERATOR_COMMANDS.keySet());
   }

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkConfigValidatorTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkConfigValidatorTest.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssink;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.lib.TestUtils;
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import io.fleak.zephflow.lib.serdes.ser.SerializerFactory;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SqsSinkConfigValidatorTest {
+
+  static final JobContext TEST_JOB_CONTEXT =
+      JobContext.builder()
+          .metricTags(TestUtils.JOB_CONTEXT.getMetricTags())
+          .otherProperties(
+              new HashMap<>(
+                  Map.of(
+                      "example-credential-id",
+                      new HashMap<>(
+                          Map.of("username", "test-access-key", "password", "test-secret-key")))))
+          .build();
+
+  @Test
+  void validateConfig_validStandardQueue() {
+    SqsSinkConfigValidator validator = new SqsSinkConfigValidator();
+    SqsSinkDto.Config config =
+        SqsSinkDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.JSON_OBJECT.name())
+            .credentialId("example-credential-id")
+            .build();
+    assertDoesNotThrow(() -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_validFifoQueue() {
+    SqsSinkConfigValidator validator = new SqsSinkConfigValidator();
+    SqsSinkDto.Config config =
+        SqsSinkDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue.fifo")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.JSON_OBJECT.name())
+            .messageGroupIdExpression("$.groupId")
+            .deduplicationIdExpression("$.dedupId")
+            .build();
+    assertDoesNotThrow(() -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_fifoQueueMissingMessageGroupId() {
+    SqsSinkConfigValidator validator = new SqsSinkConfigValidator();
+    SqsSinkDto.Config config =
+        SqsSinkDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue.fifo")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.JSON_OBJECT.name())
+            .build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_missingQueueUrl() {
+    SqsSinkConfigValidator validator = new SqsSinkConfigValidator();
+    SqsSinkDto.Config config = new SqsSinkDto.Config();
+    config.setQueueUrl("");
+    config.setRegionStr("us-east-1");
+    config.setEncodingType(EncodingType.JSON_OBJECT.name());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_missingRegion() {
+    SqsSinkConfigValidator validator = new SqsSinkConfigValidator();
+    SqsSinkDto.Config config = new SqsSinkDto.Config();
+    config.setQueueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue");
+    config.setRegionStr("");
+    config.setEncodingType(EncodingType.JSON_OBJECT.name());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_unsupportedEncodingType() {
+    SqsSinkConfigValidator validator = new SqsSinkConfigValidator();
+    SqsSinkDto.Config config =
+        SqsSinkDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.STRING_LINE.name())
+            .build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_allSupportedEncodingTypes() {
+    SqsSinkConfigValidator validator = new SqsSinkConfigValidator();
+    for (EncodingType type : SerializerFactory.SUPPORTED_ENCODING_TYPES) {
+      SqsSinkDto.Config config =
+          SqsSinkDto.Config.builder()
+              .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+              .regionStr("us-east-1")
+              .encodingType(type.name())
+              .build();
+      assertDoesNotThrow(() -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+    }
+  }
+
+  @Test
+  void validateConfig_invalidBatchSize() {
+    SqsSinkConfigValidator validator = new SqsSinkConfigValidator();
+    SqsSinkDto.Config config =
+        SqsSinkDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.JSON_OBJECT.name())
+            .batchSize(11)
+            .build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_zeroBatchSize() {
+    SqsSinkConfigValidator validator = new SqsSinkConfigValidator();
+    SqsSinkDto.Config config =
+        SqsSinkDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.JSON_OBJECT.name())
+            .batchSize(0)
+            .build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkDtoTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkDtoTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssink;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.OBJECT_MAPPER;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SqsSinkDtoTest {
+
+  @Test
+  void testConfigBuilder() {
+    SqsSinkDto.Config config =
+        SqsSinkDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue.fifo")
+            .regionStr("us-east-1")
+            .encodingType("JSON_OBJECT")
+            .credentialId("my-cred")
+            .messageGroupIdExpression("$.groupId")
+            .deduplicationIdExpression("$.dedupId")
+            .batchSize(5)
+            .build();
+
+    assertEquals(
+        "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue.fifo", config.getQueueUrl());
+    assertEquals("us-east-1", config.getRegionStr());
+    assertEquals("JSON_OBJECT", config.getEncodingType());
+    assertEquals("my-cred", config.getCredentialId());
+    assertEquals("$.groupId", config.getMessageGroupIdExpression());
+    assertEquals("$.dedupId", config.getDeduplicationIdExpression());
+    assertEquals(5, config.getBatchSize());
+  }
+
+  @Test
+  void testDefaultValues() {
+    SqsSinkDto.Config config =
+        SqsSinkDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType("JSON_OBJECT")
+            .build();
+
+    assertEquals(SqsSinkDto.DEFAULT_BATCH_SIZE, config.getBatchSize());
+    assertNull(config.getCredentialId());
+    assertNull(config.getMessageGroupIdExpression());
+    assertNull(config.getDeduplicationIdExpression());
+  }
+
+  @Test
+  void testJsonParsing() {
+    Map<String, Object> jsonMap =
+        Map.of(
+            "queueUrl", "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue",
+            "regionStr", "us-east-1",
+            "encodingType", "JSON_OBJECT",
+            "batchSize", 7,
+            "messageGroupIdExpression", "$.group");
+
+    SqsSinkDto.Config config = OBJECT_MAPPER.convertValue(jsonMap, SqsSinkDto.Config.class);
+
+    assertEquals("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue", config.getQueueUrl());
+    assertEquals("us-east-1", config.getRegionStr());
+    assertEquals("JSON_OBJECT", config.getEncodingType());
+    assertEquals(7, config.getBatchSize());
+    assertEquals("$.group", config.getMessageGroupIdExpression());
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkFlusherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkFlusherTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssink;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.api.structure.StringPrimitiveFleakData;
+import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+class SqsSinkFlusherTest {
+
+  private static final String QUEUE_URL =
+      "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue";
+
+  private SqsClient sqsClient;
+  private SqsSinkFlusher flusher;
+
+  @BeforeEach
+  void setUp() {
+    sqsClient = mock(SqsClient.class);
+    flusher = new SqsSinkFlusher(sqsClient, QUEUE_URL);
+  }
+
+  @Test
+  void testSuccessfulFlush() throws Exception {
+    SimpleSinkCommand.PreparedInputEvents<SqsOutboundMessage> preparedInputEvents =
+        new SimpleSinkCommand.PreparedInputEvents<>();
+
+    RecordFleakData record1 =
+        new RecordFleakData(Map.of("data", new StringPrimitiveFleakData("value1")));
+    RecordFleakData record2 =
+        new RecordFleakData(Map.of("data", new StringPrimitiveFleakData("value2")));
+
+    preparedInputEvents.add(record1, new SqsOutboundMessage("{\"data\":\"value1\"}", null, null));
+    preparedInputEvents.add(record2, new SqsOutboundMessage("{\"data\":\"value2\"}", null, null));
+
+    SendMessageBatchResponse response =
+        SendMessageBatchResponse.builder()
+            .successful(
+                SendMessageBatchResultEntry.builder().id("0").messageId("m1").build(),
+                SendMessageBatchResultEntry.builder().id("1").messageId("m2").build())
+            .failed(List.of())
+            .build();
+
+    when(sqsClient.sendMessageBatch(any(SendMessageBatchRequest.class))).thenReturn(response);
+
+    SimpleSinkCommand.FlushResult result = flusher.flush(preparedInputEvents, Map.of());
+
+    assertEquals(2, result.successCount());
+    assertTrue(result.errorOutputList().isEmpty());
+    assertTrue(result.flushedDataSize() > 0);
+
+    verify(sqsClient)
+        .sendMessageBatch(
+            argThat(
+                (SendMessageBatchRequest req) -> {
+                  assertEquals(QUEUE_URL, req.queueUrl());
+                  assertEquals(2, req.entries().size());
+                  assertEquals("{\"data\":\"value1\"}", req.entries().get(0).messageBody());
+                  assertEquals("{\"data\":\"value2\"}", req.entries().get(1).messageBody());
+                  return true;
+                }));
+  }
+
+  @Test
+  void testFlushWithFifoAttributes() throws Exception {
+    SimpleSinkCommand.PreparedInputEvents<SqsOutboundMessage> preparedInputEvents =
+        new SimpleSinkCommand.PreparedInputEvents<>();
+
+    RecordFleakData record =
+        new RecordFleakData(Map.of("data", new StringPrimitiveFleakData("value1")));
+    preparedInputEvents.add(
+        record, new SqsOutboundMessage("{\"data\":\"value1\"}", "group-1", "dedup-1"));
+
+    SendMessageBatchResponse response =
+        SendMessageBatchResponse.builder()
+            .successful(SendMessageBatchResultEntry.builder().id("0").messageId("m1").build())
+            .failed(List.of())
+            .build();
+
+    when(sqsClient.sendMessageBatch(any(SendMessageBatchRequest.class))).thenReturn(response);
+
+    SimpleSinkCommand.FlushResult result = flusher.flush(preparedInputEvents, Map.of());
+
+    assertEquals(1, result.successCount());
+
+    verify(sqsClient)
+        .sendMessageBatch(
+            argThat(
+                (SendMessageBatchRequest req) -> {
+                  SendMessageBatchRequestEntry entry = req.entries().get(0);
+                  assertEquals("group-1", entry.messageGroupId());
+                  assertEquals("dedup-1", entry.messageDeduplicationId());
+                  return true;
+                }));
+  }
+
+  @Test
+  void testPartialFailure() throws Exception {
+    SimpleSinkCommand.PreparedInputEvents<SqsOutboundMessage> preparedInputEvents =
+        new SimpleSinkCommand.PreparedInputEvents<>();
+
+    RecordFleakData record1 =
+        new RecordFleakData(Map.of("data", new StringPrimitiveFleakData("value1")));
+    RecordFleakData record2 =
+        new RecordFleakData(Map.of("data", new StringPrimitiveFleakData("value2")));
+
+    preparedInputEvents.add(record1, new SqsOutboundMessage("{\"data\":\"value1\"}", null, null));
+    preparedInputEvents.add(record2, new SqsOutboundMessage("{\"data\":\"value2\"}", null, null));
+
+    SendMessageBatchResponse response =
+        SendMessageBatchResponse.builder()
+            .successful(SendMessageBatchResultEntry.builder().id("0").messageId("m1").build())
+            .failed(
+                BatchResultErrorEntry.builder()
+                    .id("1")
+                    .code("InternalError")
+                    .message("Internal error occurred")
+                    .build())
+            .build();
+
+    when(sqsClient.sendMessageBatch(any(SendMessageBatchRequest.class))).thenReturn(response);
+
+    SimpleSinkCommand.FlushResult result = flusher.flush(preparedInputEvents, Map.of());
+
+    assertEquals(1, result.successCount());
+    assertEquals(1, result.errorOutputList().size());
+    assertTrue(result.errorOutputList().get(0).errorMessage().contains("InternalError"));
+  }
+
+  @Test
+  void testEmptyBatch() throws Exception {
+    SimpleSinkCommand.PreparedInputEvents<SqsOutboundMessage> preparedInputEvents =
+        new SimpleSinkCommand.PreparedInputEvents<>();
+
+    SimpleSinkCommand.FlushResult result = flusher.flush(preparedInputEvents, Map.of());
+
+    assertEquals(0, result.successCount());
+    assertTrue(result.errorOutputList().isEmpty());
+    verify(sqsClient, never()).sendMessageBatch(any(SendMessageBatchRequest.class));
+  }
+
+  @Test
+  void testSqsClientException() throws Exception {
+    SimpleSinkCommand.PreparedInputEvents<SqsOutboundMessage> preparedInputEvents =
+        new SimpleSinkCommand.PreparedInputEvents<>();
+
+    RecordFleakData record =
+        new RecordFleakData(Map.of("data", new StringPrimitiveFleakData("value1")));
+    preparedInputEvents.add(record, new SqsOutboundMessage("{\"data\":\"value1\"}", null, null));
+
+    when(sqsClient.sendMessageBatch(any(SendMessageBatchRequest.class)))
+        .thenThrow(new RuntimeException("Connection timeout"));
+
+    SimpleSinkCommand.FlushResult result = flusher.flush(preparedInputEvents, Map.of());
+
+    assertEquals(0, result.successCount());
+    assertEquals(1, result.errorOutputList().size());
+    assertTrue(result.errorOutputList().get(0).errorMessage().contains("SQS client error"));
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkMessageProcessorTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssink/SqsSinkMessageProcessorTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssink;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.api.structure.StringPrimitiveFleakData;
+import io.fleak.zephflow.lib.pathselect.PathExpression;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SqsSinkMessageProcessorTest {
+
+  @Test
+  void testPreprocessWithoutFifoFields() throws Exception {
+    SqsSinkMessageProcessor processor = new SqsSinkMessageProcessor(null, null);
+
+    RecordFleakData event =
+        new RecordFleakData(
+            Map.of(
+                "name", new StringPrimitiveFleakData("test"),
+                "value", new StringPrimitiveFleakData("123")));
+
+    SqsOutboundMessage result = processor.preprocess(event, System.currentTimeMillis());
+
+    assertNotNull(result.body());
+    assertTrue(result.body().contains("\"name\""));
+    assertTrue(result.body().contains("\"test\""));
+    assertNull(result.messageGroupId());
+    assertNull(result.deduplicationId());
+  }
+
+  @Test
+  void testPreprocessWithFifoFields() throws Exception {
+    PathExpression groupIdExpression = PathExpression.fromString("$.groupId");
+    PathExpression dedupIdExpression = PathExpression.fromString("$.dedupId");
+    SqsSinkMessageProcessor processor =
+        new SqsSinkMessageProcessor(groupIdExpression, dedupIdExpression);
+
+    RecordFleakData event =
+        new RecordFleakData(
+            Map.of(
+                "groupId", new StringPrimitiveFleakData("group-1"),
+                "dedupId", new StringPrimitiveFleakData("dedup-1"),
+                "data", new StringPrimitiveFleakData("payload")));
+
+    SqsOutboundMessage result = processor.preprocess(event, System.currentTimeMillis());
+
+    assertNotNull(result.body());
+    assertEquals("group-1", result.messageGroupId());
+    assertEquals("dedup-1", result.deduplicationId());
+  }
+
+  @Test
+  void testPreprocessWithMissingFifoFields() throws Exception {
+    PathExpression groupIdExpression = PathExpression.fromString("$.groupId");
+    PathExpression dedupIdExpression = PathExpression.fromString("$.dedupId");
+    SqsSinkMessageProcessor processor =
+        new SqsSinkMessageProcessor(groupIdExpression, dedupIdExpression);
+
+    RecordFleakData event =
+        new RecordFleakData(Map.of("data", new StringPrimitiveFleakData("payload")));
+
+    SqsOutboundMessage result = processor.preprocess(event, System.currentTimeMillis());
+
+    assertNotNull(result.body());
+    assertNull(result.messageGroupId());
+    assertNull(result.deduplicationId());
+  }
+
+  @Test
+  void testPreprocessBodyIsValidJson() throws Exception {
+    SqsSinkMessageProcessor processor = new SqsSinkMessageProcessor(null, null);
+
+    RecordFleakData event =
+        new RecordFleakData(Map.of("key", new StringPrimitiveFleakData("value")));
+
+    SqsOutboundMessage result = processor.preprocess(event, System.currentTimeMillis());
+
+    assertTrue(result.body().startsWith("{"));
+    assertTrue(result.body().endsWith("}"));
+    assertTrue(result.body().contains("\"key\""));
+    assertTrue(result.body().contains("\"value\""));
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceConfigValidatorTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceConfigValidatorTest.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.lib.TestUtils;
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SqsSourceConfigValidatorTest {
+
+  static final JobContext TEST_JOB_CONTEXT =
+      JobContext.builder()
+          .metricTags(TestUtils.JOB_CONTEXT.getMetricTags())
+          .otherProperties(
+              new HashMap<>(
+                  Map.of(
+                      "example-credential-id",
+                      new HashMap<>(
+                          Map.of("username", "test-access-key", "password", "test-secret-key")))))
+          .build();
+
+  @Test
+  void validateConfig_validConfig() {
+    SqsSourceConfigValidator validator = new SqsSourceConfigValidator();
+    SqsSourceDto.Config config =
+        SqsSourceDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.JSON_OBJECT)
+            .credentialId("example-credential-id")
+            .build();
+    assertDoesNotThrow(() -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_missingQueueUrl() {
+    SqsSourceConfigValidator validator = new SqsSourceConfigValidator();
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          SqsSourceDto.Config config =
+              SqsSourceDto.Config.builder()
+                  .queueUrl(null)
+                  .regionStr("us-east-1")
+                  .encodingType(EncodingType.JSON_OBJECT)
+                  .build();
+        });
+  }
+
+  @Test
+  void validateConfig_blankQueueUrl() {
+    SqsSourceConfigValidator validator = new SqsSourceConfigValidator();
+    SqsSourceDto.Config config = new SqsSourceDto.Config();
+    config.setQueueUrl("");
+    config.setRegionStr("us-east-1");
+    config.setEncodingType(EncodingType.JSON_OBJECT);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_missingRegion() {
+    SqsSourceConfigValidator validator = new SqsSourceConfigValidator();
+    SqsSourceDto.Config config = new SqsSourceDto.Config();
+    config.setQueueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue");
+    config.setRegionStr("");
+    config.setEncodingType(EncodingType.JSON_OBJECT);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_invalidMaxNumberOfMessages() {
+    SqsSourceConfigValidator validator = new SqsSourceConfigValidator();
+    SqsSourceDto.Config config =
+        SqsSourceDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.JSON_OBJECT)
+            .maxNumberOfMessages(11)
+            .build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_invalidWaitTimeSeconds() {
+    SqsSourceConfigValidator validator = new SqsSourceConfigValidator();
+    SqsSourceDto.Config config =
+        SqsSourceDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.JSON_OBJECT)
+            .waitTimeSeconds(21)
+            .build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_negativeVisibilityTimeout() {
+    SqsSourceConfigValidator validator = new SqsSourceConfigValidator();
+    SqsSourceDto.Config config =
+        SqsSourceDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.JSON_OBJECT)
+            .visibilityTimeoutSeconds(-1)
+            .build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_validBoundaryValues() {
+    SqsSourceConfigValidator validator = new SqsSourceConfigValidator();
+    SqsSourceDto.Config config =
+        SqsSourceDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.JSON_OBJECT)
+            .maxNumberOfMessages(10)
+            .waitTimeSeconds(20)
+            .visibilityTimeoutSeconds(0)
+            .build();
+    assertDoesNotThrow(() -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_zeroMaxNumberOfMessages() {
+    SqsSourceConfigValidator validator = new SqsSourceConfigValidator();
+    SqsSourceDto.Config config =
+        SqsSourceDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.JSON_OBJECT)
+            .maxNumberOfMessages(0)
+            .build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceDtoTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceDtoTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssource;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.OBJECT_MAPPER;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SqsSourceDtoTest {
+
+  @Test
+  void testConfigBuilder() {
+    SqsSourceDto.Config config =
+        SqsSourceDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.JSON_OBJECT)
+            .credentialId("my-cred")
+            .maxNumberOfMessages(5)
+            .waitTimeSeconds(10)
+            .visibilityTimeoutSeconds(60)
+            .build();
+
+    assertEquals("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue", config.getQueueUrl());
+    assertEquals("us-east-1", config.getRegionStr());
+    assertEquals(EncodingType.JSON_OBJECT, config.getEncodingType());
+    assertEquals("my-cred", config.getCredentialId());
+    assertEquals(5, config.getMaxNumberOfMessages());
+    assertEquals(10, config.getWaitTimeSeconds());
+    assertEquals(60, config.getVisibilityTimeoutSeconds());
+  }
+
+  @Test
+  void testDefaultValues() {
+    SqsSourceDto.Config config =
+        SqsSourceDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.JSON_OBJECT)
+            .build();
+
+    assertEquals(SqsSourceDto.DEFAULT_MAX_NUMBER_OF_MESSAGES, config.getMaxNumberOfMessages());
+    assertEquals(SqsSourceDto.DEFAULT_WAIT_TIME_SECONDS, config.getWaitTimeSeconds());
+    assertEquals(
+        SqsSourceDto.DEFAULT_VISIBILITY_TIMEOUT_SECONDS, config.getVisibilityTimeoutSeconds());
+    assertNull(config.getCredentialId());
+  }
+
+  @Test
+  void testJsonParsing() {
+    Map<String, Object> jsonMap =
+        Map.of(
+            "queueUrl", "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue",
+            "regionStr", "us-east-1",
+            "encodingType", "JSON_OBJECT",
+            "maxNumberOfMessages", 7);
+
+    SqsSourceDto.Config config = OBJECT_MAPPER.convertValue(jsonMap, SqsSourceDto.Config.class);
+
+    assertEquals("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue", config.getQueueUrl());
+    assertEquals("us-east-1", config.getRegionStr());
+    assertEquals(EncodingType.JSON_OBJECT, config.getEncodingType());
+    assertEquals(7, config.getMaxNumberOfMessages());
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceFetcherCommitTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceFetcherCommitTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssource;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.fleak.zephflow.lib.commands.source.Fetcher;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+class SqsSourceFetcherCommitTest {
+
+  private static final String QUEUE_URL =
+      "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue";
+
+  private SqsClient sqsClient;
+  private SqsSourceFetcher fetcher;
+
+  @BeforeEach
+  void setUp() {
+    sqsClient = mock(SqsClient.class);
+    fetcher = new SqsSourceFetcher(sqsClient, QUEUE_URL, 10, 20, 30);
+  }
+
+  @Test
+  void testCommitDeletesMessages() throws Exception {
+    Message message1 =
+        Message.builder()
+            .body("{\"key\": \"value1\"}")
+            .messageId("msg-1")
+            .receiptHandle("receipt-1")
+            .build();
+    Message message2 =
+        Message.builder()
+            .body("{\"key\": \"value2\"}")
+            .messageId("msg-2")
+            .receiptHandle("receipt-2")
+            .build();
+
+    ReceiveMessageResponse response =
+        ReceiveMessageResponse.builder().messages(message1, message2).build();
+    when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(response);
+
+    fetcher.fetch();
+
+    Fetcher.Committer committer = fetcher.committer();
+    committer.commit();
+
+    verify(sqsClient)
+        .deleteMessage(
+            argThat(
+                (DeleteMessageRequest req) ->
+                    QUEUE_URL.equals(req.queueUrl()) && "receipt-1".equals(req.receiptHandle())));
+    verify(sqsClient)
+        .deleteMessage(
+            argThat(
+                (DeleteMessageRequest req) ->
+                    QUEUE_URL.equals(req.queueUrl()) && "receipt-2".equals(req.receiptHandle())));
+  }
+
+  @Test
+  void testCommitWithNoMessages() throws Exception {
+    ReceiveMessageResponse response = ReceiveMessageResponse.builder().messages(List.of()).build();
+    when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(response);
+
+    fetcher.fetch();
+
+    Fetcher.Committer committer = fetcher.committer();
+    committer.commit();
+
+    verify(sqsClient, never()).deleteMessage(any(DeleteMessageRequest.class));
+  }
+
+  @Test
+  void testCommitHandlesDeleteFailureGracefully() throws Exception {
+    Message message1 =
+        Message.builder()
+            .body("{\"key\": \"value1\"}")
+            .messageId("msg-1")
+            .receiptHandle("receipt-1")
+            .build();
+    Message message2 =
+        Message.builder()
+            .body("{\"key\": \"value2\"}")
+            .messageId("msg-2")
+            .receiptHandle("receipt-2")
+            .build();
+
+    ReceiveMessageResponse response =
+        ReceiveMessageResponse.builder().messages(message1, message2).build();
+    when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(response);
+
+    doThrow(new RuntimeException("Delete failed"))
+        .doReturn(DeleteMessageResponse.builder().build())
+        .when(sqsClient)
+        .deleteMessage(any(DeleteMessageRequest.class));
+
+    fetcher.fetch();
+
+    Fetcher.Committer committer = fetcher.committer();
+    committer.commit();
+
+    verify(sqsClient, times(2)).deleteMessage(any(DeleteMessageRequest.class));
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceFetcherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sqssource/SqsSourceFetcherTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sqssource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+
+class SqsSourceFetcherTest {
+
+  private static final String QUEUE_URL =
+      "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue";
+
+  private SqsClient sqsClient;
+  private SqsSourceFetcher fetcher;
+
+  @BeforeEach
+  void setUp() {
+    sqsClient = mock(SqsClient.class);
+    fetcher = new SqsSourceFetcher(sqsClient, QUEUE_URL, 10, 20, 30);
+  }
+
+  @Test
+  void testFetchReturnsMessages() {
+    Message message1 =
+        Message.builder()
+            .body("{\"key\": \"value1\"}")
+            .messageId("msg-1")
+            .receiptHandle("receipt-1")
+            .build();
+    Message message2 =
+        Message.builder()
+            .body("{\"key\": \"value2\"}")
+            .messageId("msg-2")
+            .receiptHandle("receipt-2")
+            .build();
+
+    ReceiveMessageResponse response =
+        ReceiveMessageResponse.builder().messages(message1, message2).build();
+    when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(response);
+
+    List<SqsReceivedMessage> result = fetcher.fetch();
+
+    assertEquals(2, result.size());
+    assertEquals("msg-1", result.get(0).messageId());
+    assertEquals("receipt-1", result.get(0).receiptHandle());
+    assertArrayEquals("{\"key\": \"value1\"}".getBytes(), result.get(0).body());
+    assertEquals("msg-2", result.get(1).messageId());
+
+    verify(sqsClient)
+        .receiveMessage(
+            argThat(
+                (ReceiveMessageRequest req) -> {
+                  assertEquals(QUEUE_URL, req.queueUrl());
+                  assertEquals(10, req.maxNumberOfMessages());
+                  assertEquals(20, req.waitTimeSeconds());
+                  assertEquals(30, req.visibilityTimeout());
+                  return true;
+                }));
+  }
+
+  @Test
+  void testFetchWithMessageAttributes() {
+    Message message =
+        Message.builder()
+            .body("{\"data\": \"test\"}")
+            .messageId("msg-1")
+            .receiptHandle("receipt-1")
+            .messageAttributes(
+                java.util.Map.of(
+                    "customAttr",
+                    MessageAttributeValue.builder()
+                        .dataType("String")
+                        .stringValue("customValue")
+                        .build()))
+            .build();
+
+    ReceiveMessageResponse response = ReceiveMessageResponse.builder().messages(message).build();
+    when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(response);
+
+    List<SqsReceivedMessage> result = fetcher.fetch();
+
+    assertEquals(1, result.size());
+    assertEquals("customValue", result.get(0).attributes().get("customAttr"));
+  }
+
+  @Test
+  void testFetchReturnsEmptyWhenNoMessages() {
+    ReceiveMessageResponse response = ReceiveMessageResponse.builder().messages(List.of()).build();
+    when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(response);
+
+    List<SqsReceivedMessage> result = fetcher.fetch();
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testIsExhaustedReturnsFalse() {
+    assertFalse(fetcher.isExhausted());
+  }
+
+  @Test
+  void testCommitStrategyIsPerRecord() {
+    assertEquals(
+        io.fleak.zephflow.lib.commands.source.PerRecordCommitStrategy.INSTANCE,
+        fetcher.commitStrategy());
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/stdin/StdInSourceFetcherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/stdin/StdInSourceFetcherTest.java
@@ -85,9 +85,9 @@ class StdInSourceFetcherTest {
     // Execute fetch
     var result = fetcher.fetch();
 
-    // Verify results
+    // Verify results - empty input produces no events
     assertNotNull(result);
-    assertEquals(1, result.size());
+    assertTrue(result.isEmpty());
   }
 
   @Test
@@ -105,8 +105,9 @@ class StdInSourceFetcherTest {
     // Execute fetch
     var result = fetcher.fetch();
 
-    // Verify results
-    assertNull(result);
+    // Verify results - error returns empty list, not null
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
Implement sqssource and sqssink commands following existing Kinesis/Kafka connector patterns. SQS source uses long polling with per-record commit (message deletion). SQS sink uses sendMessageBatch with partial failure handling and FIFO queue support.