### PR TITLE
Add Email IMAP source and SMTP sink connectors

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ gcs = "2.49.0"
 activemqClassic = "5.19.4"
 activemqArtemis = "2.53.0"
 jakartaJms = "3.1.0"
+angusMail = "2.0.3"
 
 nebulaDependencyLock = "16.1.0"
 nebulaMavenPublish = "23.0.0"
@@ -164,6 +165,7 @@ gcs-storage = { module = "com.google.cloud:google-cloud-storage", version.ref = 
 activemq-client-jakarta = { module = "org.apache.activemq:activemq-client-jakarta", version.ref = "activemqClassic" }
 artemis-jakarta-client = { module = "org.apache.artemis:artemis-jakarta-client", version.ref = "activemqArtemis" }
 jakarta-jms-api = { module = "jakarta.jms:jakarta.jms-api", version.ref = "jakartaJms" }
+angus-mail = { module = "org.eclipse.angus:angus-mail", version.ref = "angusMail" }
 
 [plugins]
 nebula-dependency-lock = { id = "com.netflix.nebula.dependency-lock", version.ref = "nebulaDependencyLock" }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -46,6 +46,8 @@ dependencies {
   implementation libs.activemq.client.jakarta
   implementation libs.artemis.jakarta.client
 
+  implementation libs.angus.mail
+
   testImplementation libs.jackson.dataformat.yaml
   testImplementation libs.testcontainers.clickhouse
   testImplementation libs.testcontainers.gcloud

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/OperatorCommandRegistry.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/OperatorCommandRegistry.java
@@ -24,6 +24,7 @@ import io.fleak.zephflow.lib.commands.databrickssink.DatabricksSinkCommandFactor
 import io.fleak.zephflow.lib.commands.deltalakesink.DeltaLakeSinkCommandFactory;
 import io.fleak.zephflow.lib.commands.eval.EvalCommandFactory;
 import io.fleak.zephflow.lib.commands.filesource.FileSourceCommandFactory;
+import io.fleak.zephflow.lib.commands.imapsource.ImapSourceCommandFactory;
 import io.fleak.zephflow.lib.commands.kafkasink.KafkaSinkCommandFactory;
 import io.fleak.zephflow.lib.commands.kafkasource.KafkaSourceCommandFactory;
 import io.fleak.zephflow.lib.commands.kinesis.KinesisSinkCommandFactory;
@@ -32,6 +33,7 @@ import io.fleak.zephflow.lib.commands.noop.NoopCommandFactory;
 import io.fleak.zephflow.lib.commands.parser.ParserCommandFactory;
 import io.fleak.zephflow.lib.commands.reader.ReaderCommandFactory;
 import io.fleak.zephflow.lib.commands.s3.S3SinkCommandFactory;
+import io.fleak.zephflow.lib.commands.smtpsink.SmtpSinkCommandFactory;
 import io.fleak.zephflow.lib.commands.splunksource.SplunkSourceCommandFactory;
 import io.fleak.zephflow.lib.commands.sql.SqlCommandFactory;
 import io.fleak.zephflow.lib.commands.stdin.StdInCommandFactory;
@@ -64,5 +66,7 @@ public interface OperatorCommandRegistry {
           .put(COMMAND_NAME_DATABRICKS_SINK, new DatabricksSinkCommandFactory())
           .put(COMMAND_NAME_SYSLOG_UDP, new SyslogUdpCommandFactory())
           .put(COMMAND_NAME_ACTIVEMQ_SOURCE, new ActiveMqSourceCommandFactory())
+          .put(COMMAND_NAME_IMAP_SOURCE, new ImapSourceCommandFactory())
+          .put(COMMAND_NAME_SMTP_SINK, new SmtpSinkCommandFactory())
           .build();
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/OperatorCommandRegistry.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/OperatorCommandRegistry.java
@@ -24,9 +24,9 @@ import io.fleak.zephflow.lib.commands.databrickssink.DatabricksSinkCommandFactor
 import io.fleak.zephflow.lib.commands.deltalakesink.DeltaLakeSinkCommandFactory;
 import io.fleak.zephflow.lib.commands.eval.EvalCommandFactory;
 import io.fleak.zephflow.lib.commands.filesource.FileSourceCommandFactory;
+import io.fleak.zephflow.lib.commands.imapsource.ImapSourceCommandFactory;
 import io.fleak.zephflow.lib.commands.jdbcsink.JdbcSinkCommandFactory;
 import io.fleak.zephflow.lib.commands.jdbcsource.JdbcSourceCommandFactory;
-import io.fleak.zephflow.lib.commands.imapsource.ImapSourceCommandFactory;
 import io.fleak.zephflow.lib.commands.kafkasink.KafkaSinkCommandFactory;
 import io.fleak.zephflow.lib.commands.kafkasource.KafkaSourceCommandFactory;
 import io.fleak.zephflow.lib.commands.kinesis.KinesisSinkCommandFactory;

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/EmailMessage.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/EmailMessage.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.imapsource;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record EmailMessage(
+    String messageId,
+    String from,
+    List<String> to,
+    List<String> cc,
+    String subject,
+    String bodyText,
+    String bodyHtml,
+    Map<String, String> headers,
+    List<Attachment> attachments,
+    Instant receivedDate) {
+
+  public record Attachment(String filename, String contentType, String contentBase64) {}
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/EmailRawDataConverter.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/EmailRawDataConverter.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.imapsource;
+
+import static io.fleak.zephflow.lib.utils.MiscUtils.getCallingUserTagAndEventTags;
+
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.source.ConvertedResult;
+import io.fleak.zephflow.lib.commands.source.RawDataConverter;
+import io.fleak.zephflow.lib.commands.source.SourceExecutionContext;
+import java.util.*;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class EmailRawDataConverter implements RawDataConverter<EmailMessage> {
+
+  @Override
+  public ConvertedResult<EmailMessage> convert(
+      EmailMessage sourceRecord, SourceExecutionContext<?> sourceInitializedConfig) {
+    try {
+      Map<String, Object> map = toMap(sourceRecord);
+      RecordFleakData record = (RecordFleakData) FleakData.wrap(map);
+      List<RecordFleakData> events = List.of(record);
+
+      Map<String, String> eventTags = getCallingUserTagAndEventTags(null, record);
+      sourceInitializedConfig.inputEventCounter().increase(events.size(), eventTags);
+      sourceInitializedConfig.dataSizeCounter().increase(estimateSize(sourceRecord), eventTags);
+
+      return ConvertedResult.success(events, sourceRecord);
+    } catch (Exception e) {
+      sourceInitializedConfig.deserializeFailureCounter().increase(Map.of());
+      log.error("failed to convert email message", e);
+      return ConvertedResult.failure(e, sourceRecord);
+    }
+  }
+
+  static Map<String, Object> toMap(EmailMessage email) {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("messageId", email.messageId());
+    map.put("from", email.from());
+    map.put("to", email.to());
+    map.put("cc", email.cc());
+    map.put("subject", email.subject());
+    map.put("bodyText", email.bodyText());
+    map.put("bodyHtml", email.bodyHtml());
+    map.put("headers", email.headers());
+
+    if (email.attachments() != null && !email.attachments().isEmpty()) {
+      List<Map<String, Object>> attachmentList = new ArrayList<>();
+      for (EmailMessage.Attachment att : email.attachments()) {
+        Map<String, Object> attMap = new LinkedHashMap<>();
+        attMap.put("filename", att.filename());
+        attMap.put("contentType", att.contentType());
+        attMap.put("contentBase64", att.contentBase64());
+        attachmentList.add(attMap);
+      }
+      map.put("attachments", attachmentList);
+    } else {
+      map.put("attachments", List.of());
+    }
+
+    map.put("receivedDate", email.receivedDate() != null ? email.receivedDate().toString() : null);
+    return map;
+  }
+
+  private int estimateSize(EmailMessage email) {
+    int size = 0;
+    if (email.bodyText() != null) {
+      size += email.bodyText().length();
+    }
+    if (email.bodyHtml() != null) {
+      size += email.bodyHtml().length();
+    }
+    if (email.subject() != null) {
+      size += email.subject().length();
+    }
+    return Math.max(size, 1);
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/EmailRawDataEncoder.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/EmailRawDataEncoder.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.imapsource;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.toJsonString;
+
+import io.fleak.zephflow.lib.commands.source.RawDataEncoder;
+import io.fleak.zephflow.lib.serdes.SerializedEvent;
+import java.nio.charset.StandardCharsets;
+
+public class EmailRawDataEncoder implements RawDataEncoder<EmailMessage> {
+
+  @Override
+  public SerializedEvent serialize(EmailMessage sourceRecord) {
+    String json = toJsonString(EmailRawDataConverter.toMap(sourceRecord));
+    byte[] bytes = json != null ? json.getBytes(StandardCharsets.UTF_8) : new byte[0];
+    return new SerializedEvent(null, bytes, null);
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceCommand.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.imapsource;
+
+import static io.fleak.zephflow.lib.utils.MiscUtils.*;
+
+import io.fleak.zephflow.api.*;
+import io.fleak.zephflow.api.metric.FleakCounter;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.lib.commands.source.*;
+import io.fleak.zephflow.lib.credentials.ApiKeyCredential;
+import io.fleak.zephflow.lib.credentials.UsernamePasswordCredential;
+import io.fleak.zephflow.lib.dlq.DlqWriter;
+import io.fleak.zephflow.lib.dlq.DlqWriterFactory;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ImapSourceCommand extends SimpleSourceCommand<EmailMessage> {
+
+  public ImapSourceCommand(
+      String nodeId,
+      JobContext jobContext,
+      ConfigParser configParser,
+      ConfigValidator configValidator) {
+    super(nodeId, jobContext, configParser, configValidator);
+  }
+
+  @Override
+  protected ExecutionContext createExecutionContext(
+      MetricClientProvider metricClientProvider,
+      JobContext jobContext,
+      CommandConfig commandConfig,
+      String nodeId) {
+    ImapSourceDto.Config config = (ImapSourceDto.Config) commandConfig;
+
+    Fetcher<EmailMessage> fetcher = createImapFetcher(config, jobContext);
+    RawDataEncoder<EmailMessage> encoder = new EmailRawDataEncoder();
+    RawDataConverter<EmailMessage> converter = new EmailRawDataConverter();
+
+    Map<String, String> metricTags =
+        basicCommandMetricTags(jobContext.getMetricTags(), commandName(), nodeId);
+    FleakCounter dataSizeCounter =
+        metricClientProvider.counter(METRIC_NAME_INPUT_EVENT_SIZE_COUNT, metricTags);
+    FleakCounter inputEventCounter =
+        metricClientProvider.counter(METRIC_NAME_INPUT_EVENT_COUNT, metricTags);
+    FleakCounter deserializeFailureCounter =
+        metricClientProvider.counter(METRIC_NAME_INPUT_DESER_ERR_COUNT, metricTags);
+
+    String keyPrefix = (String) jobContext.getOtherProperties().get(JobContext.DATA_KEY_PREFIX);
+    DlqWriter dlqWriter =
+        Optional.of(jobContext)
+            .map(JobContext::getDlqConfig)
+            .map(c -> DlqWriterFactory.createDlqWriter(c, keyPrefix))
+            .orElse(null);
+    if (dlqWriter != null) {
+      dlqWriter.open();
+    }
+
+    return new SourceExecutionContext<>(
+        fetcher,
+        converter,
+        encoder,
+        dataSizeCounter,
+        inputEventCounter,
+        deserializeFailureCounter,
+        dlqWriter);
+  }
+
+  private Fetcher<EmailMessage> createImapFetcher(
+      ImapSourceDto.Config config, JobContext jobContext) {
+    try {
+      Properties props = new Properties();
+      String protocol = Boolean.TRUE.equals(config.getUseSsl()) ? "imaps" : "imap";
+
+      props.setProperty("mail.store.protocol", protocol);
+      props.setProperty("mail." + protocol + ".host", config.getHost());
+      props.setProperty("mail." + protocol + ".port", String.valueOf(config.getPort()));
+
+      if (Boolean.TRUE.equals(config.getUseSsl())) {
+        props.setProperty("mail." + protocol + ".ssl.enable", "true");
+      }
+
+      if (config.getAuthType() == ImapSourceDto.AuthType.OAUTH2) {
+        props.setProperty("mail." + protocol + ".auth.mechanisms", "XOAUTH2");
+      }
+
+      Session session = Session.getInstance(props);
+      Store store = session.getStore(protocol);
+
+      if (config.getAuthType() == ImapSourceDto.AuthType.PASSWORD) {
+        UsernamePasswordCredential credential =
+            lookupUsernamePasswordCredential(jobContext, config.getCredentialId());
+        store.connect(
+            config.getHost(), config.getPort(), credential.getUsername(), credential.getPassword());
+      } else {
+        ApiKeyCredential credential = lookupApiKeyCredential(jobContext, config.getCredentialId());
+        store.connect(config.getHost(), config.getPort(), null, credential.getKey());
+      }
+
+      return new ImapSourceFetcher(
+          store,
+          config.getFolder(),
+          config.getSearchCriteria(),
+          Boolean.TRUE.equals(config.getMarkAsRead()),
+          Boolean.TRUE.equals(config.getIncludeAttachments()),
+          config.getMaxMessages());
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create IMAP fetcher", e);
+    }
+  }
+
+  @Override
+  public SourceType sourceType() {
+    return SourceType.STREAMING;
+  }
+
+  @Override
+  public String commandName() {
+    return COMMAND_NAME_IMAP_SOURCE;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceCommandFactory.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceCommandFactory.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.imapsource;
+
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.lib.commands.JsonConfigParser;
+import io.fleak.zephflow.lib.commands.source.SourceCommandFactory;
+
+public class ImapSourceCommandFactory extends SourceCommandFactory {
+
+  @Override
+  public ImapSourceCommand createCommand(String nodeId, JobContext jobContext) {
+    JsonConfigParser<ImapSourceDto.Config> configParser =
+        new JsonConfigParser<>(ImapSourceDto.Config.class);
+    ImapSourceConfigValidator validator = new ImapSourceConfigValidator();
+    return new ImapSourceCommand(nodeId, jobContext, configParser, validator);
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceConfigValidator.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceConfigValidator.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.imapsource;
+
+import com.google.common.base.Preconditions;
+import io.fleak.zephflow.api.CommandConfig;
+import io.fleak.zephflow.api.ConfigValidator;
+import io.fleak.zephflow.api.JobContext;
+import org.apache.commons.lang3.StringUtils;
+
+public class ImapSourceConfigValidator implements ConfigValidator {
+  @Override
+  public void validateConfig(CommandConfig commandConfig, String nodeId, JobContext jobContext) {
+    ImapSourceDto.Config config = (ImapSourceDto.Config) commandConfig;
+
+    Preconditions.checkArgument(StringUtils.isNotBlank(config.getHost()), "no host is provided");
+    Preconditions.checkNotNull(config.getPort(), "no port is provided");
+    Preconditions.checkArgument(
+        config.getPort() > 0, "port must be positive, got: %s", config.getPort());
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.getCredentialId()), "no credentialId is provided");
+    Preconditions.checkNotNull(config.getAuthType(), "no authType is provided");
+
+    if (config.getMaxMessages() != null) {
+      Preconditions.checkArgument(
+          config.getMaxMessages() > 0,
+          "maxMessages must be positive, got: %s",
+          config.getMaxMessages());
+    }
+
+    if (config.getPollIntervalMs() != null) {
+      Preconditions.checkArgument(
+          config.getPollIntervalMs() > 0,
+          "pollIntervalMs must be positive, got: %s",
+          config.getPollIntervalMs());
+    }
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceDto.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.imapsource;
+
+import io.fleak.zephflow.api.CommandConfig;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public interface ImapSourceDto {
+
+  int DEFAULT_PORT = 993;
+  String DEFAULT_FOLDER = "INBOX";
+  long DEFAULT_POLL_INTERVAL_MS = 60000L;
+  boolean DEFAULT_MARK_AS_READ = true;
+  boolean DEFAULT_INCLUDE_ATTACHMENTS = false;
+  boolean DEFAULT_USE_SSL = true;
+  int DEFAULT_MAX_MESSAGES = 100;
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  class Config implements CommandConfig {
+    private String host;
+    @Builder.Default private Integer port = DEFAULT_PORT;
+    private String credentialId;
+    @Builder.Default private AuthType authType = AuthType.PASSWORD;
+    @Builder.Default private String folder = DEFAULT_FOLDER;
+    private String searchCriteria;
+    @Builder.Default private Long pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
+    @Builder.Default private Boolean markAsRead = DEFAULT_MARK_AS_READ;
+    @Builder.Default private Boolean includeAttachments = DEFAULT_INCLUDE_ATTACHMENTS;
+    @Builder.Default private Boolean useSsl = DEFAULT_USE_SSL;
+    @Builder.Default private Integer maxMessages = DEFAULT_MAX_MESSAGES;
+  }
+
+  enum AuthType {
+    PASSWORD,
+    OAUTH2
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceFetcher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceFetcher.java
@@ -1,0 +1,268 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.imapsource;
+
+import io.fleak.zephflow.lib.commands.source.Fetcher;
+import jakarta.mail.*;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMultipart;
+import jakarta.mail.search.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.*;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ImapSourceFetcher implements Fetcher<EmailMessage> {
+
+  private final Store store;
+  private final String folderName;
+  private final String searchCriteria;
+  private final boolean markAsRead;
+  private final boolean includeAttachments;
+  private final int maxMessages;
+
+  private Folder folder;
+
+  public ImapSourceFetcher(
+      Store store,
+      String folderName,
+      String searchCriteria,
+      boolean markAsRead,
+      boolean includeAttachments,
+      int maxMessages) {
+    this.store = store;
+    this.folderName = folderName;
+    this.searchCriteria = searchCriteria;
+    this.markAsRead = markAsRead;
+    this.includeAttachments = includeAttachments;
+    this.maxMessages = maxMessages;
+  }
+
+  @Override
+  public List<EmailMessage> fetch() {
+    List<EmailMessage> emails = new ArrayList<>();
+    try {
+      if (folder == null || !folder.isOpen()) {
+        folder = store.getFolder(folderName);
+        folder.open(Folder.READ_WRITE);
+      }
+
+      SearchTerm searchTerm = parseSearchCriteria(searchCriteria);
+      Message[] messages = searchTerm != null ? folder.search(searchTerm) : folder.getMessages();
+
+      int limit = Math.min(messages.length, maxMessages);
+      for (int i = 0; i < limit; i++) {
+        try {
+          emails.add(convertMessage(messages[i]));
+          if (markAsRead) {
+            messages[i].setFlag(Flags.Flag.SEEN, true);
+          }
+        } catch (Exception e) {
+          log.error("Error processing email message", e);
+        }
+      }
+
+      folder.close(false);
+      folder = null;
+    } catch (Exception e) {
+      log.error("Error fetching emails from IMAP", e);
+    }
+    log.debug("Fetched {} emails from IMAP folder {}", emails.size(), folderName);
+    return emails;
+  }
+
+  EmailMessage convertMessage(Message message) throws MessagingException, IOException {
+    String messageId = getMessageId(message);
+    String from = extractFrom(message);
+    List<String> to = extractAddresses(message, Message.RecipientType.TO);
+    List<String> cc = extractAddresses(message, Message.RecipientType.CC);
+    String subject = message.getSubject();
+    Map<String, String> headers = extractHeaders(message);
+    Instant receivedDate =
+        message.getReceivedDate() != null ? message.getReceivedDate().toInstant() : null;
+
+    String bodyText = null;
+    String bodyHtml = null;
+    List<EmailMessage.Attachment> attachments = new ArrayList<>();
+
+    Object content = message.getContent();
+    if (content instanceof String textContent) {
+      if (message.isMimeType("text/html")) {
+        bodyHtml = textContent;
+      } else {
+        bodyText = textContent;
+      }
+    } else if (content instanceof MimeMultipart multipart) {
+      BodyContent bodyContent = extractMultipartContent(multipart, attachments);
+      bodyText = bodyContent.text;
+      bodyHtml = bodyContent.html;
+    }
+
+    return new EmailMessage(
+        messageId, from, to, cc, subject, bodyText, bodyHtml, headers, attachments, receivedDate);
+  }
+
+  private String getMessageId(Message message) throws MessagingException {
+    String[] messageIdHeader = message.getHeader("Message-ID");
+    if (messageIdHeader != null && messageIdHeader.length > 0) {
+      return messageIdHeader[0];
+    }
+    return null;
+  }
+
+  private String extractFrom(Message message) throws MessagingException {
+    Address[] fromAddresses = message.getFrom();
+    if (fromAddresses != null && fromAddresses.length > 0) {
+      if (fromAddresses[0] instanceof InternetAddress ia) {
+        return ia.getAddress();
+      }
+      return fromAddresses[0].toString();
+    }
+    return null;
+  }
+
+  private List<String> extractAddresses(Message message, Message.RecipientType type)
+      throws MessagingException {
+    Address[] addresses = message.getRecipients(type);
+    if (addresses == null) {
+      return List.of();
+    }
+    List<String> result = new ArrayList<>();
+    for (Address address : addresses) {
+      if (address instanceof InternetAddress ia) {
+        result.add(ia.getAddress());
+      } else {
+        result.add(address.toString());
+      }
+    }
+    return result;
+  }
+
+  private Map<String, String> extractHeaders(Message message) throws MessagingException {
+    Map<String, String> headers = new LinkedHashMap<>();
+    Enumeration<Header> allHeaders = message.getAllHeaders();
+    while (allHeaders.hasMoreElements()) {
+      Header header = allHeaders.nextElement();
+      headers.put(header.getName(), header.getValue());
+    }
+    return headers;
+  }
+
+  private BodyContent extractMultipartContent(
+      MimeMultipart multipart, List<EmailMessage.Attachment> attachments)
+      throws MessagingException, IOException {
+    String text = null;
+    String html = null;
+
+    for (int i = 0; i < multipart.getCount(); i++) {
+      BodyPart part = multipart.getBodyPart(i);
+      String disposition = part.getDisposition();
+
+      if (disposition != null
+          && (disposition.equalsIgnoreCase(Part.ATTACHMENT)
+              || disposition.equalsIgnoreCase(Part.INLINE))) {
+        if (includeAttachments) {
+          attachments.add(extractAttachment(part));
+        }
+      } else if (part.isMimeType("text/plain") && text == null) {
+        text = (String) part.getContent();
+      } else if (part.isMimeType("text/html") && html == null) {
+        html = (String) part.getContent();
+      } else if (part.getContent() instanceof MimeMultipart nestedMultipart) {
+        BodyContent nested = extractMultipartContent(nestedMultipart, attachments);
+        if (text == null) {
+          text = nested.text;
+        }
+        if (html == null) {
+          html = nested.html;
+        }
+      }
+    }
+
+    return new BodyContent(text, html);
+  }
+
+  private EmailMessage.Attachment extractAttachment(BodyPart part)
+      throws MessagingException, IOException {
+    String filename = part.getFileName();
+    String contentType = part.getContentType();
+    try (InputStream is = part.getInputStream()) {
+      byte[] bytes = is.readAllBytes();
+      String contentBase64 = Base64.getEncoder().encodeToString(bytes);
+      return new EmailMessage.Attachment(filename, contentType, contentBase64);
+    }
+  }
+
+  static SearchTerm parseSearchCriteria(String criteria) {
+    if (criteria == null || criteria.isBlank()) {
+      return null;
+    }
+
+    String trimmed = criteria.trim();
+
+    if (trimmed.equalsIgnoreCase("UNSEEN")) {
+      return new FlagTerm(new Flags(Flags.Flag.SEEN), false);
+    }
+
+    if (trimmed.equalsIgnoreCase("SEEN")) {
+      return new FlagTerm(new Flags(Flags.Flag.SEEN), true);
+    }
+
+    if (trimmed.toUpperCase().startsWith("SINCE ")) {
+      String dateStr = trimmed.substring(6).trim();
+      try {
+        Date date = new SimpleDateFormat("yyyy-MM-dd").parse(dateStr);
+        return new ReceivedDateTerm(ComparisonTerm.GE, date);
+      } catch (ParseException e) {
+        throw new IllegalArgumentException("Invalid date format in SINCE criteria: " + dateStr, e);
+      }
+    }
+
+    if (trimmed.toUpperCase().startsWith("FROM ")) {
+      String addr = trimmed.substring(5).trim();
+      return new FromStringTerm(addr);
+    }
+
+    if (trimmed.toUpperCase().startsWith("SUBJECT ")) {
+      String text = trimmed.substring(8).trim();
+      return new SubjectTerm(text);
+    }
+
+    throw new IllegalArgumentException("Unsupported search criteria: " + criteria);
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      if (folder != null && folder.isOpen()) {
+        folder.close(false);
+      }
+    } catch (MessagingException e) {
+      log.warn("Failed to close IMAP folder", e);
+    }
+    try {
+      if (store != null && store.isConnected()) {
+        store.close();
+      }
+    } catch (MessagingException e) {
+      log.warn("Failed to close IMAP store", e);
+    }
+  }
+
+  private record BodyContent(String text, String html) {}
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/PreparedEmail.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/PreparedEmail.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.smtpsink;
+
+import java.util.List;
+
+public record PreparedEmail(
+    String from,
+    List<String> to,
+    List<String> cc,
+    String subject,
+    String body,
+    String contentType) {}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkCommand.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.smtpsink;
+
+import static io.fleak.zephflow.lib.utils.MiscUtils.*;
+
+import io.fleak.zephflow.api.*;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
+import io.fleak.zephflow.lib.commands.sink.SinkExecutionContext;
+import io.fleak.zephflow.lib.credentials.UsernamePasswordCredential;
+import jakarta.mail.Session;
+import java.util.Properties;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SmtpSinkCommand extends SimpleSinkCommand<PreparedEmail> {
+
+  private static final int SMTP_SINK_BATCH_SIZE = 50;
+
+  protected SmtpSinkCommand(
+      String nodeId,
+      JobContext jobContext,
+      ConfigParser configParser,
+      ConfigValidator configValidator) {
+    super(nodeId, jobContext, configParser, configValidator);
+  }
+
+  @Override
+  protected ExecutionContext createExecutionContext(
+      MetricClientProvider metricClientProvider,
+      JobContext jobContext,
+      CommandConfig commandConfig,
+      String nodeId) {
+    SinkCounters counters =
+        createSinkCounters(metricClientProvider, jobContext, commandName(), nodeId);
+
+    SmtpSinkDto.Config config = (SmtpSinkDto.Config) commandConfig;
+
+    UsernamePasswordCredential credential =
+        lookupUsernamePasswordCredential(jobContext, config.getCredentialId());
+
+    Session session = createSmtpSession(config);
+
+    SimpleSinkCommand.Flusher<PreparedEmail> flusher =
+        new SmtpSinkFlusher(session, credential.getUsername(), credential.getPassword());
+    SimpleSinkCommand.SinkMessagePreProcessor<PreparedEmail> messagePreProcessor =
+        new SmtpSinkMessageProcessor(config);
+
+    return new SinkExecutionContext<>(
+        flusher,
+        messagePreProcessor,
+        counters.inputMessageCounter(),
+        counters.errorCounter(),
+        counters.sinkOutputCounter(),
+        counters.outputSizeCounter(),
+        counters.sinkErrorCounter());
+  }
+
+  static Session createSmtpSession(SmtpSinkDto.Config config) {
+    Properties props = new Properties();
+    props.setProperty("mail.smtp.host", config.getHost());
+    props.setProperty("mail.smtp.port", String.valueOf(config.getPort()));
+    props.setProperty("mail.smtp.auth", "true");
+
+    if (Boolean.TRUE.equals(config.getUseTls())) {
+      props.setProperty("mail.smtp.starttls.enable", "true");
+    }
+
+    return Session.getInstance(props);
+  }
+
+  @Override
+  protected int batchSize() {
+    return SMTP_SINK_BATCH_SIZE;
+  }
+
+  @Override
+  public String commandName() {
+    return COMMAND_NAME_SMTP_SINK;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkCommandFactory.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkCommandFactory.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.smtpsink;
+
+import io.fleak.zephflow.api.CommandFactory;
+import io.fleak.zephflow.api.CommandType;
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.api.OperatorCommand;
+import io.fleak.zephflow.lib.commands.JsonConfigParser;
+
+public class SmtpSinkCommandFactory extends CommandFactory {
+  @Override
+  public OperatorCommand createCommand(String nodeId, JobContext jobContext) {
+    JsonConfigParser<SmtpSinkDto.Config> configParser =
+        new JsonConfigParser<>(SmtpSinkDto.Config.class);
+    SmtpSinkConfigValidator validator = new SmtpSinkConfigValidator();
+    return new SmtpSinkCommand(nodeId, jobContext, configParser, validator);
+  }
+
+  @Override
+  public CommandType commandType() {
+    return CommandType.SINK;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkConfigValidator.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkConfigValidator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.smtpsink;
+
+import com.google.common.base.Preconditions;
+import io.fleak.zephflow.api.CommandConfig;
+import io.fleak.zephflow.api.ConfigValidator;
+import io.fleak.zephflow.api.JobContext;
+import org.apache.commons.lang3.StringUtils;
+
+public class SmtpSinkConfigValidator implements ConfigValidator {
+  @Override
+  public void validateConfig(CommandConfig commandConfig, String nodeId, JobContext jobContext) {
+    SmtpSinkDto.Config config = (SmtpSinkDto.Config) commandConfig;
+
+    Preconditions.checkArgument(StringUtils.isNotBlank(config.getHost()), "no host is provided");
+    Preconditions.checkNotNull(config.getPort(), "no port is provided");
+    Preconditions.checkArgument(
+        config.getPort() > 0, "port must be positive, got: %s", config.getPort());
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.getCredentialId()), "no credentialId is provided");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.getFromAddress()), "no fromAddress is provided");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.getToTemplate()), "no toTemplate is provided");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.getSubjectTemplate()), "no subjectTemplate is provided");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.getBodyTemplate()), "no bodyTemplate is provided");
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkDto.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.smtpsink;
+
+import io.fleak.zephflow.api.CommandConfig;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class SmtpSinkDto {
+
+  public static final int DEFAULT_PORT = 587;
+  public static final String DEFAULT_BODY_CONTENT_TYPE = "text/plain";
+  public static final boolean DEFAULT_USE_TLS = true;
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Config implements CommandConfig {
+    private String host;
+    @Builder.Default private Integer port = DEFAULT_PORT;
+    private String credentialId;
+    private String fromAddress;
+    private String toTemplate;
+    private String ccTemplate;
+    private String subjectTemplate;
+    private String bodyTemplate;
+    @Builder.Default private String bodyContentType = DEFAULT_BODY_CONTENT_TYPE;
+    @Builder.Default private Boolean useTls = DEFAULT_USE_TLS;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkFlusher.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.smtpsink;
+
+import io.fleak.zephflow.api.ErrorOutput;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
+import jakarta.mail.Message;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+
+@Slf4j
+public class SmtpSinkFlusher implements SimpleSinkCommand.Flusher<PreparedEmail> {
+
+  private final Session session;
+  private final String username;
+  private final String password;
+  private volatile boolean closed = false;
+
+  public SmtpSinkFlusher(Session session, String username, String password) {
+    this.session = session;
+    this.username = username;
+    this.password = password;
+  }
+
+  @Override
+  public SimpleSinkCommand.FlushResult flush(
+      SimpleSinkCommand.PreparedInputEvents<PreparedEmail> preparedInputEvents,
+      Map<String, String> metricTags)
+      throws Exception {
+
+    if (closed) {
+      throw new IllegalStateException("SmtpSinkFlusher is closed");
+    }
+
+    List<PreparedEmail> emails = preparedInputEvents.preparedList();
+    if (emails.isEmpty()) {
+      return new SimpleSinkCommand.FlushResult(0, 0, List.of());
+    }
+
+    List<ErrorOutput> errorOutputs = new ArrayList<>();
+    int sentCount = 0;
+    long totalSize = 0;
+
+    List<Pair<RecordFleakData, PreparedEmail>> rawAndPrepared =
+        preparedInputEvents.rawAndPreparedList();
+
+    for (int i = 0; i < emails.size(); i++) {
+      PreparedEmail email = emails.get(i);
+      RecordFleakData rawEvent = rawAndPrepared.get(i).getKey();
+      try {
+        MimeMessage message = createMimeMessage(email);
+        Transport.send(message, username, password);
+        sentCount++;
+        totalSize += email.body() != null ? email.body().length() : 0;
+      } catch (Exception e) {
+        log.error("Failed to send email to {}", email.to(), e);
+        errorOutputs.add(new ErrorOutput(rawEvent, e.getMessage()));
+      }
+    }
+
+    log.debug("SMTP flush completed: {} sent, {} errors", sentCount, errorOutputs.size());
+    return new SimpleSinkCommand.FlushResult(sentCount, totalSize, errorOutputs);
+  }
+
+  MimeMessage createMimeMessage(PreparedEmail email) throws Exception {
+    MimeMessage message = new MimeMessage(session);
+    message.setFrom(new InternetAddress(email.from()));
+
+    for (String to : email.to()) {
+      message.addRecipient(Message.RecipientType.TO, new InternetAddress(to));
+    }
+
+    if (email.cc() != null) {
+      for (String cc : email.cc()) {
+        message.addRecipient(Message.RecipientType.CC, new InternetAddress(cc));
+      }
+    }
+
+    message.setSubject(email.subject());
+    message.setContent(email.body(), email.contentType());
+
+    return message;
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkMessageProcessor.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkMessageProcessor.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.smtpsink;
+
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.TemplatePlaceholderResolver;
+import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SmtpSinkMessageProcessor
+    implements SimpleSinkCommand.SinkMessagePreProcessor<PreparedEmail> {
+
+  private final SmtpSinkDto.Config config;
+  private final TemplatePlaceholderResolver toResolver;
+  private final TemplatePlaceholderResolver ccResolver;
+  private final TemplatePlaceholderResolver subjectResolver;
+  private final TemplatePlaceholderResolver bodyResolver;
+
+  public SmtpSinkMessageProcessor(SmtpSinkDto.Config config) {
+    this.config = config;
+    this.toResolver = TemplatePlaceholderResolver.create(config.getToTemplate());
+    this.ccResolver =
+        config.getCcTemplate() != null
+            ? TemplatePlaceholderResolver.create(config.getCcTemplate())
+            : null;
+    this.subjectResolver = TemplatePlaceholderResolver.create(config.getSubjectTemplate());
+    this.bodyResolver = TemplatePlaceholderResolver.create(config.getBodyTemplate());
+  }
+
+  @Override
+  public PreparedEmail preprocess(RecordFleakData event, long ts) {
+    String toResolved = toResolver.resolvePlaceholders(event);
+    List<String> toList = splitAddresses(toResolved);
+
+    List<String> ccList = List.of();
+    if (ccResolver != null) {
+      String ccResolved = ccResolver.resolvePlaceholders(event);
+      ccList = splitAddresses(ccResolved);
+    }
+
+    String subject = subjectResolver.resolvePlaceholders(event);
+    String body = bodyResolver.resolvePlaceholders(event);
+
+    return new PreparedEmail(
+        config.getFromAddress(), toList, ccList, subject, body, config.getBodyContentType());
+  }
+
+  private static List<String> splitAddresses(String addresses) {
+    return Arrays.stream(addresses.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .collect(Collectors.toList());
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
@@ -91,6 +91,8 @@ public interface MiscUtils {
   String COMMAND_NAME_DATABRICKS_SINK = "databrickssink";
   String COMMAND_NAME_SYSLOG_UDP = "syslogudp";
   String COMMAND_NAME_ACTIVEMQ_SOURCE = "activemqsource";
+  String COMMAND_NAME_IMAP_SOURCE = "imapsource";
+  String COMMAND_NAME_SMTP_SINK = "smtpsink";
   String METRIC_NAME_INPUT_EVENT_COUNT = "input_event_count";
   String METRIC_NAME_INPUT_EVENT_SIZE_COUNT = "input_event_size";
   String METRIC_NAME_INPUT_DESER_ERR_COUNT = "input_deser_err_count";

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/OperatorCommandRegistryTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/OperatorCommandRegistryTest.java
@@ -47,6 +47,8 @@ class OperatorCommandRegistryTest {
             .add(COMMAND_NAME_DATABRICKS_SINK)
             .add(COMMAND_NAME_SYSLOG_UDP)
             .add(COMMAND_NAME_ACTIVEMQ_SOURCE)
+            .add(COMMAND_NAME_IMAP_SOURCE)
+            .add(COMMAND_NAME_SMTP_SINK)
             .build(),
         OPERATOR_COMMANDS.keySet());
   }

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/EmailRawDataConverterTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/EmailRawDataConverterTest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.imapsource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.source.ConvertedResult;
+import io.fleak.zephflow.lib.commands.source.SourceExecutionContext;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EmailRawDataConverterTest {
+
+  private EmailRawDataConverter converter;
+  private SourceExecutionContext<?> mockContext;
+
+  @BeforeEach
+  void setUp() {
+    converter = new EmailRawDataConverter();
+    mockContext = mock(SourceExecutionContext.class);
+    when(mockContext.dataSizeCounter()).thenReturn(mock());
+    when(mockContext.inputEventCounter()).thenReturn(mock());
+    when(mockContext.deserializeFailureCounter()).thenReturn(mock());
+  }
+
+  @Test
+  void testConvertBasicEmail() {
+    Instant now = Instant.parse("2025-01-15T10:30:00Z");
+    EmailMessage email =
+        new EmailMessage(
+            "<msg123@example.com>",
+            "sender@example.com",
+            List.of("recipient@example.com"),
+            List.of("cc@example.com"),
+            "Test Subject",
+            "Hello World",
+            "<html>Hello World</html>",
+            Map.of("Subject", "Test Subject"),
+            List.of(),
+            now);
+
+    ConvertedResult<EmailMessage> result = converter.convert(email, mockContext);
+
+    assertNotNull(result.transformedData());
+    assertNull(result.error());
+    assertEquals(1, result.transformedData().size());
+
+    RecordFleakData record = result.transformedData().getFirst();
+    Map<String, Object> unwrapped = record.unwrap();
+
+    assertEquals("<msg123@example.com>", unwrapped.get("messageId"));
+    assertEquals("sender@example.com", unwrapped.get("from"));
+    assertEquals(List.of("recipient@example.com"), unwrapped.get("to"));
+    assertEquals(List.of("cc@example.com"), unwrapped.get("cc"));
+    assertEquals("Test Subject", unwrapped.get("subject"));
+    assertEquals("Hello World", unwrapped.get("bodyText"));
+    assertEquals("<html>Hello World</html>", unwrapped.get("bodyHtml"));
+    assertEquals("2025-01-15T10:30:00Z", unwrapped.get("receivedDate"));
+  }
+
+  @Test
+  void testConvertEmailWithAttachments() {
+    EmailMessage.Attachment attachment =
+        new EmailMessage.Attachment("file.pdf", "application/pdf", "dGVzdA==");
+    EmailMessage email =
+        new EmailMessage(
+            "<msg456@example.com>",
+            "sender@example.com",
+            List.of("to@example.com"),
+            List.of(),
+            "With Attachment",
+            "See attached",
+            null,
+            Map.of(),
+            List.of(attachment),
+            null);
+
+    ConvertedResult<EmailMessage> result = converter.convert(email, mockContext);
+
+    assertNotNull(result.transformedData());
+    RecordFleakData record = result.transformedData().getFirst();
+    Map<String, Object> unwrapped = record.unwrap();
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> attachments =
+        (List<Map<String, Object>>) unwrapped.get("attachments");
+    assertEquals(1, attachments.size());
+    assertEquals("file.pdf", attachments.getFirst().get("filename"));
+    assertEquals("application/pdf", attachments.getFirst().get("contentType"));
+    assertEquals("dGVzdA==", attachments.getFirst().get("contentBase64"));
+  }
+
+  @Test
+  void testConvertEmailWithNullFields() {
+    EmailMessage email =
+        new EmailMessage(
+            null, null, List.of(), List.of(), null, null, null, Map.of(), List.of(), null);
+
+    ConvertedResult<EmailMessage> result = converter.convert(email, mockContext);
+
+    assertNotNull(result.transformedData());
+    assertEquals(1, result.transformedData().size());
+
+    RecordFleakData record = result.transformedData().getFirst();
+    Map<String, Object> unwrapped = record.unwrap();
+    assertNull(unwrapped.get("messageId"));
+    assertNull(unwrapped.get("from"));
+    assertNull(unwrapped.get("receivedDate"));
+  }
+
+  @Test
+  void testToMap() {
+    Instant now = Instant.parse("2025-06-01T12:00:00Z");
+    EmailMessage email =
+        new EmailMessage(
+            "<id@test.com>",
+            "from@test.com",
+            List.of("to1@test.com", "to2@test.com"),
+            List.of(),
+            "Subject",
+            "text body",
+            "<p>html body</p>",
+            Map.of("X-Custom", "value"),
+            List.of(),
+            now);
+
+    Map<String, Object> map = EmailRawDataConverter.toMap(email);
+
+    assertEquals("<id@test.com>", map.get("messageId"));
+    assertEquals("from@test.com", map.get("from"));
+    assertEquals(List.of("to1@test.com", "to2@test.com"), map.get("to"));
+    assertEquals(List.of(), map.get("cc"));
+    assertEquals("Subject", map.get("subject"));
+    assertEquals("text body", map.get("bodyText"));
+    assertEquals("<p>html body</p>", map.get("bodyHtml"));
+    assertEquals("2025-06-01T12:00:00Z", map.get("receivedDate"));
+    assertEquals(List.of(), map.get("attachments"));
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceConfigValidatorTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceConfigValidatorTest.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.imapsource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.fleak.zephflow.api.JobContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ImapSourceConfigValidatorTest {
+
+  private ImapSourceConfigValidator validator;
+  private JobContext mockJobContext;
+
+  @BeforeEach
+  void setUp() {
+    validator = new ImapSourceConfigValidator();
+    mockJobContext = mock(JobContext.class);
+  }
+
+  @Test
+  void testValidConfig() {
+    ImapSourceDto.Config config =
+        ImapSourceDto.Config.builder()
+            .host("imap.gmail.com")
+            .port(993)
+            .credentialId("my-cred")
+            .authType(ImapSourceDto.AuthType.PASSWORD)
+            .build();
+
+    assertDoesNotThrow(() -> validator.validateConfig(config, "test-node", mockJobContext));
+  }
+
+  @Test
+  void testValidOAuth2Config() {
+    ImapSourceDto.Config config =
+        ImapSourceDto.Config.builder()
+            .host("imap.gmail.com")
+            .port(993)
+            .credentialId("my-oauth-cred")
+            .authType(ImapSourceDto.AuthType.OAUTH2)
+            .build();
+
+    assertDoesNotThrow(() -> validator.validateConfig(config, "test-node", mockJobContext));
+  }
+
+  @Test
+  void testMissingHost() {
+    ImapSourceDto.Config config =
+        ImapSourceDto.Config.builder()
+            .host("")
+            .credentialId("my-cred")
+            .authType(ImapSourceDto.AuthType.PASSWORD)
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("no host is provided"));
+  }
+
+  @Test
+  void testNullHost() {
+    ImapSourceDto.Config config =
+        ImapSourceDto.Config.builder()
+            .host(null)
+            .credentialId("my-cred")
+            .authType(ImapSourceDto.AuthType.PASSWORD)
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("no host is provided"));
+  }
+
+  @Test
+  void testInvalidPort() {
+    ImapSourceDto.Config config =
+        ImapSourceDto.Config.builder()
+            .host("imap.gmail.com")
+            .port(-1)
+            .credentialId("my-cred")
+            .authType(ImapSourceDto.AuthType.PASSWORD)
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("port must be positive"));
+  }
+
+  @Test
+  void testMissingCredentialId() {
+    ImapSourceDto.Config config =
+        ImapSourceDto.Config.builder()
+            .host("imap.gmail.com")
+            .credentialId("")
+            .authType(ImapSourceDto.AuthType.PASSWORD)
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("no credentialId is provided"));
+  }
+
+  @Test
+  void testNullAuthType() {
+    ImapSourceDto.Config config =
+        ImapSourceDto.Config.builder()
+            .host("imap.gmail.com")
+            .credentialId("my-cred")
+            .authType(null)
+            .build();
+
+    NullPointerException ex =
+        assertThrows(
+            NullPointerException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("no authType is provided"));
+  }
+
+  @Test
+  void testInvalidMaxMessages() {
+    ImapSourceDto.Config config =
+        ImapSourceDto.Config.builder()
+            .host("imap.gmail.com")
+            .credentialId("my-cred")
+            .authType(ImapSourceDto.AuthType.PASSWORD)
+            .maxMessages(0)
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("maxMessages must be positive"));
+  }
+
+  @Test
+  void testInvalidPollIntervalMs() {
+    ImapSourceDto.Config config =
+        ImapSourceDto.Config.builder()
+            .host("imap.gmail.com")
+            .credentialId("my-cred")
+            .authType(ImapSourceDto.AuthType.PASSWORD)
+            .pollIntervalMs(-1L)
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("pollIntervalMs must be positive"));
+  }
+
+  @Test
+  void testDefaultValues() {
+    ImapSourceDto.Config config =
+        ImapSourceDto.Config.builder().host("imap.gmail.com").credentialId("my-cred").build();
+
+    assertDoesNotThrow(() -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertEquals(993, config.getPort());
+    assertEquals("INBOX", config.getFolder());
+    assertEquals(60000L, config.getPollIntervalMs());
+    assertTrue(config.getMarkAsRead());
+    assertFalse(config.getIncludeAttachments());
+    assertTrue(config.getUseSsl());
+    assertEquals(100, config.getMaxMessages());
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceDtoTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceDtoTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.imapsource;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.OBJECT_MAPPER;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ImapSourceDtoTest {
+
+  @Test
+  void testConfigParsing() {
+    Map<String, Object> configMap =
+        Map.of(
+            "host",
+            "imap.example.com",
+            "port",
+            993,
+            "credentialId",
+            "email-cred",
+            "authType",
+            "PASSWORD",
+            "folder",
+            "INBOX",
+            "searchCriteria",
+            "UNSEEN",
+            "pollIntervalMs",
+            30000,
+            "markAsRead",
+            true,
+            "includeAttachments",
+            false,
+            "useSsl",
+            true);
+
+    ImapSourceDto.Config config = OBJECT_MAPPER.convertValue(configMap, ImapSourceDto.Config.class);
+
+    assertEquals("imap.example.com", config.getHost());
+    assertEquals(993, config.getPort());
+    assertEquals("email-cred", config.getCredentialId());
+    assertEquals(ImapSourceDto.AuthType.PASSWORD, config.getAuthType());
+    assertEquals("INBOX", config.getFolder());
+    assertEquals("UNSEEN", config.getSearchCriteria());
+    assertEquals(30000L, config.getPollIntervalMs());
+    assertTrue(config.getMarkAsRead());
+    assertFalse(config.getIncludeAttachments());
+    assertTrue(config.getUseSsl());
+  }
+
+  @Test
+  void testConfigParsingWithDefaults() {
+    Map<String, Object> configMap =
+        Map.of(
+            "host", "imap.example.com",
+            "credentialId", "email-cred");
+
+    ImapSourceDto.Config config = OBJECT_MAPPER.convertValue(configMap, ImapSourceDto.Config.class);
+
+    assertEquals("imap.example.com", config.getHost());
+    assertEquals(ImapSourceDto.DEFAULT_PORT, config.getPort());
+    assertEquals(ImapSourceDto.AuthType.PASSWORD, config.getAuthType());
+    assertEquals(ImapSourceDto.DEFAULT_FOLDER, config.getFolder());
+    assertNull(config.getSearchCriteria());
+    assertEquals(ImapSourceDto.DEFAULT_POLL_INTERVAL_MS, config.getPollIntervalMs());
+    assertEquals(ImapSourceDto.DEFAULT_MARK_AS_READ, config.getMarkAsRead());
+    assertEquals(ImapSourceDto.DEFAULT_INCLUDE_ATTACHMENTS, config.getIncludeAttachments());
+    assertEquals(ImapSourceDto.DEFAULT_USE_SSL, config.getUseSsl());
+    assertEquals(ImapSourceDto.DEFAULT_MAX_MESSAGES, config.getMaxMessages());
+  }
+
+  @Test
+  void testConfigParsingOAuth2() {
+    Map<String, Object> configMap =
+        Map.of(
+            "host", "imap.gmail.com",
+            "credentialId", "oauth-cred",
+            "authType", "OAUTH2");
+
+    ImapSourceDto.Config config = OBJECT_MAPPER.convertValue(configMap, ImapSourceDto.Config.class);
+
+    assertEquals(ImapSourceDto.AuthType.OAUTH2, config.getAuthType());
+  }
+
+  @Test
+  void testConfigBuilder() {
+    ImapSourceDto.Config config =
+        ImapSourceDto.Config.builder()
+            .host("imap.gmail.com")
+            .port(993)
+            .credentialId("test-cred")
+            .authType(ImapSourceDto.AuthType.PASSWORD)
+            .folder("Sent")
+            .searchCriteria("UNSEEN")
+            .pollIntervalMs(5000L)
+            .markAsRead(false)
+            .includeAttachments(true)
+            .useSsl(true)
+            .maxMessages(50)
+            .build();
+
+    assertEquals("imap.gmail.com", config.getHost());
+    assertEquals(993, config.getPort());
+    assertEquals("Sent", config.getFolder());
+    assertEquals(50, config.getMaxMessages());
+    assertFalse(config.getMarkAsRead());
+    assertTrue(config.getIncludeAttachments());
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceFetcherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceFetcherTest.java
@@ -1,0 +1,303 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.imapsource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import jakarta.mail.*;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.search.FlagTerm;
+import jakarta.mail.search.FromStringTerm;
+import jakarta.mail.search.ReceivedDateTerm;
+import jakarta.mail.search.SubjectTerm;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Vector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ImapSourceFetcherTest {
+
+  private Store mockStore;
+  private Folder mockFolder;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    mockStore = mock(Store.class);
+    mockFolder = mock(Folder.class);
+    when(mockStore.getFolder("INBOX")).thenReturn(mockFolder);
+  }
+
+  @Test
+  void testFetchWithNoMessages() throws Exception {
+    when(mockFolder.isOpen()).thenReturn(false);
+    when(mockFolder.search(any())).thenReturn(new Message[0]);
+
+    ImapSourceFetcher fetcher =
+        new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", true, false, 100);
+
+    List<EmailMessage> result = fetcher.fetch();
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+    verify(mockFolder).open(Folder.READ_WRITE);
+  }
+
+  @Test
+  void testFetchWithSimpleTextMessage() throws Exception {
+    when(mockFolder.isOpen()).thenReturn(false);
+
+    Message mockMessage =
+        createMockTextMessage(
+            "<msg1@test.com>",
+            "sender@test.com",
+            new String[] {"to@test.com"},
+            null,
+            "Test Subject",
+            "Hello World",
+            "text/plain",
+            new Date(1700000000000L));
+
+    when(mockFolder.search(any())).thenReturn(new Message[] {mockMessage});
+
+    ImapSourceFetcher fetcher =
+        new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", true, false, 100);
+
+    List<EmailMessage> result = fetcher.fetch();
+
+    assertEquals(1, result.size());
+    EmailMessage email = result.getFirst();
+    assertEquals("<msg1@test.com>", email.messageId());
+    assertEquals("sender@test.com", email.from());
+    assertEquals(List.of("to@test.com"), email.to());
+    assertEquals("Test Subject", email.subject());
+    assertEquals("Hello World", email.bodyText());
+    assertNull(email.bodyHtml());
+
+    verify(mockMessage).setFlag(Flags.Flag.SEEN, true);
+  }
+
+  @Test
+  void testFetchWithHtmlMessage() throws Exception {
+    when(mockFolder.isOpen()).thenReturn(false);
+
+    Message mockMessage =
+        createMockTextMessage(
+            "<msg2@test.com>",
+            "sender@test.com",
+            new String[] {"to@test.com"},
+            null,
+            "HTML Subject",
+            "<html>Hello</html>",
+            "text/html",
+            new Date());
+
+    when(mockFolder.search(any())).thenReturn(new Message[] {mockMessage});
+
+    ImapSourceFetcher fetcher =
+        new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", false, false, 100);
+
+    List<EmailMessage> result = fetcher.fetch();
+
+    assertEquals(1, result.size());
+    assertNull(result.getFirst().bodyText());
+    assertEquals("<html>Hello</html>", result.getFirst().bodyHtml());
+    verify(mockMessage, never()).setFlag(any(), anyBoolean());
+  }
+
+  @Test
+  void testFetchWithMaxMessagesLimit() throws Exception {
+    when(mockFolder.isOpen()).thenReturn(false);
+
+    Message[] messages = new Message[10];
+    for (int i = 0; i < 10; i++) {
+      messages[i] =
+          createMockTextMessage(
+              "<msg" + i + "@test.com>",
+              "sender@test.com",
+              new String[] {"to@test.com"},
+              null,
+              "Subject " + i,
+              "Body " + i,
+              "text/plain",
+              new Date());
+    }
+
+    when(mockFolder.search(any())).thenReturn(messages);
+
+    ImapSourceFetcher fetcher =
+        new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", false, false, 3);
+
+    List<EmailMessage> result = fetcher.fetch();
+
+    assertEquals(3, result.size());
+  }
+
+  @Test
+  void testFetchWithNullSearchCriteria() throws Exception {
+    when(mockFolder.isOpen()).thenReturn(false);
+    when(mockFolder.getMessages()).thenReturn(new Message[0]);
+
+    ImapSourceFetcher fetcher = new ImapSourceFetcher(mockStore, "INBOX", null, false, false, 100);
+
+    List<EmailMessage> result = fetcher.fetch();
+
+    assertTrue(result.isEmpty());
+    verify(mockFolder).getMessages();
+    verify(mockFolder, never()).search(any());
+  }
+
+  @Test
+  void testFetchWithCcRecipients() throws Exception {
+    when(mockFolder.isOpen()).thenReturn(false);
+
+    Message mockMessage =
+        createMockTextMessage(
+            "<msg-cc@test.com>",
+            "sender@test.com",
+            new String[] {"to@test.com"},
+            new String[] {"cc1@test.com", "cc2@test.com"},
+            "CC Subject",
+            "Body",
+            "text/plain",
+            new Date());
+
+    when(mockFolder.search(any())).thenReturn(new Message[] {mockMessage});
+
+    ImapSourceFetcher fetcher =
+        new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", false, false, 100);
+
+    List<EmailMessage> result = fetcher.fetch();
+
+    assertEquals(1, result.size());
+    assertEquals(List.of("cc1@test.com", "cc2@test.com"), result.getFirst().cc());
+  }
+
+  @Test
+  void testParseSearchCriteriaUnseen() {
+    var term = ImapSourceFetcher.parseSearchCriteria("UNSEEN");
+    assertInstanceOf(FlagTerm.class, term);
+  }
+
+  @Test
+  void testParseSearchCriteriaSeen() {
+    var term = ImapSourceFetcher.parseSearchCriteria("SEEN");
+    assertInstanceOf(FlagTerm.class, term);
+  }
+
+  @Test
+  void testParseSearchCriteriaSince() {
+    var term = ImapSourceFetcher.parseSearchCriteria("SINCE 2025-01-01");
+    assertInstanceOf(ReceivedDateTerm.class, term);
+  }
+
+  @Test
+  void testParseSearchCriteriaFrom() {
+    var term = ImapSourceFetcher.parseSearchCriteria("FROM user@example.com");
+    assertInstanceOf(FromStringTerm.class, term);
+  }
+
+  @Test
+  void testParseSearchCriteriaSubject() {
+    var term = ImapSourceFetcher.parseSearchCriteria("SUBJECT Important");
+    assertInstanceOf(SubjectTerm.class, term);
+  }
+
+  @Test
+  void testParseSearchCriteriaNull() {
+    assertNull(ImapSourceFetcher.parseSearchCriteria(null));
+    assertNull(ImapSourceFetcher.parseSearchCriteria(""));
+    assertNull(ImapSourceFetcher.parseSearchCriteria("   "));
+  }
+
+  @Test
+  void testParseSearchCriteriaUnsupported() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ImapSourceFetcher.parseSearchCriteria("INVALID_CRITERIA"));
+  }
+
+  @Test
+  void testParseSearchCriteriaInvalidDate() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ImapSourceFetcher.parseSearchCriteria("SINCE not-a-date"));
+  }
+
+  @Test
+  void testClose() throws Exception {
+    when(mockStore.isConnected()).thenReturn(true);
+
+    ImapSourceFetcher fetcher =
+        new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", true, false, 100);
+
+    fetcher.close();
+
+    verify(mockStore).close();
+  }
+
+  @Test
+  void testIsExhaustedReturnsFalse() {
+    ImapSourceFetcher fetcher =
+        new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", true, false, 100);
+
+    assertFalse(fetcher.isExhausted());
+  }
+
+  private Message createMockTextMessage(
+      String messageId,
+      String from,
+      String[] to,
+      String[] cc,
+      String subject,
+      String body,
+      String mimeType,
+      Date receivedDate)
+      throws Exception {
+    Message message = mock(Message.class);
+
+    when(message.getHeader("Message-ID")).thenReturn(new String[] {messageId});
+    when(message.getFrom()).thenReturn(new Address[] {new InternetAddress(from)});
+
+    Address[] toAddresses = new Address[to.length];
+    for (int i = 0; i < to.length; i++) {
+      toAddresses[i] = new InternetAddress(to[i]);
+    }
+    when(message.getRecipients(Message.RecipientType.TO)).thenReturn(toAddresses);
+
+    if (cc != null) {
+      Address[] ccAddresses = new Address[cc.length];
+      for (int i = 0; i < cc.length; i++) {
+        ccAddresses[i] = new InternetAddress(cc[i]);
+      }
+      when(message.getRecipients(Message.RecipientType.CC)).thenReturn(ccAddresses);
+    }
+
+    when(message.getSubject()).thenReturn(subject);
+    when(message.getContent()).thenReturn(body);
+    when(message.isMimeType("text/html")).thenReturn("text/html".equals(mimeType));
+    when(message.isMimeType("text/plain")).thenReturn("text/plain".equals(mimeType));
+    when(message.getReceivedDate()).thenReturn(receivedDate);
+
+    Vector<Header> headers = new Vector<>();
+    headers.add(new Header("Subject", subject));
+    headers.add(new Header("From", from));
+    Enumeration<Header> headerEnum = headers.elements();
+    when(message.getAllHeaders()).thenReturn(headerEnum);
+
+    return message;
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkConfigValidatorTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkConfigValidatorTest.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.smtpsink;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.fleak.zephflow.api.JobContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SmtpSinkConfigValidatorTest {
+
+  private SmtpSinkConfigValidator validator;
+  private JobContext mockJobContext;
+
+  @BeforeEach
+  void setUp() {
+    validator = new SmtpSinkConfigValidator();
+    mockJobContext = mock(JobContext.class);
+  }
+
+  @Test
+  void testValidConfig() {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.gmail.com")
+            .port(587)
+            .credentialId("smtp-cred")
+            .fromAddress("noreply@example.com")
+            .toTemplate("{{$.email}}")
+            .subjectTemplate("Hello {{$.name}}")
+            .bodyTemplate("Dear {{$.name}}, your order is ready.")
+            .build();
+
+    assertDoesNotThrow(() -> validator.validateConfig(config, "test-node", mockJobContext));
+  }
+
+  @Test
+  void testMissingHost() {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("")
+            .credentialId("cred")
+            .fromAddress("from@test.com")
+            .toTemplate("to@test.com")
+            .subjectTemplate("subj")
+            .bodyTemplate("body")
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("no host is provided"));
+  }
+
+  @Test
+  void testNullHost() {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host(null)
+            .credentialId("cred")
+            .fromAddress("from@test.com")
+            .toTemplate("to@test.com")
+            .subjectTemplate("subj")
+            .bodyTemplate("body")
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("no host is provided"));
+  }
+
+  @Test
+  void testInvalidPort() {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.example.com")
+            .port(-1)
+            .credentialId("cred")
+            .fromAddress("from@test.com")
+            .toTemplate("to@test.com")
+            .subjectTemplate("subj")
+            .bodyTemplate("body")
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("port must be positive"));
+  }
+
+  @Test
+  void testMissingCredentialId() {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.example.com")
+            .credentialId("")
+            .fromAddress("from@test.com")
+            .toTemplate("to@test.com")
+            .subjectTemplate("subj")
+            .bodyTemplate("body")
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("no credentialId is provided"));
+  }
+
+  @Test
+  void testMissingFromAddress() {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.example.com")
+            .credentialId("cred")
+            .fromAddress("")
+            .toTemplate("to@test.com")
+            .subjectTemplate("subj")
+            .bodyTemplate("body")
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("no fromAddress is provided"));
+  }
+
+  @Test
+  void testMissingToTemplate() {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.example.com")
+            .credentialId("cred")
+            .fromAddress("from@test.com")
+            .toTemplate("")
+            .subjectTemplate("subj")
+            .bodyTemplate("body")
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("no toTemplate is provided"));
+  }
+
+  @Test
+  void testMissingSubjectTemplate() {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.example.com")
+            .credentialId("cred")
+            .fromAddress("from@test.com")
+            .toTemplate("to@test.com")
+            .subjectTemplate("")
+            .bodyTemplate("body")
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("no subjectTemplate is provided"));
+  }
+
+  @Test
+  void testMissingBodyTemplate() {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.example.com")
+            .credentialId("cred")
+            .fromAddress("from@test.com")
+            .toTemplate("to@test.com")
+            .subjectTemplate("subj")
+            .bodyTemplate("")
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("no bodyTemplate is provided"));
+  }
+
+  @Test
+  void testDefaultValues() {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.example.com")
+            .credentialId("cred")
+            .fromAddress("from@test.com")
+            .toTemplate("to@test.com")
+            .subjectTemplate("subj")
+            .bodyTemplate("body")
+            .build();
+
+    assertDoesNotThrow(() -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertEquals(587, config.getPort());
+    assertEquals("text/plain", config.getBodyContentType());
+    assertTrue(config.getUseTls());
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkDtoTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkDtoTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.smtpsink;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.OBJECT_MAPPER;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SmtpSinkDtoTest {
+
+  @Test
+  void testConfigParsing() {
+    Map<String, Object> configMap = new HashMap<>();
+    configMap.put("host", "smtp.example.com");
+    configMap.put("port", 465);
+    configMap.put("credentialId", "smtp-cred");
+    configMap.put("fromAddress", "noreply@example.com");
+    configMap.put("toTemplate", "{{$.email}}");
+    configMap.put("ccTemplate", "{{$.ccEmail}}");
+    configMap.put("subjectTemplate", "Order {{$.orderId}}");
+    configMap.put("bodyTemplate", "Your order {{$.orderId}} is ready.");
+    configMap.put("bodyContentType", "text/html");
+    configMap.put("useTls", false);
+
+    SmtpSinkDto.Config config = OBJECT_MAPPER.convertValue(configMap, SmtpSinkDto.Config.class);
+
+    assertEquals("smtp.example.com", config.getHost());
+    assertEquals(465, config.getPort());
+    assertEquals("smtp-cred", config.getCredentialId());
+    assertEquals("noreply@example.com", config.getFromAddress());
+    assertEquals("{{$.email}}", config.getToTemplate());
+    assertEquals("{{$.ccEmail}}", config.getCcTemplate());
+    assertEquals("Order {{$.orderId}}", config.getSubjectTemplate());
+    assertEquals("Your order {{$.orderId}} is ready.", config.getBodyTemplate());
+    assertEquals("text/html", config.getBodyContentType());
+    assertFalse(config.getUseTls());
+  }
+
+  @Test
+  void testConfigParsingWithDefaults() {
+    Map<String, Object> configMap = new HashMap<>();
+    configMap.put("host", "smtp.example.com");
+    configMap.put("credentialId", "cred");
+    configMap.put("fromAddress", "from@test.com");
+    configMap.put("toTemplate", "to@test.com");
+    configMap.put("subjectTemplate", "subj");
+    configMap.put("bodyTemplate", "body");
+
+    SmtpSinkDto.Config config = OBJECT_MAPPER.convertValue(configMap, SmtpSinkDto.Config.class);
+
+    assertEquals(SmtpSinkDto.DEFAULT_PORT, config.getPort());
+    assertEquals(SmtpSinkDto.DEFAULT_BODY_CONTENT_TYPE, config.getBodyContentType());
+    assertEquals(SmtpSinkDto.DEFAULT_USE_TLS, config.getUseTls());
+    assertNull(config.getCcTemplate());
+  }
+
+  @Test
+  void testConfigBuilder() {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.gmail.com")
+            .port(587)
+            .credentialId("gmail-cred")
+            .fromAddress("sender@gmail.com")
+            .toTemplate("{{$.recipient}}")
+            .subjectTemplate("Notification")
+            .bodyTemplate("Hello {{$.name}}")
+            .bodyContentType("text/html")
+            .useTls(true)
+            .build();
+
+    assertEquals("smtp.gmail.com", config.getHost());
+    assertEquals(587, config.getPort());
+    assertEquals("gmail-cred", config.getCredentialId());
+    assertEquals("sender@gmail.com", config.getFromAddress());
+    assertEquals("text/html", config.getBodyContentType());
+    assertTrue(config.getUseTls());
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkFlusherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkFlusherTest.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.smtpsink;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
+import jakarta.mail.Message;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SmtpSinkFlusherTest {
+
+  private Session session;
+  private SmtpSinkFlusher flusher;
+
+  @BeforeEach
+  void setUp() {
+    Properties props = new Properties();
+    props.setProperty("mail.smtp.host", "localhost");
+    props.setProperty("mail.smtp.port", "25");
+    session = Session.getInstance(props);
+    flusher = new SmtpSinkFlusher(session, "user", "pass");
+  }
+
+  @Test
+  void testCreateMimeMessage() throws Exception {
+    PreparedEmail email =
+        new PreparedEmail(
+            "from@test.com",
+            List.of("to@test.com"),
+            List.of("cc@test.com"),
+            "Test Subject",
+            "Hello World",
+            "text/plain");
+
+    MimeMessage message = flusher.createMimeMessage(email);
+
+    assertEquals("from@test.com", ((InternetAddress) message.getFrom()[0]).getAddress());
+    assertEquals(
+        "to@test.com",
+        ((InternetAddress) message.getRecipients(Message.RecipientType.TO)[0]).getAddress());
+    assertEquals(
+        "cc@test.com",
+        ((InternetAddress) message.getRecipients(Message.RecipientType.CC)[0]).getAddress());
+    assertEquals("Test Subject", message.getSubject());
+  }
+
+  @Test
+  void testCreateMimeMessageWithMultipleRecipients() throws Exception {
+    PreparedEmail email =
+        new PreparedEmail(
+            "from@test.com",
+            List.of("to1@test.com", "to2@test.com"),
+            List.of("cc1@test.com", "cc2@test.com"),
+            "Multi Recipient",
+            "Body",
+            "text/plain");
+
+    MimeMessage message = flusher.createMimeMessage(email);
+
+    assertEquals(2, message.getRecipients(Message.RecipientType.TO).length);
+    assertEquals(2, message.getRecipients(Message.RecipientType.CC).length);
+    assertEquals(
+        "to1@test.com",
+        ((InternetAddress) message.getRecipients(Message.RecipientType.TO)[0]).getAddress());
+    assertEquals(
+        "to2@test.com",
+        ((InternetAddress) message.getRecipients(Message.RecipientType.TO)[1]).getAddress());
+  }
+
+  @Test
+  void testCreateMimeMessageWithNullCc() throws Exception {
+    PreparedEmail email =
+        new PreparedEmail(
+            "from@test.com", List.of("to@test.com"), null, "No CC", "Body", "text/plain");
+
+    MimeMessage message = flusher.createMimeMessage(email);
+
+    assertNull(message.getRecipients(Message.RecipientType.CC));
+  }
+
+  @Test
+  void testCreateMimeMessageWithEmptyCc() throws Exception {
+    PreparedEmail email =
+        new PreparedEmail(
+            "from@test.com", List.of("to@test.com"), List.of(), "Empty CC", "Body", "text/html");
+
+    MimeMessage message = flusher.createMimeMessage(email);
+
+    assertNull(message.getRecipients(Message.RecipientType.CC));
+  }
+
+  @Test
+  void testFlushEmptyEvents() throws Exception {
+    SimpleSinkCommand.PreparedInputEvents<PreparedEmail> emptyEvents =
+        new SimpleSinkCommand.PreparedInputEvents<>();
+
+    SimpleSinkCommand.FlushResult result =
+        flusher.flush(emptyEvents, Map.of("callingUser", "test"));
+
+    assertEquals(0, result.successCount());
+    assertEquals(0, result.flushedDataSize());
+    assertEquals(0, result.errorOutputList().size());
+  }
+
+  @Test
+  void testClosedFlusherThrowsException() {
+    flusher.close();
+
+    SimpleSinkCommand.PreparedInputEvents<PreparedEmail> events =
+        new SimpleSinkCommand.PreparedInputEvents<>();
+    RecordFleakData rawEvent = (RecordFleakData) FleakData.wrap(Map.of("key", "value"));
+    PreparedEmail email =
+        new PreparedEmail(
+            "from@test.com", List.of("to@test.com"), List.of(), "Subject", "Body", "text/plain");
+    events.add(rawEvent, email);
+
+    assertThrows(
+        IllegalStateException.class, () -> flusher.flush(events, Map.of("callingUser", "test")));
+  }
+
+  @Test
+  void testFlushWithSendFailure() throws Exception {
+    SimpleSinkCommand.PreparedInputEvents<PreparedEmail> events =
+        new SimpleSinkCommand.PreparedInputEvents<>();
+    RecordFleakData rawEvent = (RecordFleakData) FleakData.wrap(Map.of("key", "value"));
+    PreparedEmail email =
+        new PreparedEmail(
+            "from@test.com", List.of("to@test.com"), List.of(), "Subject", "Body", "text/plain");
+    events.add(rawEvent, email);
+
+    SimpleSinkCommand.FlushResult result = flusher.flush(events, Map.of("callingUser", "test"));
+
+    assertEquals(1, result.errorOutputList().size());
+    assertEquals(0, result.successCount());
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkMessageProcessorTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkMessageProcessorTest.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.smtpsink;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SmtpSinkMessageProcessorTest {
+
+  @Test
+  void testBasicTemplateResolution() throws Exception {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.test.com")
+            .credentialId("cred")
+            .fromAddress("sender@test.com")
+            .toTemplate("{{$.email}}")
+            .subjectTemplate("Hello {{$.name}}")
+            .bodyTemplate("Dear {{$.name}}, your order #{{$.orderId}} is ready.")
+            .bodyContentType("text/plain")
+            .build();
+
+    SmtpSinkMessageProcessor processor = new SmtpSinkMessageProcessor(config);
+
+    RecordFleakData event =
+        (RecordFleakData)
+            FleakData.wrap(Map.of("email", "user@example.com", "name", "John", "orderId", "12345"));
+
+    PreparedEmail result = processor.preprocess(event, System.currentTimeMillis());
+
+    assertEquals("sender@test.com", result.from());
+    assertEquals(List.of("user@example.com"), result.to());
+    assertEquals(List.of(), result.cc());
+    assertEquals("Hello John", result.subject());
+    assertEquals("Dear John, your order #12345 is ready.", result.body());
+    assertEquals("text/plain", result.contentType());
+  }
+
+  @Test
+  void testMultipleToRecipients() throws Exception {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.test.com")
+            .credentialId("cred")
+            .fromAddress("sender@test.com")
+            .toTemplate("{{$.email1}},{{$.email2}}")
+            .subjectTemplate("Test")
+            .bodyTemplate("Body")
+            .build();
+
+    SmtpSinkMessageProcessor processor = new SmtpSinkMessageProcessor(config);
+
+    RecordFleakData event =
+        (RecordFleakData) FleakData.wrap(Map.of("email1", "a@test.com", "email2", "b@test.com"));
+
+    PreparedEmail result = processor.preprocess(event, System.currentTimeMillis());
+
+    assertEquals(List.of("a@test.com", "b@test.com"), result.to());
+  }
+
+  @Test
+  void testCcTemplateResolution() throws Exception {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.test.com")
+            .credentialId("cred")
+            .fromAddress("sender@test.com")
+            .toTemplate("{{$.to}}")
+            .ccTemplate("{{$.cc}}")
+            .subjectTemplate("Test")
+            .bodyTemplate("Body")
+            .build();
+
+    SmtpSinkMessageProcessor processor = new SmtpSinkMessageProcessor(config);
+
+    RecordFleakData event =
+        (RecordFleakData) FleakData.wrap(Map.of("to", "to@test.com", "cc", "cc@test.com"));
+
+    PreparedEmail result = processor.preprocess(event, System.currentTimeMillis());
+
+    assertEquals(List.of("to@test.com"), result.to());
+    assertEquals(List.of("cc@test.com"), result.cc());
+  }
+
+  @Test
+  void testNoCcTemplate() throws Exception {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.test.com")
+            .credentialId("cred")
+            .fromAddress("sender@test.com")
+            .toTemplate("to@test.com")
+            .subjectTemplate("Subject")
+            .bodyTemplate("Body")
+            .build();
+
+    SmtpSinkMessageProcessor processor = new SmtpSinkMessageProcessor(config);
+
+    RecordFleakData event = (RecordFleakData) FleakData.wrap(Map.of("key", "value"));
+
+    PreparedEmail result = processor.preprocess(event, System.currentTimeMillis());
+
+    assertEquals(List.of(), result.cc());
+  }
+
+  @Test
+  void testStaticTemplateValues() throws Exception {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.test.com")
+            .credentialId("cred")
+            .fromAddress("sender@test.com")
+            .toTemplate("static@test.com")
+            .subjectTemplate("Static Subject")
+            .bodyTemplate("Static Body Content")
+            .build();
+
+    SmtpSinkMessageProcessor processor = new SmtpSinkMessageProcessor(config);
+
+    RecordFleakData event = (RecordFleakData) FleakData.wrap(Map.of("key", "value"));
+
+    PreparedEmail result = processor.preprocess(event, System.currentTimeMillis());
+
+    assertEquals(List.of("static@test.com"), result.to());
+    assertEquals("Static Subject", result.subject());
+    assertEquals("Static Body Content", result.body());
+  }
+
+  @Test
+  void testHtmlBodyContentType() throws Exception {
+    SmtpSinkDto.Config config =
+        SmtpSinkDto.Config.builder()
+            .host("smtp.test.com")
+            .credentialId("cred")
+            .fromAddress("sender@test.com")
+            .toTemplate("to@test.com")
+            .subjectTemplate("Test")
+            .bodyTemplate("<html><body>{{$.content}}</body></html>")
+            .bodyContentType("text/html")
+            .build();
+
+    SmtpSinkMessageProcessor processor = new SmtpSinkMessageProcessor(config);
+
+    RecordFleakData event = (RecordFleakData) FleakData.wrap(Map.of("content", "Hello World"));
+
+    PreparedEmail result = processor.preprocess(event, System.currentTimeMillis());
+
+    assertEquals("<html><body>Hello World</body></html>", result.body());
+    assertEquals("text/html", result.contentType());
+  }
+}


### PR DESCRIPTION
Implement imapsource connector for reading emails via IMAP protocol with support for PASSWORD and OAUTH2 authentication, configurable search criteria, folder selection, and attachment extraction. Implement smtpsink connector for sending emails via SMTP with template-based field resolution using the existing TemplatePlaceholderResolver.