### PR TITLE
FLE-1502: Fix IMAP source pollIntervalMs and search compose

### DIFF
--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceCommand.java
@@ -113,15 +113,18 @@ public class ImapSourceCommand extends SimpleSourceCommand<EmailMessage> {
         store.connect(config.getHost(), config.getPort(), null, credential.getKey());
       }
 
-      return new ImapSourceFetcher(
-          store,
-          config.getFolder(),
-          config.getSearchCriteria(),
-          Boolean.TRUE.equals(config.getMarkAsRead()),
-          Boolean.TRUE.equals(config.getIncludeAttachments()),
-          config.getMaxMessages(),
-          Optional.ofNullable(config.getPollIntervalMs())
-              .orElse(ImapSourceDto.DEFAULT_POLL_INTERVAL_MS));
+      ImapSourceFetcher fetcher =
+          new ImapSourceFetcher(
+              store,
+              config.getFolder(),
+              config.getSearchCriteria(),
+              Boolean.TRUE.equals(config.getMarkAsRead()),
+              Boolean.TRUE.equals(config.getIncludeAttachments()),
+              config.getMaxMessages(),
+              Optional.ofNullable(config.getPollIntervalMs())
+                  .orElse(ImapSourceDto.DEFAULT_POLL_INTERVAL_MS));
+      fetcher.start();
+      return fetcher;
     } catch (Exception e) {
       throw new RuntimeException("Failed to create IMAP fetcher", e);
     }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceCommand.java
@@ -119,7 +119,9 @@ public class ImapSourceCommand extends SimpleSourceCommand<EmailMessage> {
           config.getSearchCriteria(),
           Boolean.TRUE.equals(config.getMarkAsRead()),
           Boolean.TRUE.equals(config.getIncludeAttachments()),
-          config.getMaxMessages());
+          config.getMaxMessages(),
+          Optional.ofNullable(config.getPollIntervalMs())
+              .orElse(ImapSourceDto.DEFAULT_POLL_INTERVAL_MS));
     } catch (Exception e) {
       throw new RuntimeException("Failed to create IMAP fetcher", e);
     }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceCommand.java
@@ -49,41 +49,61 @@ public class ImapSourceCommand extends SimpleSourceCommand<EmailMessage> {
       String nodeId) {
     ImapSourceDto.Config config = (ImapSourceDto.Config) commandConfig;
 
-    Fetcher<EmailMessage> fetcher = createImapFetcher(config, jobContext);
-    RawDataEncoder<EmailMessage> encoder = new EmailRawDataEncoder();
-    RawDataConverter<EmailMessage> converter = new EmailRawDataConverter();
+    ImapSourceFetcher fetcher = createImapFetcher(config, jobContext);
+    try {
+      RawDataEncoder<EmailMessage> encoder = new EmailRawDataEncoder();
+      RawDataConverter<EmailMessage> converter = new EmailRawDataConverter();
 
-    Map<String, String> metricTags =
-        basicCommandMetricTags(jobContext.getMetricTags(), commandName(), nodeId);
-    FleakCounter dataSizeCounter =
-        metricClientProvider.counter(METRIC_NAME_INPUT_EVENT_SIZE_COUNT, metricTags);
-    FleakCounter inputEventCounter =
-        metricClientProvider.counter(METRIC_NAME_INPUT_EVENT_COUNT, metricTags);
-    FleakCounter deserializeFailureCounter =
-        metricClientProvider.counter(METRIC_NAME_INPUT_DESER_ERR_COUNT, metricTags);
+      Map<String, String> metricTags =
+          basicCommandMetricTags(jobContext.getMetricTags(), commandName(), nodeId);
+      FleakCounter dataSizeCounter =
+          metricClientProvider.counter(METRIC_NAME_INPUT_EVENT_SIZE_COUNT, metricTags);
+      FleakCounter inputEventCounter =
+          metricClientProvider.counter(METRIC_NAME_INPUT_EVENT_COUNT, metricTags);
+      FleakCounter deserializeFailureCounter =
+          metricClientProvider.counter(METRIC_NAME_INPUT_DESER_ERR_COUNT, metricTags);
 
-    String keyPrefix = (String) jobContext.getOtherProperties().get(JobContext.DATA_KEY_PREFIX);
-    DlqWriter dlqWriter =
-        Optional.of(jobContext)
-            .map(JobContext::getDlqConfig)
-            .map(c -> DlqWriterFactory.createDlqWriter(c, keyPrefix))
-            .orElse(null);
-    if (dlqWriter != null) {
-      dlqWriter.open();
+      String keyPrefix = (String) jobContext.getOtherProperties().get(JobContext.DATA_KEY_PREFIX);
+      DlqWriter dlqWriter =
+          Optional.of(jobContext)
+              .map(JobContext::getDlqConfig)
+              .map(c -> DlqWriterFactory.createDlqWriter(c, keyPrefix))
+              .orElse(null);
+      if (dlqWriter != null) {
+        dlqWriter.open();
+      }
+
+      // Start the poller only after every dependency (metrics, DLQ, ...) is in place so we don't
+      // mark messages as read before the pipeline can consume them.
+      fetcher.start();
+
+      return new SourceExecutionContext<>(
+          fetcher,
+          converter,
+          encoder,
+          dataSizeCounter,
+          inputEventCounter,
+          deserializeFailureCounter,
+          dlqWriter);
+    } catch (RuntimeException e) {
+      closeFetcherQuietly(fetcher);
+      throw e;
+    } catch (Exception e) {
+      closeFetcherQuietly(fetcher);
+      throw new RuntimeException("Failed to initialize IMAP source", e);
     }
-
-    return new SourceExecutionContext<>(
-        fetcher,
-        converter,
-        encoder,
-        dataSizeCounter,
-        inputEventCounter,
-        deserializeFailureCounter,
-        dlqWriter);
   }
 
-  private Fetcher<EmailMessage> createImapFetcher(
-      ImapSourceDto.Config config, JobContext jobContext) {
+  private void closeFetcherQuietly(ImapSourceFetcher fetcher) {
+    try {
+      fetcher.close();
+    } catch (Exception ex) {
+      log.warn("Failed to close IMAP fetcher during initialization rollback", ex);
+    }
+  }
+
+  private ImapSourceFetcher createImapFetcher(ImapSourceDto.Config config, JobContext jobContext) {
+    Store store = null;
     try {
       Properties props = new Properties();
       String protocol = Boolean.TRUE.equals(config.getUseSsl()) ? "imaps" : "imap";
@@ -101,7 +121,7 @@ public class ImapSourceCommand extends SimpleSourceCommand<EmailMessage> {
       }
 
       Session session = Session.getInstance(props);
-      Store store = session.getStore(protocol);
+      store = session.getStore(protocol);
 
       if (config.getAuthType() == ImapSourceDto.AuthType.PASSWORD) {
         UsernamePasswordCredential credential =
@@ -113,19 +133,23 @@ public class ImapSourceCommand extends SimpleSourceCommand<EmailMessage> {
         store.connect(config.getHost(), config.getPort(), null, credential.getKey());
       }
 
-      ImapSourceFetcher fetcher =
-          new ImapSourceFetcher(
-              store,
-              config.getFolder(),
-              config.getSearchCriteria(),
-              Boolean.TRUE.equals(config.getMarkAsRead()),
-              Boolean.TRUE.equals(config.getIncludeAttachments()),
-              config.getMaxMessages(),
-              Optional.ofNullable(config.getPollIntervalMs())
-                  .orElse(ImapSourceDto.DEFAULT_POLL_INTERVAL_MS));
-      fetcher.start();
-      return fetcher;
+      return new ImapSourceFetcher(
+          store,
+          config.getFolder(),
+          config.getSearchCriteria(),
+          Boolean.TRUE.equals(config.getMarkAsRead()),
+          Boolean.TRUE.equals(config.getIncludeAttachments()),
+          config.getMaxMessages(),
+          Optional.ofNullable(config.getPollIntervalMs())
+              .orElse(ImapSourceDto.DEFAULT_POLL_INTERVAL_MS));
     } catch (Exception e) {
+      if (store != null) {
+        try {
+          store.close();
+        } catch (Exception closeEx) {
+          log.warn("Failed to close IMAP store after init error", closeEx);
+        }
+      }
       throw new RuntimeException("Failed to create IMAP fetcher", e);
     }
   }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceConfigValidator.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceConfigValidator.java
@@ -45,5 +45,16 @@ public class ImapSourceConfigValidator implements ConfigValidator {
           "pollIntervalMs must be positive, got: %s",
           config.getPollIntervalMs());
     }
+
+    // markAsRead=true makes the fetcher AND the user criteria with `\Seen=false` to keep
+    // de-duplication closed across polls; combining that with searchCriteria=SEEN would always
+    // produce an empty result set, which is almost certainly a misconfiguration.
+    if (Boolean.TRUE.equals(config.getMarkAsRead())
+        && "SEEN".equalsIgnoreCase(StringUtils.trimToEmpty(config.getSearchCriteria()))) {
+      throw new IllegalArgumentException(
+          "searchCriteria=SEEN is incompatible with markAsRead=true (the effective filter becomes"
+              + " SEEN AND UNSEEN, which matches nothing). Set markAsRead=false or pick a"
+              + " different searchCriteria.");
+    }
   }
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceFetcher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceFetcher.java
@@ -24,10 +24,18 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ImapSourceFetcher implements Fetcher<EmailMessage> {
+
+  private static final int FETCH_POLL_TIMEOUT_MS = 100;
+  private static final int QUEUE_CAPACITY_MULTIPLIER = 10;
+  private static final int SHUTDOWN_TIMEOUT_SECONDS = 5;
 
   private final Store store;
   private final String folderName;
@@ -36,9 +44,11 @@ public class ImapSourceFetcher implements Fetcher<EmailMessage> {
   private final boolean includeAttachments;
   private final int maxMessages;
   private final long pollIntervalMs;
+  private final LinkedBlockingQueue<EmailMessage> queue;
 
   private Folder folder;
-  private long lastFetchTime = 0;
+  private ScheduledExecutorService scheduler;
+  private volatile boolean running;
 
   public ImapSourceFetcher(
       Store store,
@@ -72,15 +82,27 @@ public class ImapSourceFetcher implements Fetcher<EmailMessage> {
     this.includeAttachments = includeAttachments;
     this.maxMessages = maxMessages;
     this.pollIntervalMs = pollIntervalMs;
+    this.queue = new LinkedBlockingQueue<>(maxMessages * QUEUE_CAPACITY_MULTIPLIER);
   }
 
-  @Override
-  public List<EmailMessage> fetch() {
-    List<EmailMessage> emails = new ArrayList<>();
-    if (!waitForNextPoll()) {
-      return emails;
+  public void start() {
+    if (running) {
+      return;
     }
-    lastFetchTime = System.currentTimeMillis();
+    running = true;
+    scheduler =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              Thread t = new Thread(r, "imap-source-poller");
+              t.setDaemon(true);
+              return t;
+            });
+    scheduler.scheduleWithFixedDelay(this::poll, 0, pollIntervalMs, TimeUnit.MILLISECONDS);
+    log.info("IMAP source poller started for folder {} interval={}ms", folderName, pollIntervalMs);
+  }
+
+  // Package-private to allow unit tests to drive a single poll without spinning up the scheduler.
+  void poll() {
     try {
       if (folder == null || !folder.isOpen()) {
         folder = store.getFolder(folderName);
@@ -91,12 +113,21 @@ public class ImapSourceFetcher implements Fetcher<EmailMessage> {
       Message[] messages = searchTerm != null ? folder.search(searchTerm) : folder.getMessages();
 
       int limit = Math.min(messages.length, maxMessages);
+      int delivered = 0;
       for (int i = 0; i < limit; i++) {
         try {
-          emails.add(convertMessage(messages[i]));
+          EmailMessage email = convertMessage(messages[i]);
+          // Use put() so we apply backpressure if the consumer is slow;
+          // dropping is not safe because markAsRead may already have been set.
+          queue.put(email);
           if (markAsRead) {
             messages[i].setFlag(Flags.Flag.SEEN, true);
           }
+          delivered++;
+        } catch (InterruptedException e) {
+          // Honor thread interruption (e.g., scheduler.shutdownNow()) by bailing out.
+          Thread.currentThread().interrupt();
+          break;
         } catch (Exception e) {
           log.error("Error processing email message", e);
         }
@@ -104,31 +135,27 @@ public class ImapSourceFetcher implements Fetcher<EmailMessage> {
 
       folder.close(false);
       folder = null;
-    } catch (Exception e) {
-      log.error("Error fetching emails from IMAP", e);
+      log.debug("IMAP poll delivered {} messages from folder {}", delivered, folderName);
+    } catch (Throwable t) {
+      // scheduleWithFixedDelay stops on uncaught exceptions; swallow + log so polling continues.
+      log.error("Error during IMAP poll", t);
+      closeFolderQuietly();
     }
-    log.debug("Fetched {} emails from IMAP folder {}", emails.size(), folderName);
-    return emails;
   }
 
-  private boolean waitForNextPoll() {
-    if (lastFetchTime <= 0) {
-      return true;
-    }
-
-    long elapsed = System.currentTimeMillis() - lastFetchTime;
-    long toWait = pollIntervalMs - elapsed;
-    if (toWait <= 0) {
-      return true;
-    }
-
+  @Override
+  public List<EmailMessage> fetch() {
+    List<EmailMessage> batch = new ArrayList<>();
     try {
-      Thread.sleep(toWait);
-      return true;
+      EmailMessage first = queue.poll(FETCH_POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      if (first != null) {
+        batch.add(first);
+        queue.drainTo(batch, maxMessages - 1);
+      }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      return false;
     }
+    return batch;
   }
 
   private SearchTerm buildSearchTerm() {
@@ -305,19 +332,38 @@ public class ImapSourceFetcher implements Fetcher<EmailMessage> {
 
   @Override
   public void close() throws IOException {
-    try {
-      if (folder != null && folder.isOpen()) {
-        folder.close(false);
+    running = false;
+    if (scheduler != null) {
+      scheduler.shutdown();
+      try {
+        if (!scheduler.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+          scheduler.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        scheduler.shutdownNow();
       }
-    } catch (MessagingException e) {
-      log.warn("Failed to close IMAP folder", e);
+      scheduler = null;
     }
+    closeFolderQuietly();
     try {
       if (store != null && store.isConnected()) {
         store.close();
       }
     } catch (MessagingException e) {
       log.warn("Failed to close IMAP store", e);
+    }
+  }
+
+  private void closeFolderQuietly() {
+    try {
+      if (folder != null && folder.isOpen()) {
+        folder.close(false);
+      }
+    } catch (MessagingException e) {
+      log.warn("Failed to close IMAP folder", e);
+    } finally {
+      folder = null;
     }
   }
 

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceFetcher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceFetcher.java
@@ -35,8 +35,10 @@ public class ImapSourceFetcher implements Fetcher<EmailMessage> {
   private final boolean markAsRead;
   private final boolean includeAttachments;
   private final int maxMessages;
+  private final long pollIntervalMs;
 
   private Folder folder;
+  private long lastFetchTime = 0;
 
   public ImapSourceFetcher(
       Store store,
@@ -45,24 +47,47 @@ public class ImapSourceFetcher implements Fetcher<EmailMessage> {
       boolean markAsRead,
       boolean includeAttachments,
       int maxMessages) {
+    this(
+        store,
+        folderName,
+        searchCriteria,
+        markAsRead,
+        includeAttachments,
+        maxMessages,
+        ImapSourceDto.DEFAULT_POLL_INTERVAL_MS);
+  }
+
+  public ImapSourceFetcher(
+      Store store,
+      String folderName,
+      String searchCriteria,
+      boolean markAsRead,
+      boolean includeAttachments,
+      int maxMessages,
+      long pollIntervalMs) {
     this.store = store;
     this.folderName = folderName;
     this.searchCriteria = searchCriteria;
     this.markAsRead = markAsRead;
     this.includeAttachments = includeAttachments;
     this.maxMessages = maxMessages;
+    this.pollIntervalMs = pollIntervalMs;
   }
 
   @Override
   public List<EmailMessage> fetch() {
     List<EmailMessage> emails = new ArrayList<>();
+    if (!waitForNextPoll()) {
+      return emails;
+    }
+    lastFetchTime = System.currentTimeMillis();
     try {
       if (folder == null || !folder.isOpen()) {
         folder = store.getFolder(folderName);
         folder.open(Folder.READ_WRITE);
       }
 
-      SearchTerm searchTerm = parseSearchCriteria(searchCriteria);
+      SearchTerm searchTerm = buildSearchTerm();
       Message[] messages = searchTerm != null ? folder.search(searchTerm) : folder.getMessages();
 
       int limit = Math.min(messages.length, maxMessages);
@@ -84,6 +109,38 @@ public class ImapSourceFetcher implements Fetcher<EmailMessage> {
     }
     log.debug("Fetched {} emails from IMAP folder {}", emails.size(), folderName);
     return emails;
+  }
+
+  private boolean waitForNextPoll() {
+    if (lastFetchTime <= 0) {
+      return true;
+    }
+
+    long elapsed = System.currentTimeMillis() - lastFetchTime;
+    long toWait = pollIntervalMs - elapsed;
+    if (toWait <= 0) {
+      return true;
+    }
+
+    try {
+      Thread.sleep(toWait);
+      return true;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+
+  private SearchTerm buildSearchTerm() {
+    SearchTerm baseSearchTerm = parseSearchCriteria(searchCriteria);
+    if (!markAsRead) {
+      return baseSearchTerm;
+    }
+
+    SearchTerm unseenSearchTerm = new FlagTerm(new Flags(Flags.Flag.SEEN), false);
+    return baseSearchTerm == null
+        ? unseenSearchTerm
+        : new AndTerm(unseenSearchTerm, baseSearchTerm);
   }
 
   EmailMessage convertMessage(Message message) throws MessagingException, IOException {

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceConfigValidatorTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceConfigValidatorTest.java
@@ -173,6 +173,38 @@ class ImapSourceConfigValidatorTest {
   }
 
   @Test
+  void testSeenSearchCriteriaWithMarkAsReadIsRejected() {
+    ImapSourceDto.Config config =
+        ImapSourceDto.Config.builder()
+            .host("imap.gmail.com")
+            .credentialId("my-cred")
+            .authType(ImapSourceDto.AuthType.PASSWORD)
+            .searchCriteria("SEEN")
+            .markAsRead(true)
+            .build();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", mockJobContext));
+    assertTrue(ex.getMessage().contains("searchCriteria=SEEN is incompatible with markAsRead"));
+  }
+
+  @Test
+  void testSeenSearchCriteriaWithoutMarkAsReadIsAllowed() {
+    ImapSourceDto.Config config =
+        ImapSourceDto.Config.builder()
+            .host("imap.gmail.com")
+            .credentialId("my-cred")
+            .authType(ImapSourceDto.AuthType.PASSWORD)
+            .searchCriteria("SEEN")
+            .markAsRead(false)
+            .build();
+
+    assertDoesNotThrow(() -> validator.validateConfig(config, "test-node", mockJobContext));
+  }
+
+  @Test
   void testDefaultValues() {
     ImapSourceDto.Config config =
         ImapSourceDto.Config.builder().host("imap.gmail.com").credentialId("my-cred").build();

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceFetcherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceFetcherTest.java
@@ -400,6 +400,21 @@ class ImapSourceFetcherTest {
   }
 
   @Test
+  void testCloseIsIdempotent() throws Exception {
+    when(mockStore.isConnected()).thenReturn(true).thenReturn(false);
+
+    ImapSourceFetcher fetcher =
+        new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", true, false, 100);
+
+    fetcher.close();
+    // A second close (e.g. from an init-failure rollback path that already called close once)
+    // must not throw or double-close the store.
+    fetcher.close();
+
+    verify(mockStore, times(1)).close();
+  }
+
+  @Test
   void testIsExhaustedReturnsFalse() {
     ImapSourceFetcher fetcher =
         new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", true, false, 100);

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceFetcherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceFetcherTest.java
@@ -21,11 +21,14 @@ import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.search.FlagTerm;
 import jakarta.mail.search.FromStringTerm;
 import jakarta.mail.search.ReceivedDateTerm;
+import jakarta.mail.search.SearchTerm;
 import jakarta.mail.search.SubjectTerm;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Vector;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -158,6 +161,116 @@ class ImapSourceFetcherTest {
     assertTrue(result.isEmpty());
     verify(mockFolder).getMessages();
     verify(mockFolder, never()).search(any());
+  }
+
+  @Test
+  void testFetchHonorsPollIntervalBetweenPolls() throws Exception {
+    when(mockFolder.isOpen()).thenReturn(false);
+    when(mockFolder.search(any())).thenReturn(new Message[0]);
+
+    ImapSourceFetcher fetcher =
+        new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", false, false, 100, 50L);
+
+    fetcher.fetch();
+    long start = System.currentTimeMillis();
+    fetcher.fetch();
+
+    assertTrue(System.currentTimeMillis() - start >= 35);
+  }
+
+  @Test
+  void testSearchCriteriaWithMarkAsReadFiltersOutAlreadySeenMessages() throws Exception {
+    when(mockFolder.isOpen()).thenReturn(false);
+
+    Message unseenMessage =
+        createMockTextMessage(
+            "<msg-unseen@test.com>",
+            "sender@test.com",
+            new String[] {"to@test.com"},
+            null,
+            "FLE-1502 alert",
+            "Body",
+            "text/plain",
+            new Date());
+    Message seenMessage1 =
+        createMockTextMessage(
+            "<msg-seen-1@test.com>",
+            "sender@test.com",
+            new String[] {"to@test.com"},
+            null,
+            "FLE-1502 alert",
+            "Body",
+            "text/plain",
+            new Date());
+    Message seenMessage2 =
+        createMockTextMessage(
+            "<msg-seen-2@test.com>",
+            "sender@test.com",
+            new String[] {"to@test.com"},
+            null,
+            "FLE-1502 alert",
+            "Body",
+            "text/plain",
+            new Date());
+
+    stubSeenFlag(unseenMessage, false);
+    stubSeenFlag(seenMessage1, true);
+    stubSeenFlag(seenMessage2, true);
+    whenFolderSearchFilters(unseenMessage, seenMessage1, seenMessage2);
+
+    ImapSourceFetcher fetcher =
+        new ImapSourceFetcher(mockStore, "INBOX", "SUBJECT FLE-1502", true, false, 100, 1L);
+
+    List<EmailMessage> firstPoll = fetcher.fetch();
+    List<EmailMessage> secondPoll = fetcher.fetch();
+
+    assertEquals(1, firstPoll.size());
+    assertEquals("<msg-unseen@test.com>", firstPoll.getFirst().messageId());
+    assertTrue(secondPoll.isEmpty());
+    verify(unseenMessage).setFlag(Flags.Flag.SEEN, true);
+    verify(seenMessage1, never()).setFlag(any(), anyBoolean());
+    verify(seenMessage2, never()).setFlag(any(), anyBoolean());
+  }
+
+  @Test
+  void testEmptySearchCriteriaWithMarkAsReadDoesNotRefetchProcessedMessages() throws Exception {
+    when(mockFolder.isOpen()).thenReturn(false);
+
+    Message message1 =
+        createMockTextMessage(
+            "<msg1@test.com>",
+            "sender@test.com",
+            new String[] {"to@test.com"},
+            null,
+            "Subject 1",
+            "Body 1",
+            "text/plain",
+            new Date());
+    Message message2 =
+        createMockTextMessage(
+            "<msg2@test.com>",
+            "sender@test.com",
+            new String[] {"to@test.com"},
+            null,
+            "Subject 2",
+            "Body 2",
+            "text/plain",
+            new Date());
+
+    stubSeenFlag(message1, false);
+    stubSeenFlag(message2, false);
+    whenFolderSearchFilters(message1, message2);
+
+    ImapSourceFetcher fetcher =
+        new ImapSourceFetcher(mockStore, "INBOX", null, true, false, 100, 1L);
+
+    List<EmailMessage> firstPoll = fetcher.fetch();
+    List<EmailMessage> secondPoll = fetcher.fetch();
+
+    assertEquals(2, firstPoll.size());
+    assertTrue(secondPoll.isEmpty());
+    verify(mockFolder, times(2)).search(any());
+    verify(mockFolder, never()).getMessages();
   }
 
   @Test
@@ -299,5 +412,28 @@ class ImapSourceFetcherTest {
     when(message.getAllHeaders()).thenReturn(headerEnum);
 
     return message;
+  }
+
+  private void whenFolderSearchFilters(Message... messages) throws Exception {
+    when(mockFolder.search(any(SearchTerm.class)))
+        .thenAnswer(
+            invocation -> {
+              SearchTerm term = invocation.getArgument(0);
+              return Arrays.stream(messages).filter(term::match).toArray(Message[]::new);
+            });
+  }
+
+  private void stubSeenFlag(Message message, boolean seen) throws Exception {
+    AtomicBoolean isSeen = new AtomicBoolean(seen);
+    when(message.getFlags())
+        .thenAnswer(invocation -> isSeen.get() ? new Flags(Flags.Flag.SEEN) : new Flags());
+    when(message.isSet(Flags.Flag.SEEN)).thenAnswer(invocation -> isSeen.get());
+    doAnswer(
+            invocation -> {
+              isSeen.set(invocation.getArgument(1));
+              return null;
+            })
+        .when(message)
+        .setFlag(eq(Flags.Flag.SEEN), anyBoolean());
   }
 }

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceFetcherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/imapsource/ImapSourceFetcherTest.java
@@ -29,6 +29,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +45,13 @@ class ImapSourceFetcherTest {
     when(mockStore.getFolder("INBOX")).thenReturn(mockFolder);
   }
 
+  // Drives a single poll cycle (push results into the internal queue) then drains via fetch().
+  // This bypasses the ScheduledExecutorService so tests stay deterministic.
+  private List<EmailMessage> pollAndDrain(ImapSourceFetcher fetcher) {
+    fetcher.poll();
+    return fetcher.fetch();
+  }
+
   @Test
   void testFetchWithNoMessages() throws Exception {
     when(mockFolder.isOpen()).thenReturn(false);
@@ -52,7 +60,7 @@ class ImapSourceFetcherTest {
     ImapSourceFetcher fetcher =
         new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", true, false, 100);
 
-    List<EmailMessage> result = fetcher.fetch();
+    List<EmailMessage> result = pollAndDrain(fetcher);
 
     assertNotNull(result);
     assertTrue(result.isEmpty());
@@ -79,7 +87,7 @@ class ImapSourceFetcherTest {
     ImapSourceFetcher fetcher =
         new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", true, false, 100);
 
-    List<EmailMessage> result = fetcher.fetch();
+    List<EmailMessage> result = pollAndDrain(fetcher);
 
     assertEquals(1, result.size());
     EmailMessage email = result.getFirst();
@@ -113,7 +121,7 @@ class ImapSourceFetcherTest {
     ImapSourceFetcher fetcher =
         new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", false, false, 100);
 
-    List<EmailMessage> result = fetcher.fetch();
+    List<EmailMessage> result = pollAndDrain(fetcher);
 
     assertEquals(1, result.size());
     assertNull(result.getFirst().bodyText());
@@ -144,7 +152,7 @@ class ImapSourceFetcherTest {
     ImapSourceFetcher fetcher =
         new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", false, false, 3);
 
-    List<EmailMessage> result = fetcher.fetch();
+    List<EmailMessage> result = pollAndDrain(fetcher);
 
     assertEquals(3, result.size());
   }
@@ -156,7 +164,7 @@ class ImapSourceFetcherTest {
 
     ImapSourceFetcher fetcher = new ImapSourceFetcher(mockStore, "INBOX", null, false, false, 100);
 
-    List<EmailMessage> result = fetcher.fetch();
+    List<EmailMessage> result = pollAndDrain(fetcher);
 
     assertTrue(result.isEmpty());
     verify(mockFolder).getMessages();
@@ -164,18 +172,32 @@ class ImapSourceFetcherTest {
   }
 
   @Test
-  void testFetchHonorsPollIntervalBetweenPolls() throws Exception {
+  void testStartSchedulesPollerAtConfiguredInterval() throws Exception {
     when(mockFolder.isOpen()).thenReturn(false);
-    when(mockFolder.search(any())).thenReturn(new Message[0]);
+    AtomicInteger searchCalls = new AtomicInteger();
+    when(mockFolder.search(any()))
+        .thenAnswer(
+            invocation -> {
+              searchCalls.incrementAndGet();
+              return new Message[0];
+            });
 
     ImapSourceFetcher fetcher =
-        new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", false, false, 100, 50L);
+        new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", false, false, 100, 30L);
 
-    fetcher.fetch();
-    long start = System.currentTimeMillis();
-    fetcher.fetch();
-
-    assertTrue(System.currentTimeMillis() - start >= 35);
+    fetcher.start();
+    try {
+      // Three polls at 30ms interval take ~90ms; allow generous slack for CI scheduling jitter.
+      long deadline = System.currentTimeMillis() + 2000;
+      while (searchCalls.get() < 3 && System.currentTimeMillis() < deadline) {
+        Thread.sleep(20);
+      }
+      assertTrue(
+          searchCalls.get() >= 3,
+          "Expected scheduler to fire >= 3 polls, observed " + searchCalls.get());
+    } finally {
+      fetcher.close();
+    }
   }
 
   @Test
@@ -221,8 +243,8 @@ class ImapSourceFetcherTest {
     ImapSourceFetcher fetcher =
         new ImapSourceFetcher(mockStore, "INBOX", "SUBJECT FLE-1502", true, false, 100, 1L);
 
-    List<EmailMessage> firstPoll = fetcher.fetch();
-    List<EmailMessage> secondPoll = fetcher.fetch();
+    List<EmailMessage> firstPoll = pollAndDrain(fetcher);
+    List<EmailMessage> secondPoll = pollAndDrain(fetcher);
 
     assertEquals(1, firstPoll.size());
     assertEquals("<msg-unseen@test.com>", firstPoll.getFirst().messageId());
@@ -264,8 +286,8 @@ class ImapSourceFetcherTest {
     ImapSourceFetcher fetcher =
         new ImapSourceFetcher(mockStore, "INBOX", null, true, false, 100, 1L);
 
-    List<EmailMessage> firstPoll = fetcher.fetch();
-    List<EmailMessage> secondPoll = fetcher.fetch();
+    List<EmailMessage> firstPoll = pollAndDrain(fetcher);
+    List<EmailMessage> secondPoll = pollAndDrain(fetcher);
 
     assertEquals(2, firstPoll.size());
     assertTrue(secondPoll.isEmpty());
@@ -293,7 +315,7 @@ class ImapSourceFetcherTest {
     ImapSourceFetcher fetcher =
         new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", false, false, 100);
 
-    List<EmailMessage> result = fetcher.fetch();
+    List<EmailMessage> result = pollAndDrain(fetcher);
 
     assertEquals(1, result.size());
     assertEquals(List.of("cc1@test.com", "cc2@test.com"), result.getFirst().cc());
@@ -351,12 +373,27 @@ class ImapSourceFetcherTest {
   }
 
   @Test
-  void testClose() throws Exception {
+  void testCloseWithoutStartIsSafe() throws Exception {
     when(mockStore.isConnected()).thenReturn(true);
 
     ImapSourceFetcher fetcher =
         new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", true, false, 100);
 
+    fetcher.close();
+
+    verify(mockStore).close();
+  }
+
+  @Test
+  void testCloseAfterStartShutsDownScheduler() throws Exception {
+    when(mockFolder.isOpen()).thenReturn(false);
+    when(mockFolder.search(any())).thenReturn(new Message[0]);
+    when(mockStore.isConnected()).thenReturn(true);
+
+    ImapSourceFetcher fetcher =
+        new ImapSourceFetcher(mockStore, "INBOX", "UNSEEN", false, false, 100, 50L);
+
+    fetcher.start();
     fetcher.close();
 
     verify(mockStore).close();


### PR DESCRIPTION
Discovered during end-to-end testing of webapp FLE-1521 (Email IMAP/SMTP UI).

- pollIntervalMs was unused; fetcher now sleeps for the remaining interval of fetch(), mirroring JdbcSourceFetcher.
- When markAsRead=true, AND the user search criteria with FlagTerm(SEEN, false) so SUBJECT/FROM/SINCE/empty stop re-fetching already-processed messages.
- Three new fetcher tests cover the throttling and AND-with-UNSEEN.