### PR TITLE
Fix: Databricks WRITE VOLUME PermissionDenied not surfaced to UI – shows as silent failure

### DIFF
--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/databrickssink/BatchDatabricksFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/databrickssink/BatchDatabricksFlusher.java
@@ -218,7 +218,11 @@ public class BatchDatabricksFlusher extends AbstractBufferedFlusher<Map<String, 
             parquetResult.generatedFiles.size());
         cleanupTempFiles(parquetResult.generatedFiles);
         cleanupRemoteBatchDirectory(batchId);
-        return createCompleteFailureResult(batch, "Partial upload failure - aborting batch");
+        String uploadFailMsg =
+            uploadResult.lastErrorMessage() != null
+                ? "Databricks upload failed: " + uploadResult.lastErrorMessage()
+                : "Databricks upload failed";
+        return createCompleteFailureResult(batch, uploadFailMsg);
       }
 
       log.info(
@@ -355,6 +359,7 @@ public class BatchDatabricksFlusher extends AbstractBufferedFlusher<Map<String, 
   private UploadResult uploadFilesWithRetry(List<File> files, String batchId) {
     List<String> uploadedPaths = new ArrayList<>();
     List<File> failedFiles = new ArrayList<>();
+    String lastErrorMessage = null;
 
     for (File file : files) {
       boolean uploaded = false;
@@ -400,10 +405,11 @@ public class BatchDatabricksFlusher extends AbstractBufferedFlusher<Map<String, 
             MAX_UPLOAD_RETRIES,
             lastException.getMessage());
         failedFiles.add(file);
+        lastErrorMessage = lastException.getMessage();
       }
     }
 
-    return new UploadResult(uploadedPaths, failedFiles);
+    return new UploadResult(uploadedPaths, failedFiles, lastErrorMessage);
   }
 
   private String buildRemotePath(File file, String batchId) {
@@ -546,7 +552,8 @@ public class BatchDatabricksFlusher extends AbstractBufferedFlusher<Map<String, 
   private record ParquetGenerationResult(
       List<File> generatedFiles, List<ErrorOutput> errors, int successfulRecordCount) {}
 
-  private record UploadResult(List<String> uploadedPaths, List<File> failedFiles) {}
+  private record UploadResult(
+      List<String> uploadedPaths, List<File> failedFiles, String lastErrorMessage) {}
 
   private record CopyIntoResult(boolean success, long recordsLoaded, String errorMessage) {}
 }

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/databrickssink/BatchDatabricksFlusherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/databrickssink/BatchDatabricksFlusherTest.java
@@ -28,6 +28,7 @@ import io.fleak.zephflow.lib.commands.databrickssink.DatabricksSqlExecutor.CopyI
 import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
 import io.fleak.zephflow.lib.dlq.DlqWriter;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -279,7 +280,73 @@ class BatchDatabricksFlusherTest {
 
       assertEquals(0, result.successCount());
       assertEquals(1, result.errorOutputList().size());
-      assertTrue(result.errorOutputList().get(0).errorMessage().contains("Partial upload failure"));
+      String errorMessage = result.errorOutputList().get(0).errorMessage();
+      assertTrue(errorMessage.startsWith("Databricks upload failed: "));
+      assertTrue(errorMessage.contains("Upload failed"));
+
+      verifyNoInteractions(sqlExecutor);
+    }
+  }
+
+  @Test
+  void testFlushHandlesUploadFailureWithPermissionDenied() throws Exception {
+    DatabricksSinkDto.Config smallBatchConfig =
+        DatabricksSinkDto.Config.builder()
+            .volumePath("/Volumes/test/catalog/vol")
+            .tableName("test.catalog.vol_table")
+            .warehouseId("test-warehouse-id")
+            .batchSize(1)
+            .flushIntervalMillis(60000)
+            .cleanupAfterCopy(true)
+            .build();
+
+    try (BatchDatabricksFlusher flusher =
+        new BatchDatabricksFlusher(
+            smallBatchConfig,
+            parquetWriter,
+            volumeUploader,
+            sqlExecutor,
+            tempDir,
+            dlqWriter,
+            schema,
+            sinkOutputCounter,
+            outputSizeCounter,
+            sinkErrorCounter,
+            null)) {
+
+      File mockFile = createMockFile("test.parquet");
+
+      when(parquetWriter.writeParquetFiles(anyList(), any(Path.class)))
+          .thenReturn(List.of(mockFile));
+
+      // Mimics what DatabricksVolumeUploader.uploadFile throws when the
+      // Databricks SDK reports a PERMISSION_DENIED on the target volume.
+      doThrow(
+              new IOException(
+                  "Upload failed: User does not have WRITE VOLUME privilege on VOLUME 'test.catalog.vol'."))
+          .when(volumeUploader)
+          .uploadFile(any(File.class), anyString());
+
+      SimpleSinkCommand.PreparedInputEvents<Map<String, Object>> events =
+          new SimpleSinkCommand.PreparedInputEvents<>();
+      events.add(
+          (RecordFleakData) FleakData.wrap(Map.of("id", 1, "name", "test")),
+          Map.of("id", 1, "name", "test"));
+
+      SimpleSinkCommand.FlushResult result = flusher.flush(events, Map.of());
+
+      assertEquals(0, result.successCount());
+      assertEquals(1, result.errorOutputList().size());
+      String errorMessage = result.errorOutputList().get(0).errorMessage();
+      assertTrue(
+          errorMessage.startsWith("Databricks upload failed: "),
+          "expected prefix 'Databricks upload failed: ' but got: " + errorMessage);
+      assertTrue(
+          errorMessage.contains("WRITE VOLUME"),
+          "expected 'WRITE VOLUME' in message but got: " + errorMessage);
+      assertTrue(
+          errorMessage.contains("test.catalog.vol"),
+          "expected volume name in message but got: " + errorMessage);
 
       verifyNoInteractions(sqlExecutor);
     }


### PR DESCRIPTION
https://linear.app/fleak/issue/FLE-1440/bug-databricks-write-volume-permissiondenied-not-surfaced-to-ui-shows