### PR TITLE
Add SQS-triggered real-time S3 source (s3rtsource)

### DIFF
--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/OperatorCommandRegistry.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/OperatorCommandRegistry.java
@@ -45,6 +45,7 @@ import io.fleak.zephflow.lib.commands.pubsubsink.PubSubSinkCommandFactory;
 import io.fleak.zephflow.lib.commands.pubsubsource.PubSubSourceCommandFactory;
 import io.fleak.zephflow.lib.commands.reader.ReaderCommandFactory;
 import io.fleak.zephflow.lib.commands.s3.S3SinkCommandFactory;
+import io.fleak.zephflow.lib.commands.s3realtimesource.S3RealtimeSourceCommandFactory;
 import io.fleak.zephflow.lib.commands.smtpsink.SmtpSinkCommandFactory;
 import io.fleak.zephflow.lib.commands.splunkhecsink.SplunkHecSinkCommandFactory;
 import io.fleak.zephflow.lib.commands.splunksource.SplunkSourceCommandFactory;
@@ -86,6 +87,7 @@ public interface OperatorCommandRegistry {
           .put(COMMAND_NAME_JDBC_SINK, new JdbcSinkCommandFactory())
           .put(COMMAND_NAME_SQS_SOURCE, new SqsSourceCommandFactory())
           .put(COMMAND_NAME_SQS_SINK, new SqsSinkCommandFactory())
+          .put(COMMAND_NAME_S3_REALTIME_SOURCE, new S3RealtimeSourceCommandFactory())
           .put(COMMAND_NAME_IMAP_SOURCE, new ImapSourceCommandFactory())
           .put(COMMAND_NAME_SMTP_SINK, new SmtpSinkCommandFactory())
           .put(COMMAND_NAME_LDAP_SOURCE, new LdapSourceCommandFactory())

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3EventMessage.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3EventMessage.java
@@ -18,7 +18,8 @@ import java.util.List;
 /**
  * An SQS message carrying one or more S3 object references. Acts as the commit unit: its {@code
  * receiptHandle} is used to delete the message from SQS once all its referenced objects have been
- * processed.
+ * processed. {@code rawBody} is the original SQS message body (the S3 event notification) and is
+ * the canonical "raw data" representation used for the DLQ and raw-data sampling.
  */
 public record S3EventMessage(
-    String messageId, String receiptHandle, List<S3ObjectRef> objectRefs) {}
+    String messageId, String receiptHandle, String rawBody, List<S3ObjectRef> objectRefs) {}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3EventMessage.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3EventMessage.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import java.util.List;
+
+/**
+ * An SQS message carrying one or more S3 object references. Acts as the commit unit: its {@code
+ * receiptHandle} is used to delete the message from SQS once all its referenced objects have been
+ * processed.
+ */
+public record S3EventMessage(
+    String messageId, String receiptHandle, List<S3ObjectRef> objectRefs) {}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3EventNotificationParser.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3EventNotificationParser.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.OBJECT_MAPPER;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parses a standard AWS S3 event notification (direct, or wrapped in an SNS envelope) into the list
+ * of {@link S3ObjectRef}s it references. Only {@code ObjectCreated:*} events are kept; everything
+ * else (e.g. {@code s3:TestEvent}, {@code ObjectRemoved:*}) yields an empty list.
+ */
+public final class S3EventNotificationParser {
+
+  private static final String EVENT_NAME_OBJECT_CREATED_PREFIX = "ObjectCreated:";
+
+  private S3EventNotificationParser() {}
+
+  public static List<S3ObjectRef> parse(String body) {
+    JsonNode root;
+    try {
+      root = OBJECT_MAPPER.readTree(body);
+      // Unwrap SNS -> SQS delivery: the S3 event is a JSON string in the "Message" field.
+      if ("Notification".equals(root.path("Type").asText()) && root.hasNonNull("Message")) {
+        root = OBJECT_MAPPER.readTree(root.path("Message").asText());
+      }
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("malformed S3 event notification", e);
+    }
+
+    JsonNode records = root.path("Records");
+    if (!records.isArray()) {
+      return List.of();
+    }
+
+    List<S3ObjectRef> refs = new ArrayList<>();
+    for (JsonNode record : records) {
+      String eventName = record.path("eventName").asText("");
+      if (!eventName.startsWith(EVENT_NAME_OBJECT_CREATED_PREFIX)) {
+        continue;
+      }
+      JsonNode s3 = record.path("s3");
+      JsonNode bucketNode = s3.path("bucket").path("name");
+      JsonNode keyNode = s3.path("object").path("key");
+      if (bucketNode.isMissingNode() || keyNode.isMissingNode()) {
+        continue;
+      }
+      String key = URLDecoder.decode(keyNode.asText(), StandardCharsets.UTF_8);
+      refs.add(new S3ObjectRef(bucketNode.asText(), key));
+    }
+    return refs;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3ObjectRef.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3ObjectRef.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+/** A reference to a single S3 object extracted from an S3 event notification. */
+public record S3ObjectRef(String bucket, String key) {}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverter.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverter.java
@@ -46,8 +46,10 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
  * <p>Each object is handled independently and a failure is <b>terminal</b>: an object that can't be
  * downloaded or parsed is written (with its real error) to the DLQ and skipped, never retried. So
  * {@code convert()} always succeeds and the message is always acknowledged; a multi-object message
- * emits its good objects and DLQs the bad ones. ({@code NoSuchKey} / oversized are benign skips
- * with no DLQ.) Downstream {@code accept()} failures are handled by the framework's DLQ path.
+ * emits its good objects and DLQs the bad ones (including oversized objects, which exist but exceed
+ * the size limit). A deleted object ({@code NoSuchKey}) is the one benign skip with no DLQ, since
+ * there is nothing to recover. Downstream {@code accept()} failures are handled by the framework's
+ * DLQ path.
  */
 @Slf4j
 public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessage> {
@@ -106,8 +108,10 @@ public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessa
             ref.key());
         continue;
       } catch (ObjectTooLargeException e) {
-        // Terminal but benign (the object will always be too large): skip + acknowledge, no DLQ.
-        log.warn("{}; skipping the notification", e.getMessage());
+        // The object exists but exceeds the size limit -- a real drop, not a benign skip (unlike a
+        // deleted object). Dead-letter the notification (with the reason) + ack so the skip is
+        // auditable/recoverable rather than silently lost.
+        deadLetter(sourceRecord, ref, e, sourceInitializedConfig);
         continue;
       } catch (Exception e) {
         // Any other download problem is treated as terminal: dead-letter (with the real error) and

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverter.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverter.java
@@ -39,8 +39,8 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 /**
  * Downloads the S3 object(s) referenced by an {@link S3EventMessage} — one at a time, so at most a
  * single object is held in memory — and deserializes each into {@link RecordFleakData}. On success
- * the message's receipt handle is queued for commit (deletion); on failure the whole message is
- * routed to the DLQ and left undeleted for SQS redelivery.
+ * the message's receipt handle is queued for commit (deletion); on failure it is left undeleted for
+ * SQS redelivery, and the fetcher dead-letters it once the retry cap is reached.
  */
 @Slf4j
 public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessage> {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverter.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverter.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import static io.fleak.zephflow.lib.utils.MiscUtils.getCallingUserTagAndEventTags;
+
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.source.ConvertedResult;
+import io.fleak.zephflow.lib.commands.source.RawDataConverter;
+import io.fleak.zephflow.lib.commands.source.SourceExecutionContext;
+import io.fleak.zephflow.lib.serdes.CompressionType;
+import io.fleak.zephflow.lib.serdes.SerializedEvent;
+import io.fleak.zephflow.lib.serdes.des.FleakDeserializer;
+import io.fleak.zephflow.lib.utils.CompressionUtils;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+/**
+ * Downloads the S3 object(s) referenced by an {@link S3EventMessage} — one at a time, so at most a
+ * single object is held in memory — and deserializes each into {@link RecordFleakData}. On success
+ * the message's receipt handle is queued for commit (deletion); on failure the whole message is
+ * routed to the DLQ and left undeleted for SQS redelivery.
+ */
+@Slf4j
+public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessage> {
+
+  static final String S3_METADATA_BUCKET = "__s3_bucket";
+  static final String S3_METADATA_KEY = "__s3_key";
+
+  private final S3Client s3Client;
+  private final FleakDeserializer<?> fleakDeserializer;
+  // When null, gzip is auto-detected via magic bytes; when GZIP, decompression is forced.
+  private final CompressionType compressionType;
+  private final long maxObjectSizeBytes;
+  private final boolean addS3Metadata;
+  private final Queue<String> confirmedReceiptHandles;
+
+  public S3RealtimeRawDataConverter(
+      S3Client s3Client,
+      FleakDeserializer<?> fleakDeserializer,
+      CompressionType compressionType,
+      long maxObjectSizeBytes,
+      boolean addS3Metadata,
+      Queue<String> confirmedReceiptHandles) {
+    this.s3Client = s3Client;
+    this.fleakDeserializer = fleakDeserializer;
+    this.compressionType = compressionType;
+    this.maxObjectSizeBytes = maxObjectSizeBytes;
+    this.addS3Metadata = addS3Metadata;
+    this.confirmedReceiptHandles = confirmedReceiptHandles;
+  }
+
+  @Override
+  public ConvertedResult<S3EventMessage> convert(
+      S3EventMessage sourceRecord, SourceExecutionContext<?> sourceInitializedConfig) {
+    try {
+      List<RecordFleakData> events = new ArrayList<>();
+      long totalBytes = 0;
+      for (S3ObjectRef ref : sourceRecord.objectRefs()) {
+        byte[] raw;
+        try {
+          raw = downloadObject(ref);
+        } catch (NoSuchKeyException e) {
+          // The object was deleted (e.g. by an S3 lifecycle policy) between the notification being
+          // emitted and us reading it. It will never appear, so acknowledge and skip rather than
+          // retrying. Common with backlogged queues on log buckets that expire objects.
+          log.warn(
+              "S3 object s3://{}/{} no longer exists; skipping the notification",
+              ref.bucket(),
+              ref.key());
+          continue;
+        }
+        byte[] body = maybeDecompress(raw);
+        totalBytes += body.length;
+        List<RecordFleakData> objectEvents =
+            fleakDeserializer.deserialize(new SerializedEvent(null, body, null));
+        if (addS3Metadata) {
+          objectEvents.forEach(e -> enrich(e, ref));
+        }
+        events.addAll(objectEvents);
+      }
+
+      Map<String, String> eventTags =
+          getCallingUserTagAndEventTags(null, events.isEmpty() ? null : events.getFirst());
+      sourceInitializedConfig.dataSizeCounter().increase(totalBytes, eventTags);
+      sourceInitializedConfig.inputEventCounter().increase(events.size(), eventTags);
+
+      confirmedReceiptHandles.add(sourceRecord.receiptHandle());
+      return ConvertedResult.success(events, sourceRecord);
+    } catch (Exception e) {
+      sourceInitializedConfig.deserializeFailureCounter().increase(Map.of());
+      log.error("failed to process S3 event message {}", sourceRecord.messageId(), e);
+      return ConvertedResult.failure(e, sourceRecord);
+    }
+  }
+
+  private byte[] downloadObject(S3ObjectRef ref) throws IOException {
+    try (ResponseInputStream<GetObjectResponse> in =
+        s3Client.getObject(
+            GetObjectRequest.builder().bucket(ref.bucket()).key(ref.key()).build())) {
+      long contentLength = in.response().contentLength();
+      if (contentLength > maxObjectSizeBytes) {
+        throw new IOException(
+            "S3 object s3://%s/%s size %d exceeds maxObjectSizeBytes %d"
+                .formatted(ref.bucket(), ref.key(), contentLength, maxObjectSizeBytes));
+      }
+      return in.readAllBytes();
+    }
+  }
+
+  private byte[] maybeDecompress(byte[] body) {
+    if (compressionType == CompressionType.GZIP || (compressionType == null && isGzip(body))) {
+      return CompressionUtils.gunzip(body);
+    }
+    return body;
+  }
+
+  private static boolean isGzip(byte[] body) {
+    return body.length >= 2 && (body[0] & 0xFF) == 0x1F && (body[1] & 0xFF) == 0x8B;
+  }
+
+  private static void enrich(RecordFleakData event, S3ObjectRef ref) {
+    event.getPayload().put(S3_METADATA_BUCKET, FleakData.wrap(ref.bucket()));
+    event.getPayload().put(S3_METADATA_KEY, FleakData.wrap(ref.key()));
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverter.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverter.java
@@ -75,6 +75,13 @@ public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessa
   public ConvertedResult<S3EventMessage> convert(
       S3EventMessage sourceRecord, SourceExecutionContext<?> sourceInitializedConfig) {
     try {
+      // A message is the atomic unit: a single SQS receipt handle covers all of its objects, so we
+      // emit every object's records together (on success) or none (on failure) -- there is no
+      // per-object ack. A partial failure therefore emits nothing and the whole message is retried;
+      // the already-deserialized objects are reprocessed but not double-emitted. At-least-once
+      // still
+      // holds: if the process dies after emit() but before the delete, redelivery re-emits every
+      // object in the message, so a multi-object message duplicates more records than a single one.
       List<RecordFleakData> events = new ArrayList<>();
       long totalBytes = 0;
       for (S3ObjectRef ref : sourceRecord.objectRefs()) {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverter.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverter.java
@@ -19,7 +19,9 @@ import io.fleak.zephflow.api.structure.FleakData;
 import io.fleak.zephflow.api.structure.RecordFleakData;
 import io.fleak.zephflow.lib.commands.source.ConvertedResult;
 import io.fleak.zephflow.lib.commands.source.RawDataConverter;
+import io.fleak.zephflow.lib.commands.source.RawDataEncoder;
 import io.fleak.zephflow.lib.commands.source.SourceExecutionContext;
+import io.fleak.zephflow.lib.dlq.DlqWriter;
 import io.fleak.zephflow.lib.serdes.CompressionType;
 import io.fleak.zephflow.lib.serdes.SerializedEvent;
 import io.fleak.zephflow.lib.serdes.des.FleakDeserializer;
@@ -30,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -38,9 +41,13 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 /**
  * Downloads the S3 object(s) referenced by an {@link S3EventMessage} — one at a time, so at most a
- * single object is held in memory — and deserializes each into {@link RecordFleakData}. On success
- * the message's receipt handle is queued for commit (deletion); on failure it is left undeleted for
- * SQS redelivery, and the fetcher dead-letters it once the retry cap is reached.
+ * single object is held in memory — and deserializes each into {@link RecordFleakData}.
+ *
+ * <p>Each object is handled independently and a failure is <b>terminal</b>: an object that can't be
+ * downloaded or parsed is written (with its real error) to the DLQ and skipped, never retried. So
+ * {@code convert()} always succeeds and the message is always acknowledged; a multi-object message
+ * emits its good objects and DLQs the bad ones. ({@code NoSuchKey} / oversized are benign skips
+ * with no DLQ.) Downstream {@code accept()} failures are handled by the framework's DLQ path.
  */
 @Slf4j
 public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessage> {
@@ -55,6 +62,9 @@ public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessa
   private final long maxObjectSizeBytes;
   private final boolean addS3Metadata;
   private final Queue<String> confirmedReceiptHandles;
+  private final DlqWriter dlqWriter;
+  private final RawDataEncoder<S3EventMessage> encoder;
+  private final String nodeId;
 
   public S3RealtimeRawDataConverter(
       S3Client s3Client,
@@ -62,68 +72,94 @@ public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessa
       CompressionType compressionType,
       long maxObjectSizeBytes,
       boolean addS3Metadata,
-      Queue<String> confirmedReceiptHandles) {
+      Queue<String> confirmedReceiptHandles,
+      DlqWriter dlqWriter,
+      RawDataEncoder<S3EventMessage> encoder,
+      String nodeId) {
     this.s3Client = s3Client;
     this.fleakDeserializer = fleakDeserializer;
     this.compressionType = compressionType;
     this.maxObjectSizeBytes = maxObjectSizeBytes;
     this.addS3Metadata = addS3Metadata;
     this.confirmedReceiptHandles = confirmedReceiptHandles;
+    this.dlqWriter = dlqWriter;
+    this.encoder = encoder;
+    this.nodeId = nodeId;
   }
 
   @Override
   public ConvertedResult<S3EventMessage> convert(
       S3EventMessage sourceRecord, SourceExecutionContext<?> sourceInitializedConfig) {
-    try {
-      // A message is the atomic unit: a single SQS receipt handle covers all of its objects, so we
-      // emit every object's records together (on success) or none (on failure) -- there is no
-      // per-object ack. A partial failure therefore emits nothing and the whole message is retried;
-      // the already-deserialized objects are reprocessed but not double-emitted. At-least-once
-      // still
-      // holds: if the process dies after emit() but before the delete, redelivery re-emits every
-      // object in the message, so a multi-object message duplicates more records than a single one.
-      List<RecordFleakData> events = new ArrayList<>();
-      long totalBytes = 0;
-      for (S3ObjectRef ref : sourceRecord.objectRefs()) {
-        byte[] raw;
-        try {
-          raw = downloadObject(ref);
-        } catch (NoSuchKeyException e) {
-          // The object was deleted (e.g. by an S3 lifecycle policy) between the notification being
-          // emitted and us reading it. It will never appear, so acknowledge and skip rather than
-          // retrying. Common with backlogged queues on log buckets that expire objects.
-          log.warn(
-              "S3 object s3://{}/{} no longer exists; skipping the notification",
-              ref.bucket(),
-              ref.key());
-          continue;
-        } catch (ObjectTooLargeException e) {
-          // Terminal condition (the object will always be too large), so skip + acknowledge instead
-          // of failing and retrying.
-          log.warn("{}; skipping the notification", e.getMessage());
-          continue;
-        }
-        byte[] body = maybeDecompress(raw);
-        totalBytes += body.length;
+    List<RecordFleakData> events = new ArrayList<>();
+    long totalBytes = 0;
+    for (S3ObjectRef ref : sourceRecord.objectRefs()) {
+      byte[] body;
+      try {
+        body = maybeDecompress(downloadObject(ref));
+      } catch (NoSuchKeyException e) {
+        // The object was deleted (e.g. by an S3 lifecycle policy) between the notification being
+        // emitted and us reading it. It will never appear, so acknowledge and skip (no DLQ).
+        // Common with backlogged queues on log buckets that expire objects.
+        log.warn(
+            "S3 object s3://{}/{} no longer exists; skipping the notification",
+            ref.bucket(),
+            ref.key());
+        continue;
+      } catch (ObjectTooLargeException e) {
+        // Terminal but benign (the object will always be too large): skip + acknowledge, no DLQ.
+        log.warn("{}; skipping the notification", e.getMessage());
+        continue;
+      } catch (Exception e) {
+        // Any other download problem is treated as terminal: dead-letter (with the real error) and
+        // skip, rather than failing the whole message and retrying.
+        deadLetter(sourceRecord, ref, e, sourceInitializedConfig);
+        continue;
+      }
+
+      try {
         List<RecordFleakData> objectEvents =
             fleakDeserializer.deserialize(new SerializedEvent(null, body, null));
         if (addS3Metadata) {
           objectEvents.forEach(e -> enrich(e, ref));
         }
         events.addAll(objectEvents);
+        totalBytes += body.length;
+      } catch (Exception e) {
+        // The object's content can't be parsed; retrying won't help -> dead-letter + skip.
+        deadLetter(sourceRecord, ref, e, sourceInitializedConfig);
       }
+    }
 
-      Map<String, String> eventTags =
-          getCallingUserTagAndEventTags(null, events.isEmpty() ? null : events.getFirst());
-      sourceInitializedConfig.dataSizeCounter().increase(totalBytes, eventTags);
-      sourceInitializedConfig.inputEventCounter().increase(events.size(), eventTags);
+    Map<String, String> eventTags =
+        getCallingUserTagAndEventTags(null, events.isEmpty() ? null : events.getFirst());
+    sourceInitializedConfig.dataSizeCounter().increase(totalBytes, eventTags);
+    sourceInitializedConfig.inputEventCounter().increase(events.size(), eventTags);
 
-      confirmedReceiptHandles.add(sourceRecord.receiptHandle());
-      return ConvertedResult.success(events, sourceRecord);
-    } catch (Exception e) {
-      sourceInitializedConfig.deserializeFailureCounter().increase(Map.of());
-      log.error("failed to process S3 event message {}", sourceRecord.messageId(), e);
-      return ConvertedResult.failure(e, sourceRecord);
+    confirmedReceiptHandles.add(sourceRecord.receiptHandle());
+    return ConvertedResult.success(events, sourceRecord);
+  }
+
+  private void deadLetter(
+      S3EventMessage message, S3ObjectRef ref, Exception e, SourceExecutionContext<?> ctx) {
+    ctx.deserializeFailureCounter().increase(Map.of());
+    log.error(
+        "failed to process s3://{}/{} from message {}",
+        ref.bucket(),
+        ref.key(),
+        message.messageId(),
+        e);
+    if (dlqWriter == null) {
+      log.warn("dropping failed object s3://{}/{} (no DLQ configured)", ref.bucket(), ref.key());
+      return;
+    }
+    String errorMsg =
+        "failed to process s3://%s/%s: %s"
+            .formatted(ref.bucket(), ref.key(), ExceptionUtils.getStackTrace(e));
+    try {
+      dlqWriter.writeToDlq(
+          System.currentTimeMillis(), encoder.serialize(message), errorMsg, nodeId);
+    } catch (Exception ex) {
+      log.error("failed to write failed object s3://{}/{} to DLQ", ref.bucket(), ref.key(), ex);
     }
   }
 

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverter.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverter.java
@@ -90,6 +90,11 @@ public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessa
               ref.bucket(),
               ref.key());
           continue;
+        } catch (ObjectTooLargeException e) {
+          // Terminal condition (the object will always be too large), so skip + acknowledge instead
+          // of failing and retrying.
+          log.warn("{}; skipping the notification", e.getMessage());
+          continue;
         }
         byte[] body = maybeDecompress(raw);
         totalBytes += body.length;
@@ -121,11 +126,18 @@ public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessa
             GetObjectRequest.builder().bucket(ref.bucket()).key(ref.key()).build())) {
       long contentLength = in.response().contentLength();
       if (contentLength > maxObjectSizeBytes) {
-        throw new IOException(
+        // Read the size from the response headers and abort before transferring the body.
+        throw new ObjectTooLargeException(
             "S3 object s3://%s/%s size %d exceeds maxObjectSizeBytes %d"
                 .formatted(ref.bucket(), ref.key(), contentLength, maxObjectSizeBytes));
       }
       return in.readAllBytes();
+    }
+  }
+
+  private static final class ObjectTooLargeException extends RuntimeException {
+    ObjectTooLargeException(String message) {
+      super(message);
     }
   }
 

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverter.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverter.java
@@ -15,6 +15,7 @@ package io.fleak.zephflow.lib.commands.s3realtimesource;
 
 import static io.fleak.zephflow.lib.utils.MiscUtils.getCallingUserTagAndEventTags;
 
+import io.fleak.zephflow.api.metric.FleakCounter;
 import io.fleak.zephflow.api.structure.FleakData;
 import io.fleak.zephflow.api.structure.RecordFleakData;
 import io.fleak.zephflow.lib.commands.source.ConvertedResult;
@@ -67,6 +68,8 @@ public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessa
   private final DlqWriter dlqWriter;
   private final RawDataEncoder<S3EventMessage> encoder;
   private final String nodeId;
+  // Counts objects deliberately not processed, tagged by reason (missing, oversized).
+  private final FleakCounter skippedObjectCounter;
 
   public S3RealtimeRawDataConverter(
       S3Client s3Client,
@@ -77,7 +80,8 @@ public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessa
       Queue<String> confirmedReceiptHandles,
       DlqWriter dlqWriter,
       RawDataEncoder<S3EventMessage> encoder,
-      String nodeId) {
+      String nodeId,
+      FleakCounter skippedObjectCounter) {
     this.s3Client = s3Client;
     this.fleakDeserializer = fleakDeserializer;
     this.compressionType = compressionType;
@@ -87,6 +91,7 @@ public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessa
     this.dlqWriter = dlqWriter;
     this.encoder = encoder;
     this.nodeId = nodeId;
+    this.skippedObjectCounter = skippedObjectCounter;
   }
 
   @Override
@@ -102,6 +107,7 @@ public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessa
         // The object was deleted (e.g. by an S3 lifecycle policy) between the notification being
         // emitted and us reading it. It will never appear, so acknowledge and skip (no DLQ).
         // Common with backlogged queues on log buckets that expire objects.
+        skippedObjectCounter.increase(Map.of("reason", "missing"));
         log.warn(
             "S3 object s3://{}/{} no longer exists; skipping the notification",
             ref.bucket(),
@@ -111,12 +117,14 @@ public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessa
         // The object exists but exceeds the size limit -- a real drop, not a benign skip (unlike a
         // deleted object). Dead-letter the notification (with the reason) + ack so the skip is
         // auditable/recoverable rather than silently lost.
-        deadLetter(sourceRecord, ref, e, sourceInitializedConfig);
+        skippedObjectCounter.increase(Map.of("reason", "oversized"));
+        deadLetter(sourceRecord, ref, e);
         continue;
       } catch (Exception e) {
         // Any other download problem is treated as terminal: dead-letter (with the real error) and
         // skip, rather than failing the whole message and retrying.
-        deadLetter(sourceRecord, ref, e, sourceInitializedConfig);
+        sourceInitializedConfig.deserializeFailureCounter().increase(Map.of());
+        deadLetter(sourceRecord, ref, e);
         continue;
       }
 
@@ -130,7 +138,8 @@ public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessa
         totalBytes += body.length;
       } catch (Exception e) {
         // The object's content can't be parsed; retrying won't help -> dead-letter + skip.
-        deadLetter(sourceRecord, ref, e, sourceInitializedConfig);
+        sourceInitializedConfig.deserializeFailureCounter().increase(Map.of());
+        deadLetter(sourceRecord, ref, e);
       }
     }
 
@@ -143,9 +152,7 @@ public class S3RealtimeRawDataConverter implements RawDataConverter<S3EventMessa
     return ConvertedResult.success(events, sourceRecord);
   }
 
-  private void deadLetter(
-      S3EventMessage message, S3ObjectRef ref, Exception e, SourceExecutionContext<?> ctx) {
-    ctx.deserializeFailureCounter().increase(Map.of());
+  private void deadLetter(S3EventMessage message, S3ObjectRef ref, Exception e) {
     log.error(
         "failed to process s3://{}/{} from message {}",
         ref.bucket(),

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataEncoder.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataEncoder.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.toJsonString;
+
+import io.fleak.zephflow.lib.commands.source.RawDataEncoder;
+import io.fleak.zephflow.lib.serdes.SerializedEvent;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Encodes a failed {@link S3EventMessage} for the DLQ. Object bytes are not retained on the
+ * message, so the DLQ entry captures the referenced object(s) (bucket/key) keyed by message id.
+ */
+public class S3RealtimeRawDataEncoder implements RawDataEncoder<S3EventMessage> {
+  @Override
+  public SerializedEvent serialize(S3EventMessage sourceRecord) {
+    byte[] key =
+        sourceRecord.messageId() == null
+            ? null
+            : sourceRecord.messageId().getBytes(StandardCharsets.UTF_8);
+    byte[] value = toJsonString(sourceRecord.objectRefs()).getBytes(StandardCharsets.UTF_8);
+    return new SerializedEvent(key, value, null);
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataEncoder.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataEncoder.java
@@ -13,15 +13,14 @@
  */
 package io.fleak.zephflow.lib.commands.s3realtimesource;
 
-import static io.fleak.zephflow.lib.utils.JsonUtils.toJsonString;
-
 import io.fleak.zephflow.lib.commands.source.RawDataEncoder;
 import io.fleak.zephflow.lib.serdes.SerializedEvent;
 import java.nio.charset.StandardCharsets;
 
 /**
- * Encodes a failed {@link S3EventMessage} for the DLQ. Object bytes are not retained on the
- * message, so the DLQ entry captures the referenced object(s) (bucket/key) keyed by message id.
+ * Serializes an {@link S3EventMessage} as the original SQS message body (the S3 event
+ * notification), keyed by message id — the same shape the fetcher writes to the DLQ, so the DLQ and
+ * raw-data sampling share one schema.
  */
 public class S3RealtimeRawDataEncoder implements RawDataEncoder<S3EventMessage> {
   @Override
@@ -30,7 +29,10 @@ public class S3RealtimeRawDataEncoder implements RawDataEncoder<S3EventMessage> 
         sourceRecord.messageId() == null
             ? null
             : sourceRecord.messageId().getBytes(StandardCharsets.UTF_8);
-    byte[] value = toJsonString(sourceRecord.objectRefs()).getBytes(StandardCharsets.UTF_8);
+    byte[] value =
+        sourceRecord.rawBody() == null
+            ? new byte[0]
+            : sourceRecord.rawBody().getBytes(StandardCharsets.UTF_8);
     return new SerializedEvent(key, value, null);
   }
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommand.java
@@ -79,6 +79,8 @@ public class S3RealtimeSourceCommand extends SimpleSourceCommand<S3EventMessage>
         metricClientProvider.counter(METRIC_NAME_INPUT_EVENT_COUNT, metricTags);
     FleakCounter deserializeFailureCounter =
         metricClientProvider.counter(METRIC_NAME_INPUT_DESER_ERR_COUNT, metricTags);
+    FleakCounter skippedObjectCounter =
+        metricClientProvider.counter(METRIC_NAME_SKIPPED_OBJECT_COUNT, metricTags);
 
     String keyPrefix = (String) jobContext.getOtherProperties().get(JobContext.DATA_KEY_PREFIX);
     DlqWriter dlqWriter =
@@ -107,7 +109,8 @@ public class S3RealtimeSourceCommand extends SimpleSourceCommand<S3EventMessage>
             confirmedReceiptHandles,
             dlqWriter,
             encoder,
-            nodeId);
+            nodeId,
+            skippedObjectCounter);
 
     Fetcher<S3EventMessage> fetcher =
         new S3RealtimeSourceFetcher(

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommand.java
@@ -123,6 +123,10 @@ public class S3RealtimeSourceCommand extends SimpleSourceCommand<S3EventMessage>
             nodeId,
             confirmedReceiptHandles);
 
+    // The DLQ is owned by the fetcher (it writes the single dead-letter entry when the retry cap is
+    // hit, and closes the writer). We pass null here so SimpleSourceCommand does NOT also write to
+    // the DLQ on every failed convert attempt — otherwise a message that fails and is redelivered
+    // until the cap would produce one DLQ entry per attempt.
     return new SourceExecutionContext<>(
         fetcher,
         converter,
@@ -130,7 +134,7 @@ public class S3RealtimeSourceCommand extends SimpleSourceCommand<S3EventMessage>
         dataSizeCounter,
         inputEventCounter,
         deserializeFailureCounter,
-        dlqWriter);
+        null);
   }
 
   private UsernamePasswordCredential resolveCredential(JobContext jobContext, String credentialId) {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommand.java
@@ -95,6 +95,7 @@ public class S3RealtimeSourceCommand extends SimpleSourceCommand<S3EventMessage>
     FleakDeserializer<?> deserializer =
         DeserializerFactory.createDeserializerFactory(config.getEncodingType())
             .createDeserializer();
+    RawDataEncoder<S3EventMessage> encoder = new S3RealtimeRawDataEncoder();
     RawDataConverter<S3EventMessage> converter =
         new S3RealtimeRawDataConverter(
             s3Client,
@@ -103,8 +104,10 @@ public class S3RealtimeSourceCommand extends SimpleSourceCommand<S3EventMessage>
             orDefault(
                 config.getMaxObjectSizeBytes(), S3RealtimeSourceDto.DEFAULT_MAX_OBJECT_SIZE_BYTES),
             config.isAddS3Metadata(),
-            confirmedReceiptHandles);
-    RawDataEncoder<S3EventMessage> encoder = new S3RealtimeRawDataEncoder();
+            confirmedReceiptHandles,
+            dlqWriter,
+            encoder,
+            nodeId);
 
     Fetcher<S3EventMessage> fetcher =
         new S3RealtimeSourceFetcher(
@@ -123,10 +126,9 @@ public class S3RealtimeSourceCommand extends SimpleSourceCommand<S3EventMessage>
             nodeId,
             confirmedReceiptHandles);
 
-    // The DLQ is owned by the fetcher (it writes the single dead-letter entry when the retry cap is
-    // hit, and closes the writer). We pass null here so SimpleSourceCommand does NOT also write to
-    // the DLQ on every failed convert attempt — otherwise a message that fails and is redelivered
-    // until the cap would produce one DLQ entry per attempt.
+    // Restore the framework DLQ so downstream accept() failures are captured (the converter itself
+    // dead-letters convert failures terminally, so there is no per-attempt duplicate). The context
+    // owns closing the writer.
     return new SourceExecutionContext<>(
         fetcher,
         converter,
@@ -134,7 +136,7 @@ public class S3RealtimeSourceCommand extends SimpleSourceCommand<S3EventMessage>
         dataSizeCounter,
         inputEventCounter,
         deserializeFailureCounter,
-        null);
+        dlqWriter);
   }
 
   private UsernamePasswordCredential resolveCredential(JobContext jobContext, String credentialId) {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommand.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import static io.fleak.zephflow.lib.utils.MiscUtils.*;
+
+import io.fleak.zephflow.api.*;
+import io.fleak.zephflow.api.metric.FleakCounter;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.lib.aws.AwsClientFactory;
+import io.fleak.zephflow.lib.commands.source.*;
+import io.fleak.zephflow.lib.credentials.UsernamePasswordCredential;
+import io.fleak.zephflow.lib.dlq.DlqWriter;
+import io.fleak.zephflow.lib.dlq.DlqWriterFactory;
+import io.fleak.zephflow.lib.serdes.des.DeserializerFactory;
+import io.fleak.zephflow.lib.serdes.des.FleakDeserializer;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.sqs.SqsClient;
+
+public class S3RealtimeSourceCommand extends SimpleSourceCommand<S3EventMessage> {
+
+  private final AwsClientFactory awsClientFactory;
+
+  public S3RealtimeSourceCommand(
+      String nodeId,
+      JobContext jobContext,
+      ConfigParser configParser,
+      ConfigValidator configValidator,
+      AwsClientFactory awsClientFactory) {
+    super(nodeId, jobContext, configParser, configValidator);
+    this.awsClientFactory = awsClientFactory;
+  }
+
+  @Override
+  protected ExecutionContext createExecutionContext(
+      MetricClientProvider metricClientProvider,
+      JobContext jobContext,
+      CommandConfig commandConfig,
+      String nodeId) {
+    S3RealtimeSourceDto.Config config = (S3RealtimeSourceDto.Config) commandConfig;
+
+    UsernamePasswordCredential sqsCredential =
+        resolveCredential(jobContext, config.getCredentialId());
+    String s3CredentialId =
+        StringUtils.trimToNull(config.getS3CredentialId()) != null
+            ? config.getS3CredentialId()
+            : config.getCredentialId();
+    UsernamePasswordCredential s3Credential = resolveCredential(jobContext, s3CredentialId);
+
+    SqsClient sqsClient = awsClientFactory.createSqsClient(config.getRegionStr(), sqsCredential);
+    String s3Region =
+        StringUtils.trimToNull(config.getS3RegionStr()) != null
+            ? config.getS3RegionStr()
+            : config.getRegionStr();
+    S3Client s3Client =
+        awsClientFactory.createS3Client(s3Region, s3Credential, config.getS3EndpointOverride());
+
+    Map<String, String> metricTags =
+        basicCommandMetricTags(jobContext.getMetricTags(), commandName(), nodeId);
+    FleakCounter dataSizeCounter =
+        metricClientProvider.counter(METRIC_NAME_INPUT_EVENT_SIZE_COUNT, metricTags);
+    FleakCounter inputEventCounter =
+        metricClientProvider.counter(METRIC_NAME_INPUT_EVENT_COUNT, metricTags);
+    FleakCounter deserializeFailureCounter =
+        metricClientProvider.counter(METRIC_NAME_INPUT_DESER_ERR_COUNT, metricTags);
+
+    String keyPrefix = (String) jobContext.getOtherProperties().get(JobContext.DATA_KEY_PREFIX);
+    DlqWriter dlqWriter =
+        Optional.of(jobContext)
+            .map(JobContext::getDlqConfig)
+            .map(c -> DlqWriterFactory.createDlqWriter(c, keyPrefix))
+            .orElse(null);
+    if (dlqWriter != null) {
+      dlqWriter.open();
+    }
+
+    Queue<String> confirmedReceiptHandles = new ConcurrentLinkedQueue<>();
+
+    FleakDeserializer<?> deserializer =
+        DeserializerFactory.createDeserializerFactory(config.getEncodingType())
+            .createDeserializer();
+    RawDataConverter<S3EventMessage> converter =
+        new S3RealtimeRawDataConverter(
+            s3Client,
+            deserializer,
+            config.getCompressionType(),
+            orDefault(
+                config.getMaxObjectSizeBytes(), S3RealtimeSourceDto.DEFAULT_MAX_OBJECT_SIZE_BYTES),
+            config.isAddS3Metadata(),
+            confirmedReceiptHandles);
+    RawDataEncoder<S3EventMessage> encoder = new S3RealtimeRawDataEncoder();
+
+    Fetcher<S3EventMessage> fetcher =
+        new S3RealtimeSourceFetcher(
+            sqsClient,
+            s3Client,
+            config.getQueueUrl(),
+            orDefault(
+                config.getMaxNumberOfMessages(),
+                S3RealtimeSourceDto.DEFAULT_MAX_NUMBER_OF_MESSAGES),
+            orDefault(config.getWaitTimeSeconds(), S3RealtimeSourceDto.DEFAULT_WAIT_TIME_SECONDS),
+            orDefault(
+                config.getVisibilityTimeoutSeconds(),
+                S3RealtimeSourceDto.DEFAULT_VISIBILITY_TIMEOUT_SECONDS),
+            orDefault(config.getMaxRetries(), S3RealtimeSourceDto.DEFAULT_MAX_RETRIES),
+            dlqWriter,
+            nodeId,
+            confirmedReceiptHandles);
+
+    return new SourceExecutionContext<>(
+        fetcher,
+        converter,
+        encoder,
+        dataSizeCounter,
+        inputEventCounter,
+        deserializeFailureCounter,
+        dlqWriter);
+  }
+
+  private UsernamePasswordCredential resolveCredential(JobContext jobContext, String credentialId) {
+    if (StringUtils.trimToNull(credentialId) == null) {
+      return null;
+    }
+    return lookupUsernamePasswordCredentialOpt(jobContext, credentialId).orElse(null);
+  }
+
+  private static int orDefault(Integer value, int defaultValue) {
+    return value != null ? value : defaultValue;
+  }
+
+  private static long orDefault(Long value, long defaultValue) {
+    return value != null ? value : defaultValue;
+  }
+
+  @Override
+  public SourceType sourceType() {
+    return SourceType.STREAMING;
+  }
+
+  @Override
+  public String commandName() {
+    return COMMAND_NAME_S3_REALTIME_SOURCE;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommandFactory.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommandFactory.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.lib.aws.AwsClientFactory;
+import io.fleak.zephflow.lib.commands.JsonConfigParser;
+import io.fleak.zephflow.lib.commands.source.SourceCommandFactory;
+
+public class S3RealtimeSourceCommandFactory extends SourceCommandFactory {
+  @Override
+  public S3RealtimeSourceCommand createCommand(String nodeId, JobContext jobContext) {
+    return new S3RealtimeSourceCommand(
+        nodeId,
+        jobContext,
+        new JsonConfigParser<>(S3RealtimeSourceDto.Config.class),
+        new S3RealtimeSourceConfigValidator(),
+        new AwsClientFactory());
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceConfigValidator.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceConfigValidator.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import static io.fleak.zephflow.lib.utils.MiscUtils.enforceCredentials;
+import static io.fleak.zephflow.lib.utils.MiscUtils.lookupUsernamePasswordCredential;
+
+import com.google.common.base.Preconditions;
+import io.fleak.zephflow.api.CommandConfig;
+import io.fleak.zephflow.api.ConfigValidator;
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.lib.serdes.des.DeserializerFactory;
+import org.apache.commons.lang3.StringUtils;
+
+public class S3RealtimeSourceConfigValidator implements ConfigValidator {
+  @Override
+  public void validateConfig(CommandConfig commandConfig, String nodeId, JobContext jobContext) {
+    S3RealtimeSourceDto.Config config = (S3RealtimeSourceDto.Config) commandConfig;
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.getQueueUrl()), "no queue URL is provided");
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(config.getRegionStr()), "no region is provided");
+    Preconditions.checkNotNull(config.getEncodingType(), "no encoding type is provided");
+    DeserializerFactory.validateEncodingType(config.getEncodingType());
+
+    if (config.getMaxNumberOfMessages() != null) {
+      Preconditions.checkArgument(
+          config.getMaxNumberOfMessages() >= 1
+              && config.getMaxNumberOfMessages() <= S3RealtimeSourceDto.MAX_MAX_NUMBER_OF_MESSAGES,
+          "maxNumberOfMessages must be between 1 and %s",
+          S3RealtimeSourceDto.MAX_MAX_NUMBER_OF_MESSAGES);
+    }
+
+    if (config.getWaitTimeSeconds() != null) {
+      Preconditions.checkArgument(
+          config.getWaitTimeSeconds() >= 0
+              && config.getWaitTimeSeconds() <= S3RealtimeSourceDto.MAX_WAIT_TIME_SECONDS,
+          "waitTimeSeconds must be between 0 and %s",
+          S3RealtimeSourceDto.MAX_WAIT_TIME_SECONDS);
+    }
+
+    if (config.getVisibilityTimeoutSeconds() != null) {
+      Preconditions.checkArgument(
+          config.getVisibilityTimeoutSeconds() >= 0,
+          "visibilityTimeoutSeconds must be non-negative");
+    }
+
+    if (config.getMaxObjectSizeBytes() != null) {
+      Preconditions.checkArgument(
+          config.getMaxObjectSizeBytes() > 0, "maxObjectSizeBytes must be positive");
+    }
+
+    if (config.getMaxRetries() != null) {
+      Preconditions.checkArgument(config.getMaxRetries() >= 1, "maxRetries must be at least 1");
+    }
+
+    if (enforceCredentials(jobContext)) {
+      if (StringUtils.trimToNull(config.getCredentialId()) != null) {
+        lookupUsernamePasswordCredential(jobContext, config.getCredentialId());
+      }
+      if (StringUtils.trimToNull(config.getS3CredentialId()) != null) {
+        lookupUsernamePasswordCredential(jobContext, config.getS3CredentialId());
+      }
+    }
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceDto.java
@@ -24,7 +24,10 @@ public interface S3RealtimeSourceDto {
   int MAX_MAX_NUMBER_OF_MESSAGES = 10;
   int DEFAULT_WAIT_TIME_SECONDS = 20;
   int MAX_WAIT_TIME_SECONDS = 20;
-  int DEFAULT_VISIBILITY_TIMEOUT_SECONDS = 30;
+  // Generous default so a single large object's download + decompress + deserialize finishes before
+  // the message becomes visible again. Operators with large objects/slow processing should raise
+  // it.
+  int DEFAULT_VISIBILITY_TIMEOUT_SECONDS = 300;
   long DEFAULT_MAX_OBJECT_SIZE_BYTES = 256L * 1024 * 1024;
   int DEFAULT_MAX_RETRIES = 5;
 
@@ -65,6 +68,14 @@ public interface S3RealtimeSourceDto {
 
     @Builder.Default private Integer maxNumberOfMessages = DEFAULT_MAX_NUMBER_OF_MESSAGES;
     @Builder.Default private Integer waitTimeSeconds = DEFAULT_WAIT_TIME_SECONDS;
+
+    /**
+     * SQS visibility timeout (seconds). A message is deleted only after its object is fully
+     * downloaded, decompressed, and deserialized; if that takes longer than this window the message
+     * becomes visible again and is reprocessed, causing duplicate emits. Size this above the
+     * expected worst-case processing time, which grows with {@code maxObjectSizeBytes} (and more so
+     * for compressed objects).
+     */
     @Builder.Default private Integer visibilityTimeoutSeconds = DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
 
     /**

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceDto.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import io.fleak.zephflow.api.CommandConfig;
+import io.fleak.zephflow.lib.serdes.CompressionType;
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import lombok.*;
+
+public interface S3RealtimeSourceDto {
+
+  int DEFAULT_MAX_NUMBER_OF_MESSAGES = 10;
+  int MAX_MAX_NUMBER_OF_MESSAGES = 10;
+  int DEFAULT_WAIT_TIME_SECONDS = 20;
+  int MAX_WAIT_TIME_SECONDS = 20;
+  int DEFAULT_VISIBILITY_TIMEOUT_SECONDS = 30;
+  long DEFAULT_MAX_OBJECT_SIZE_BYTES = 256L * 1024 * 1024;
+  int DEFAULT_MAX_RETRIES = 5;
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  class Config implements CommandConfig {
+    /** URL of the SQS queue receiving the S3 event notifications. */
+    @NonNull private String queueUrl;
+
+    /** Region of the SQS queue. */
+    @NonNull private String regionStr;
+
+    /** Encoding of the referenced S3 objects' content. */
+    @NonNull private EncodingType encodingType;
+
+    /**
+     * Compression of the referenced S3 objects. When null, gzip is auto-detected from the object's
+     * magic bytes (so plain and gzipped objects both work); set {@code GZIP} to force
+     * decompression.
+     */
+    private CompressionType compressionType;
+
+    /** Credential used for both SQS and S3 (falls back to the default AWS credential chain). */
+    private String credentialId;
+
+    /**
+     * Optional S3 credential override for cross-account buckets; defaults to {@code credentialId}.
+     */
+    private String s3CredentialId;
+
+    /** Optional S3 region; defaults to {@code regionStr}. */
+    private String s3RegionStr;
+
+    /** Optional S3 endpoint override (e.g. MinIO/localstack). */
+    private String s3EndpointOverride;
+
+    @Builder.Default private Integer maxNumberOfMessages = DEFAULT_MAX_NUMBER_OF_MESSAGES;
+    @Builder.Default private Integer waitTimeSeconds = DEFAULT_WAIT_TIME_SECONDS;
+    @Builder.Default private Integer visibilityTimeoutSeconds = DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
+
+    /** Objects larger than this are sent to the DLQ instead of being downloaded. */
+    @Builder.Default private Long maxObjectSizeBytes = DEFAULT_MAX_OBJECT_SIZE_BYTES;
+
+    /** In-app retry cap: messages whose ApproximateReceiveCount exceeds this are dead-lettered. */
+    @Builder.Default private Integer maxRetries = DEFAULT_MAX_RETRIES;
+
+    /** When true, enrich each emitted record with {@code __s3_bucket} / {@code __s3_key}. */
+    @Builder.Default private boolean addS3Metadata = false;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceDto.java
@@ -79,8 +79,8 @@ public interface S3RealtimeSourceDto {
     @Builder.Default private Integer visibilityTimeoutSeconds = DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
 
     /**
-     * Objects whose size exceeds this are skipped (and logged) and the notification is
-     * acknowledged; the object's content is not downloaded.
+     * Objects whose size exceeds this are dead-lettered (the notification + reason) and the message
+     * is acknowledged; the object's content is not downloaded.
      */
     @Builder.Default private Long maxObjectSizeBytes = DEFAULT_MAX_OBJECT_SIZE_BYTES;
 

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceDto.java
@@ -67,7 +67,10 @@ public interface S3RealtimeSourceDto {
     @Builder.Default private Integer waitTimeSeconds = DEFAULT_WAIT_TIME_SECONDS;
     @Builder.Default private Integer visibilityTimeoutSeconds = DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
 
-    /** Objects larger than this are sent to the DLQ instead of being downloaded. */
+    /**
+     * Objects whose size exceeds this are skipped (and logged) and the notification is
+     * acknowledged; the object's content is not downloaded.
+     */
     @Builder.Default private Long maxObjectSizeBytes = DEFAULT_MAX_OBJECT_SIZE_BYTES;
 
     /** In-app retry cap: messages whose ApproximateReceiveCount exceeds this are dead-lettered. */

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcher.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import io.fleak.zephflow.lib.commands.source.CommitStrategy;
+import io.fleak.zephflow.lib.commands.source.Fetcher;
+import io.fleak.zephflow.lib.commands.source.PerRecordCommitStrategy;
+import io.fleak.zephflow.lib.dlq.DlqWriter;
+import io.fleak.zephflow.lib.serdes.SerializedEvent;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+
+/**
+ * Long-polls SQS for S3 event notifications and turns each message into an {@link S3EventMessage}
+ * (object references only — no S3 I/O happens here). Enforces an in-app retry cap based on the
+ * message's {@code ApproximateReceiveCount}: once exceeded the message is dead-lettered and deleted
+ * rather than reprocessed.
+ */
+@Slf4j
+public class S3RealtimeSourceFetcher implements Fetcher<S3EventMessage> {
+
+  private final SqsClient sqsClient;
+  // Held only so the shared S3 client is closed when this fetcher is closed by the execution
+  // context; the actual S3 reads happen in S3RealtimeRawDataConverter.
+  private final S3Client s3Client;
+  private final String queueUrl;
+  private final int maxNumberOfMessages;
+  private final int waitTimeSeconds;
+  private final int visibilityTimeoutSeconds;
+  private final int maxRetries;
+  private final DlqWriter dlqWriter;
+  private final String nodeId;
+
+  // Receipt handles of messages whose records were successfully converted+emitted. The converter
+  // adds to this queue on success; the committer drains it. Failed messages are never added, so
+  // they are left undeleted for SQS redelivery.
+  private final Queue<String> confirmedReceiptHandles;
+
+  public S3RealtimeSourceFetcher(
+      SqsClient sqsClient,
+      S3Client s3Client,
+      String queueUrl,
+      int maxNumberOfMessages,
+      int waitTimeSeconds,
+      int visibilityTimeoutSeconds,
+      int maxRetries,
+      DlqWriter dlqWriter,
+      String nodeId,
+      Queue<String> confirmedReceiptHandles) {
+    this.sqsClient = sqsClient;
+    this.s3Client = s3Client;
+    this.queueUrl = queueUrl;
+    this.maxNumberOfMessages = maxNumberOfMessages;
+    this.waitTimeSeconds = waitTimeSeconds;
+    this.visibilityTimeoutSeconds = visibilityTimeoutSeconds;
+    this.maxRetries = maxRetries;
+    this.dlqWriter = dlqWriter;
+    this.nodeId = nodeId;
+    this.confirmedReceiptHandles = confirmedReceiptHandles;
+  }
+
+  @Override
+  public List<S3EventMessage> fetch() {
+    ReceiveMessageRequest request =
+        ReceiveMessageRequest.builder()
+            .queueUrl(queueUrl)
+            .maxNumberOfMessages(maxNumberOfMessages)
+            .waitTimeSeconds(waitTimeSeconds)
+            .visibilityTimeout(visibilityTimeoutSeconds)
+            .messageSystemAttributeNames(MessageSystemAttributeName.APPROXIMATE_RECEIVE_COUNT)
+            .build();
+
+    ReceiveMessageResponse response = sqsClient.receiveMessage(request);
+    List<Message> messages = response.messages();
+    if (messages == null || messages.isEmpty()) {
+      return List.of();
+    }
+
+    List<S3EventMessage> result = new ArrayList<>(messages.size());
+    for (Message message : messages) {
+      List<S3ObjectRef> refs;
+      try {
+        refs = S3EventNotificationParser.parse(message.body());
+      } catch (Exception e) {
+        // Malformed envelope can never succeed; dead-letter and remove it.
+        deadLetter(message, "failed to parse S3 event notification: " + e.getMessage());
+        deleteMessage(message.receiptHandle());
+        continue;
+      }
+
+      if (refs.isEmpty()) {
+        // s3:TestEvent or non-ObjectCreated event: nothing to process, just acknowledge.
+        log.debug("skipping SQS message {} with no ObjectCreated records", message.messageId());
+        deleteMessage(message.receiptHandle());
+        continue;
+      }
+
+      if (receiveCount(message) > maxRetries) {
+        deadLetter(message, "exceeded maxRetries=" + maxRetries);
+        deleteMessage(message.receiptHandle());
+        continue;
+      }
+
+      result.add(new S3EventMessage(message.messageId(), message.receiptHandle(), refs));
+    }
+
+    log.debug("fetched {} S3 event messages from queue {}", result.size(), queueUrl);
+    return result;
+  }
+
+  @Override
+  public boolean isExhausted() {
+    return false;
+  }
+
+  @Override
+  public Committer committer() {
+    return () -> {
+      String receiptHandle;
+      while ((receiptHandle = confirmedReceiptHandles.poll()) != null) {
+        deleteMessage(receiptHandle);
+      }
+    };
+  }
+
+  @Override
+  public CommitStrategy commitStrategy() {
+    return PerRecordCommitStrategy.INSTANCE;
+  }
+
+  @Override
+  public void close() {
+    if (sqsClient != null) {
+      sqsClient.close();
+    }
+    if (s3Client != null) {
+      s3Client.close();
+    }
+  }
+
+  private int receiveCount(Message message) {
+    String value = message.attributes().get(MessageSystemAttributeName.APPROXIMATE_RECEIVE_COUNT);
+    if (value == null) {
+      return 1;
+    }
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      return 1;
+    }
+  }
+
+  private void deadLetter(Message message, String errorMsg) {
+    if (dlqWriter == null) {
+      log.warn("dropping SQS message {} (no DLQ configured): {}", message.messageId(), errorMsg);
+      return;
+    }
+    SerializedEvent raw =
+        new SerializedEvent(
+            message.messageId() == null
+                ? null
+                : message.messageId().getBytes(StandardCharsets.UTF_8),
+            message.body().getBytes(StandardCharsets.UTF_8),
+            null);
+    dlqWriter.writeToDlq(System.currentTimeMillis(), raw, errorMsg, nodeId);
+  }
+
+  private void deleteMessage(String receiptHandle) {
+    try {
+      sqsClient.deleteMessage(
+          DeleteMessageRequest.builder().queueUrl(queueUrl).receiptHandle(receiptHandle).build());
+    } catch (Exception e) {
+      log.error("failed to delete SQS message with receiptHandle: {}", receiptHandle, e);
+    }
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcher.java
@@ -157,6 +157,13 @@ public class S3RealtimeSourceFetcher implements Fetcher<S3EventMessage> {
     if (s3Client != null) {
       s3Client.close();
     }
+    if (dlqWriter != null) {
+      try {
+        dlqWriter.close();
+      } catch (Exception e) {
+        log.warn("failed to close DLQ writer", e);
+      }
+    }
   }
 
   private int receiveCount(Message message) {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcher.java
@@ -158,13 +158,7 @@ public class S3RealtimeSourceFetcher implements Fetcher<S3EventMessage> {
     if (s3Client != null) {
       s3Client.close();
     }
-    if (dlqWriter != null) {
-      try {
-        dlqWriter.close();
-      } catch (Exception e) {
-        log.warn("failed to close DLQ writer", e);
-      }
-    }
+    // The DLQ writer is owned (and closed) by the SourceExecutionContext.
   }
 
   private int receiveCount(Message message) {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcher.java
@@ -122,7 +122,8 @@ public class S3RealtimeSourceFetcher implements Fetcher<S3EventMessage> {
         continue;
       }
 
-      result.add(new S3EventMessage(message.messageId(), message.receiptHandle(), refs));
+      result.add(
+          new S3EventMessage(message.messageId(), message.receiptHandle(), message.body(), refs));
     }
 
     log.debug("fetched {} S3 event messages from queue {}", result.size(), queueUrl);

--- a/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
@@ -96,6 +96,7 @@ public interface MiscUtils {
   String COMMAND_NAME_JDBC_SINK = "jdbcsink";
   String COMMAND_NAME_SQS_SOURCE = "sqssource";
   String COMMAND_NAME_SQS_SINK = "sqssink";
+  String COMMAND_NAME_S3_REALTIME_SOURCE = "s3rtsource";
   String COMMAND_NAME_IMAP_SOURCE = "imapsource";
   String COMMAND_NAME_SMTP_SINK = "smtpsink";
   String COMMAND_NAME_LDAP_SOURCE = "ldapsource";

--- a/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
@@ -112,6 +112,7 @@ public interface MiscUtils {
   String METRIC_NAME_INPUT_EVENT_COUNT = "input_event_count";
   String METRIC_NAME_INPUT_EVENT_SIZE_COUNT = "input_event_size";
   String METRIC_NAME_INPUT_DESER_ERR_COUNT = "input_deser_err_count";
+  String METRIC_NAME_SKIPPED_OBJECT_COUNT = "input_skipped_object_count";
   String METRIC_NAME_OUTPUT_EVENT_COUNT = "output_event_count";
   String METRIC_NAME_OUTPUT_EVENT_SIZE_COUNT = "output_event_size";
   String METRIC_NAME_ERROR_EVENT_COUNT = "error_event_count";

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/OperatorCommandRegistryTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/OperatorCommandRegistryTest.java
@@ -52,6 +52,7 @@ class OperatorCommandRegistryTest {
             .add(COMMAND_NAME_JDBC_SOURCE)
             .add(COMMAND_NAME_SQS_SINK)
             .add(COMMAND_NAME_SQS_SOURCE)
+            .add(COMMAND_NAME_S3_REALTIME_SOURCE)
             .add(COMMAND_NAME_IMAP_SOURCE)
             .add(COMMAND_NAME_SMTP_SINK)
             .add(COMMAND_NAME_LDAP_SOURCE)

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3EventNotificationParserTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3EventNotificationParserTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class S3EventNotificationParserTest {
+
+  @Test
+  void parse_directNotification() {
+    String body =
+        """
+        {"Records":[{"eventName":"ObjectCreated:Put",
+          "s3":{"bucket":{"name":"my-bucket"},"object":{"key":"path/to/file.json","size":42}}}]}
+        """;
+    assertEquals(List.of(new S3ObjectRef("my-bucket", "path/to/file.json")), parse(body));
+  }
+
+  @Test
+  void parse_snsWrappedNotification() {
+    String inner =
+        "{\"Records\":[{\"eventName\":\"ObjectCreated:Post\","
+            + "\"s3\":{\"bucket\":{\"name\":\"b\"},\"object\":{\"key\":\"k.csv\"}}}]}";
+    String body =
+        "{\"Type\":\"Notification\",\"TopicArn\":\"arn:aws:sns:us-east-1:123:topic\","
+            + "\"Message\":"
+            + quote(inner)
+            + "}";
+    assertEquals(List.of(new S3ObjectRef("b", "k.csv")), parse(body));
+  }
+
+  @Test
+  void parse_testEventReturnsEmpty() {
+    String body =
+        """
+        {"Service":"Amazon S3","Event":"s3:TestEvent","Time":"2025-01-01T00:00:00.000Z",
+         "Bucket":"my-bucket","RequestId":"abc","HostId":"xyz"}
+        """;
+    assertEquals(List.of(), parse(body));
+  }
+
+  @Test
+  void parse_objectRemovedSkipped() {
+    String body =
+        """
+        {"Records":[{"eventName":"ObjectRemoved:Delete",
+          "s3":{"bucket":{"name":"b"},"object":{"key":"gone.json"}}}]}
+        """;
+    assertEquals(List.of(), parse(body));
+  }
+
+  @Test
+  void parse_urlEncodedKeys() {
+    String body =
+        """
+        {"Records":[
+          {"eventName":"ObjectCreated:Put","s3":{"bucket":{"name":"b"},"object":{"key":"a+b.json"}}},
+          {"eventName":"ObjectCreated:Put","s3":{"bucket":{"name":"b"},"object":{"key":"dir/with%20space.json"}}},
+          {"eventName":"ObjectCreated:Put","s3":{"bucket":{"name":"b"},"object":{"key":"100%25.json"}}}
+        ]}
+        """;
+    assertEquals(
+        List.of(
+            new S3ObjectRef("b", "a b.json"),
+            new S3ObjectRef("b", "dir/with space.json"),
+            new S3ObjectRef("b", "100%.json")),
+        parse(body));
+  }
+
+  @Test
+  void parse_multipleRecordsMixedEvents() {
+    String body =
+        """
+        {"Records":[
+          {"eventName":"ObjectCreated:Put","s3":{"bucket":{"name":"b1"},"object":{"key":"k1"}}},
+          {"eventName":"ObjectRemoved:Delete","s3":{"bucket":{"name":"b1"},"object":{"key":"k2"}}},
+          {"eventName":"ObjectCreated:CompleteMultipartUpload","s3":{"bucket":{"name":"b2"},"object":{"key":"k3"}}}
+        ]}
+        """;
+    assertEquals(List.of(new S3ObjectRef("b1", "k1"), new S3ObjectRef("b2", "k3")), parse(body));
+  }
+
+  @Test
+  void parse_malformedThrows() {
+    assertThrows(IllegalArgumentException.class, () -> parse("not json"));
+  }
+
+  private static List<S3ObjectRef> parse(String body) {
+    return S3EventNotificationParser.parse(body);
+  }
+
+  private static String quote(String s) {
+    return "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverterTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverterTest.java
@@ -22,6 +22,7 @@ import io.fleak.zephflow.api.structure.FleakData;
 import io.fleak.zephflow.api.structure.RecordFleakData;
 import io.fleak.zephflow.lib.commands.source.ConvertedResult;
 import io.fleak.zephflow.lib.commands.source.SourceExecutionContext;
+import io.fleak.zephflow.lib.dlq.DlqWriter;
 import io.fleak.zephflow.lib.serdes.CompressionType;
 import io.fleak.zephflow.lib.serdes.EncodingType;
 import io.fleak.zephflow.lib.serdes.des.DeserializerFactory;
@@ -49,12 +50,14 @@ class S3RealtimeRawDataConverterTest {
 
   private S3Client s3Client;
   private Queue<String> confirmed;
+  private DlqWriter dlqWriter;
   private SourceExecutionContext<S3EventMessage> ctx;
 
   @BeforeEach
   void setUp() {
     s3Client = mock(S3Client.class);
     confirmed = new ConcurrentLinkedQueue<>();
+    dlqWriter = mock(DlqWriter.class);
     ctx =
         new SourceExecutionContext<>(
             null,
@@ -75,7 +78,15 @@ class S3RealtimeRawDataConverterTest {
     FleakDeserializer<?> deserializer =
         DeserializerFactory.createDeserializerFactory(encodingType).createDeserializer();
     return new S3RealtimeRawDataConverter(
-        s3Client, deserializer, compressionType, MAX_OBJECT_SIZE, addS3Metadata, confirmed);
+        s3Client,
+        deserializer,
+        compressionType,
+        MAX_OBJECT_SIZE,
+        addS3Metadata,
+        confirmed,
+        dlqWriter,
+        new S3RealtimeRawDataEncoder(),
+        "node");
   }
 
   private void stubGetObject(String bucket, String key, byte[] data) {
@@ -157,10 +168,11 @@ class S3RealtimeRawDataConverterTest {
     ConvertedResult<S3EventMessage> result =
         converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
 
-    // Oversized is terminal: skip + acknowledge (no records), not a retryable failure.
+    // Oversized is a benign skip: acknowledge (no records), no DLQ, not a retryable failure.
     assertNull(result.error());
     assertEquals(List.of(), result.transformedData());
     assertEquals(List.of("r1"), List.copyOf(confirmed));
+    verifyNoInteractions(dlqWriter);
   }
 
   @Test
@@ -176,27 +188,65 @@ class S3RealtimeRawDataConverterTest {
     ConvertedResult<S3EventMessage> result =
         converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
 
-    // A deleted object is acknowledged (success with no records), not failed -> message gets
-    // deleted.
+    // A deleted object is a benign skip: acknowledged (no records), no DLQ.
     assertNull(result.error());
     assertEquals(List.of(), result.transformedData());
     assertEquals(List.of("r1"), List.copyOf(confirmed));
+    verifyNoInteractions(dlqWriter);
   }
 
   @Test
-  void convert_deserializeFailureNotConfirmed() {
-    when(s3Client.getObject(any(GetObjectRequest.class)))
-        .thenThrow(new RuntimeException("s3 down"));
+  void convert_deserializeFailureDlqdAndAcknowledged() {
+    stubGetObject("b", "bad.jsonl", "not valid json".getBytes(StandardCharsets.UTF_8));
     S3EventMessage msg =
-        new S3EventMessage("m1", "r1", null, List.of(new S3ObjectRef("b", "k.json")));
+        new S3EventMessage("m1", "r1", "raw-body", List.of(new S3ObjectRef("b", "bad.jsonl")));
 
     ConvertedResult<S3EventMessage> result =
         converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
 
-    assertNull(result.transformedData());
-    assertNotNull(result.error());
-    assertEquals(msg, result.sourceRecord());
-    assertTrue(confirmed.isEmpty());
+    // Terminal: dead-lettered with the real error + acknowledged, not a retryable failure.
+    assertNull(result.error());
+    assertEquals(List.of(), result.transformedData());
+    assertEquals(List.of("r1"), List.copyOf(confirmed));
+    verify(dlqWriter)
+        .writeToDlq(anyLong(), any(), contains("failed to process s3://b/bad.jsonl"), eq("node"));
+  }
+
+  @Test
+  void convert_downloadFailureDlqdAndAcknowledged() {
+    when(s3Client.getObject(any(GetObjectRequest.class)))
+        .thenThrow(new RuntimeException("s3 unavailable"));
+    S3EventMessage msg =
+        new S3EventMessage("m1", "r1", "raw-body", List.of(new S3ObjectRef("b", "k.json")));
+
+    ConvertedResult<S3EventMessage> result =
+        converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
+
+    assertNull(result.error());
+    assertEquals(List.of(), result.transformedData());
+    assertEquals(List.of("r1"), List.copyOf(confirmed));
+    verify(dlqWriter).writeToDlq(anyLong(), any(), contains("s3 unavailable"), eq("node"));
+  }
+
+  @Test
+  void convert_multiObjectPartialFailureEmitsGoodAndDlqsBad() {
+    stubGetObject("b", "good.jsonl", "{\"msg\":\"a\"}".getBytes(StandardCharsets.UTF_8));
+    stubGetObject("b", "bad.jsonl", "not valid json".getBytes(StandardCharsets.UTF_8));
+    S3EventMessage msg =
+        new S3EventMessage(
+            "m1",
+            "r1",
+            "raw-body",
+            List.of(new S3ObjectRef("b", "good.jsonl"), new S3ObjectRef("b", "bad.jsonl")));
+
+    ConvertedResult<S3EventMessage> result =
+        converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
+
+    // Good object emitted, bad object dead-lettered, message acknowledged.
+    assertEquals(List.of(record(Map.of("msg", "a"))), result.transformedData());
+    assertEquals(List.of("r1"), List.copyOf(confirmed));
+    verify(dlqWriter)
+        .writeToDlq(anyLong(), any(), contains("failed to process s3://b/bad.jsonl"), eq("node"));
   }
 
   @Test

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverterTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverterTest.java
@@ -156,23 +156,25 @@ class S3RealtimeRawDataConverterTest {
   }
 
   @Test
-  void convert_oversizedObjectSkippedAndAcknowledged() {
+  void convert_oversizedObjectDlqdAndAcknowledged() {
     ResponseInputStream<GetObjectResponse> stream =
         new ResponseInputStream<>(
             GetObjectResponse.builder().contentLength(MAX_OBJECT_SIZE + 1).build(),
             AbortableInputStream.create(new ByteArrayInputStream(new byte[0])));
     when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(stream);
     S3EventMessage msg =
-        new S3EventMessage("m1", "r1", null, List.of(new S3ObjectRef("b", "big.json")));
+        new S3EventMessage("m1", "r1", "raw-body", List.of(new S3ObjectRef("b", "big.json")));
 
     ConvertedResult<S3EventMessage> result =
         converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
 
-    // Oversized is a benign skip: acknowledge (no records), no DLQ, not a retryable failure.
+    // Oversized is a real drop (the object exists): dead-lettered with the reason + acknowledged,
+    // not silently skipped.
     assertNull(result.error());
     assertEquals(List.of(), result.transformedData());
     assertEquals(List.of("r1"), List.copyOf(confirmed));
-    verifyNoInteractions(dlqWriter);
+    verify(dlqWriter)
+        .writeToDlq(anyLong(), any(), contains("exceeds maxObjectSizeBytes"), eq("node"));
   }
 
   @Test

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverterTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverterTest.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.fleak.zephflow.api.metric.FleakCounter;
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.source.ConvertedResult;
+import io.fleak.zephflow.lib.commands.source.SourceExecutionContext;
+import io.fleak.zephflow.lib.serdes.CompressionType;
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import io.fleak.zephflow.lib.serdes.des.DeserializerFactory;
+import io.fleak.zephflow.lib.serdes.des.FleakDeserializer;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.zip.GZIPOutputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+class S3RealtimeRawDataConverterTest {
+
+  private static final long MAX_OBJECT_SIZE = 1024 * 1024;
+
+  private S3Client s3Client;
+  private Queue<String> confirmed;
+  private SourceExecutionContext<S3EventMessage> ctx;
+
+  @BeforeEach
+  void setUp() {
+    s3Client = mock(S3Client.class);
+    confirmed = new ConcurrentLinkedQueue<>();
+    ctx =
+        new SourceExecutionContext<>(
+            null,
+            null,
+            null,
+            mock(FleakCounter.class),
+            mock(FleakCounter.class),
+            mock(FleakCounter.class),
+            null);
+  }
+
+  private S3RealtimeRawDataConverter converter(EncodingType encodingType, boolean addS3Metadata) {
+    return converter(encodingType, addS3Metadata, null);
+  }
+
+  private S3RealtimeRawDataConverter converter(
+      EncodingType encodingType, boolean addS3Metadata, CompressionType compressionType) {
+    FleakDeserializer<?> deserializer =
+        DeserializerFactory.createDeserializerFactory(encodingType).createDeserializer();
+    return new S3RealtimeRawDataConverter(
+        s3Client, deserializer, compressionType, MAX_OBJECT_SIZE, addS3Metadata, confirmed);
+  }
+
+  private void stubGetObject(String bucket, String key, byte[] data) {
+    ResponseInputStream<GetObjectResponse> stream =
+        new ResponseInputStream<>(
+            GetObjectResponse.builder().contentLength((long) data.length).build(),
+            AbortableInputStream.create(new ByteArrayInputStream(data)));
+    when(s3Client.getObject(argThatMatches(bucket, key))).thenReturn(stream);
+  }
+
+  private static GetObjectRequest argThatMatches(String bucket, String key) {
+    return org.mockito.ArgumentMatchers.argThat(
+        (GetObjectRequest r) -> r != null && bucket.equals(r.bucket()) && key.equals(r.key()));
+  }
+
+  @Test
+  void convert_jsonObjectLineSuccess() {
+    byte[] body = "{\"msg\":\"a\"}\n{\"msg\":\"b\"}".getBytes(StandardCharsets.UTF_8);
+    stubGetObject("b", "k.jsonl", body);
+    S3EventMessage msg = new S3EventMessage("m1", "r1", List.of(new S3ObjectRef("b", "k.jsonl")));
+
+    ConvertedResult<S3EventMessage> result =
+        converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
+
+    List<RecordFleakData> expected =
+        List.of(record(Map.of("msg", "a")), record(Map.of("msg", "b")));
+    assertEquals(expected, result.transformedData());
+    assertNull(result.error());
+    assertEquals(List.of("r1"), List.copyOf(confirmed));
+  }
+
+  @Test
+  void convert_addsS3Metadata() {
+    byte[] body = "{\"msg\":\"a\"}".getBytes(StandardCharsets.UTF_8);
+    stubGetObject("my-bucket", "dir/k.json", body);
+    S3EventMessage msg =
+        new S3EventMessage("m1", "r1", List.of(new S3ObjectRef("my-bucket", "dir/k.json")));
+
+    ConvertedResult<S3EventMessage> result =
+        converter(EncodingType.JSON_OBJECT_LINE, true).convert(msg, ctx);
+
+    Map<String, Object> expectedPayload = new LinkedHashMap<>();
+    expectedPayload.put("msg", "a");
+    expectedPayload.put("__s3_bucket", "my-bucket");
+    expectedPayload.put("__s3_key", "dir/k.json");
+    assertEquals(List.of(record(expectedPayload)), result.transformedData());
+  }
+
+  @Test
+  void convert_multipleRefsDownloadedOneAtATime() {
+    stubGetObject("b", "k1.jsonl", "{\"msg\":\"a\"}".getBytes(StandardCharsets.UTF_8));
+    stubGetObject("b", "k2.jsonl", "{\"msg\":\"b\"}".getBytes(StandardCharsets.UTF_8));
+    S3EventMessage msg =
+        new S3EventMessage(
+            "m1",
+            "r1",
+            List.of(new S3ObjectRef("b", "k1.jsonl"), new S3ObjectRef("b", "k2.jsonl")));
+
+    ConvertedResult<S3EventMessage> result =
+        converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
+
+    assertEquals(
+        List.of(record(Map.of("msg", "a")), record(Map.of("msg", "b"))), result.transformedData());
+    verify(s3Client, times(2)).getObject(any(GetObjectRequest.class));
+  }
+
+  @Test
+  void convert_oversizedObjectFails() {
+    ResponseInputStream<GetObjectResponse> stream =
+        new ResponseInputStream<>(
+            GetObjectResponse.builder().contentLength(MAX_OBJECT_SIZE + 1).build(),
+            AbortableInputStream.create(new ByteArrayInputStream(new byte[0])));
+    when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(stream);
+    S3EventMessage msg = new S3EventMessage("m1", "r1", List.of(new S3ObjectRef("b", "big.json")));
+
+    ConvertedResult<S3EventMessage> result =
+        converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
+
+    assertNull(result.transformedData());
+    assertNotNull(result.error());
+    assertTrue(confirmed.isEmpty());
+  }
+
+  @Test
+  void convert_missingObjectSkippedAndAcknowledged() {
+    when(s3Client.getObject(any(GetObjectRequest.class)))
+        .thenThrow(
+            software.amazon.awssdk.services.s3.model.NoSuchKeyException.builder()
+                .message("The specified key does not exist.")
+                .build());
+    S3EventMessage msg =
+        new S3EventMessage("m1", "r1", List.of(new S3ObjectRef("b", "gone.jsonl")));
+
+    ConvertedResult<S3EventMessage> result =
+        converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
+
+    // A deleted object is acknowledged (success with no records), not failed -> message gets
+    // deleted.
+    assertNull(result.error());
+    assertEquals(List.of(), result.transformedData());
+    assertEquals(List.of("r1"), List.copyOf(confirmed));
+  }
+
+  @Test
+  void convert_deserializeFailureNotConfirmed() {
+    when(s3Client.getObject(any(GetObjectRequest.class)))
+        .thenThrow(new RuntimeException("s3 down"));
+    S3EventMessage msg = new S3EventMessage("m1", "r1", List.of(new S3ObjectRef("b", "k.json")));
+
+    ConvertedResult<S3EventMessage> result =
+        converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
+
+    assertNull(result.transformedData());
+    assertNotNull(result.error());
+    assertEquals(msg, result.sourceRecord());
+    assertTrue(confirmed.isEmpty());
+  }
+
+  @Test
+  void convert_autoDetectsGzip() {
+    stubGetObject("b", "data.jsonl.gz", gzip("{\"msg\":\"a\"}\n{\"msg\":\"b\"}"));
+    S3EventMessage msg =
+        new S3EventMessage("m1", "r1", List.of(new S3ObjectRef("b", "data.jsonl.gz")));
+
+    ConvertedResult<S3EventMessage> result =
+        converter(EncodingType.JSON_OBJECT_LINE, false, null).convert(msg, ctx);
+
+    assertEquals(
+        List.of(record(Map.of("msg", "a")), record(Map.of("msg", "b"))), result.transformedData());
+    assertNull(result.error());
+  }
+
+  @Test
+  void convert_explicitGzip() {
+    stubGetObject("b", "data", gzip("{\"msg\":\"a\"}"));
+    S3EventMessage msg = new S3EventMessage("m1", "r1", List.of(new S3ObjectRef("b", "data")));
+
+    ConvertedResult<S3EventMessage> result =
+        converter(EncodingType.JSON_OBJECT_LINE, false, CompressionType.GZIP).convert(msg, ctx);
+
+    assertEquals(List.of(record(Map.of("msg", "a"))), result.transformedData());
+  }
+
+  private static RecordFleakData record(Map<String, Object> payload) {
+    return (RecordFleakData) FleakData.wrap(payload);
+  }
+
+  private static byte[] gzip(String content) {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (GZIPOutputStream gos = new GZIPOutputStream(bos)) {
+      gos.write(content.getBytes(StandardCharsets.UTF_8));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return bos.toByteArray();
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverterTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverterTest.java
@@ -143,7 +143,7 @@ class S3RealtimeRawDataConverterTest {
   }
 
   @Test
-  void convert_oversizedObjectFails() {
+  void convert_oversizedObjectSkippedAndAcknowledged() {
     ResponseInputStream<GetObjectResponse> stream =
         new ResponseInputStream<>(
             GetObjectResponse.builder().contentLength(MAX_OBJECT_SIZE + 1).build(),
@@ -154,9 +154,10 @@ class S3RealtimeRawDataConverterTest {
     ConvertedResult<S3EventMessage> result =
         converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
 
-    assertNull(result.transformedData());
-    assertNotNull(result.error());
-    assertTrue(confirmed.isEmpty());
+    // Oversized is terminal: skip + acknowledge (no records), not a retryable failure.
+    assertNull(result.error());
+    assertEquals(List.of(), result.transformedData());
+    assertEquals(List.of("r1"), List.copyOf(confirmed));
   }
 
   @Test

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverterTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverterTest.java
@@ -95,7 +95,8 @@ class S3RealtimeRawDataConverterTest {
   void convert_jsonObjectLineSuccess() {
     byte[] body = "{\"msg\":\"a\"}\n{\"msg\":\"b\"}".getBytes(StandardCharsets.UTF_8);
     stubGetObject("b", "k.jsonl", body);
-    S3EventMessage msg = new S3EventMessage("m1", "r1", List.of(new S3ObjectRef("b", "k.jsonl")));
+    S3EventMessage msg =
+        new S3EventMessage("m1", "r1", null, List.of(new S3ObjectRef("b", "k.jsonl")));
 
     ConvertedResult<S3EventMessage> result =
         converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
@@ -112,7 +113,7 @@ class S3RealtimeRawDataConverterTest {
     byte[] body = "{\"msg\":\"a\"}".getBytes(StandardCharsets.UTF_8);
     stubGetObject("my-bucket", "dir/k.json", body);
     S3EventMessage msg =
-        new S3EventMessage("m1", "r1", List.of(new S3ObjectRef("my-bucket", "dir/k.json")));
+        new S3EventMessage("m1", "r1", null, List.of(new S3ObjectRef("my-bucket", "dir/k.json")));
 
     ConvertedResult<S3EventMessage> result =
         converter(EncodingType.JSON_OBJECT_LINE, true).convert(msg, ctx);
@@ -132,6 +133,7 @@ class S3RealtimeRawDataConverterTest {
         new S3EventMessage(
             "m1",
             "r1",
+            null,
             List.of(new S3ObjectRef("b", "k1.jsonl"), new S3ObjectRef("b", "k2.jsonl")));
 
     ConvertedResult<S3EventMessage> result =
@@ -149,7 +151,8 @@ class S3RealtimeRawDataConverterTest {
             GetObjectResponse.builder().contentLength(MAX_OBJECT_SIZE + 1).build(),
             AbortableInputStream.create(new ByteArrayInputStream(new byte[0])));
     when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(stream);
-    S3EventMessage msg = new S3EventMessage("m1", "r1", List.of(new S3ObjectRef("b", "big.json")));
+    S3EventMessage msg =
+        new S3EventMessage("m1", "r1", null, List.of(new S3ObjectRef("b", "big.json")));
 
     ConvertedResult<S3EventMessage> result =
         converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
@@ -168,7 +171,7 @@ class S3RealtimeRawDataConverterTest {
                 .message("The specified key does not exist.")
                 .build());
     S3EventMessage msg =
-        new S3EventMessage("m1", "r1", List.of(new S3ObjectRef("b", "gone.jsonl")));
+        new S3EventMessage("m1", "r1", null, List.of(new S3ObjectRef("b", "gone.jsonl")));
 
     ConvertedResult<S3EventMessage> result =
         converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
@@ -184,7 +187,8 @@ class S3RealtimeRawDataConverterTest {
   void convert_deserializeFailureNotConfirmed() {
     when(s3Client.getObject(any(GetObjectRequest.class)))
         .thenThrow(new RuntimeException("s3 down"));
-    S3EventMessage msg = new S3EventMessage("m1", "r1", List.of(new S3ObjectRef("b", "k.json")));
+    S3EventMessage msg =
+        new S3EventMessage("m1", "r1", null, List.of(new S3ObjectRef("b", "k.json")));
 
     ConvertedResult<S3EventMessage> result =
         converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
@@ -199,7 +203,7 @@ class S3RealtimeRawDataConverterTest {
   void convert_autoDetectsGzip() {
     stubGetObject("b", "data.jsonl.gz", gzip("{\"msg\":\"a\"}\n{\"msg\":\"b\"}"));
     S3EventMessage msg =
-        new S3EventMessage("m1", "r1", List.of(new S3ObjectRef("b", "data.jsonl.gz")));
+        new S3EventMessage("m1", "r1", null, List.of(new S3ObjectRef("b", "data.jsonl.gz")));
 
     ConvertedResult<S3EventMessage> result =
         converter(EncodingType.JSON_OBJECT_LINE, false, null).convert(msg, ctx);
@@ -212,7 +216,8 @@ class S3RealtimeRawDataConverterTest {
   @Test
   void convert_explicitGzip() {
     stubGetObject("b", "data", gzip("{\"msg\":\"a\"}"));
-    S3EventMessage msg = new S3EventMessage("m1", "r1", List.of(new S3ObjectRef("b", "data")));
+    S3EventMessage msg =
+        new S3EventMessage("m1", "r1", null, List.of(new S3ObjectRef("b", "data")));
 
     ConvertedResult<S3EventMessage> result =
         converter(EncodingType.JSON_OBJECT_LINE, false, CompressionType.GZIP).convert(msg, ctx);

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverterTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeRawDataConverterTest.java
@@ -51,6 +51,7 @@ class S3RealtimeRawDataConverterTest {
   private S3Client s3Client;
   private Queue<String> confirmed;
   private DlqWriter dlqWriter;
+  private FleakCounter skippedObjectCounter;
   private SourceExecutionContext<S3EventMessage> ctx;
 
   @BeforeEach
@@ -58,6 +59,7 @@ class S3RealtimeRawDataConverterTest {
     s3Client = mock(S3Client.class);
     confirmed = new ConcurrentLinkedQueue<>();
     dlqWriter = mock(DlqWriter.class);
+    skippedObjectCounter = mock(FleakCounter.class);
     ctx =
         new SourceExecutionContext<>(
             null,
@@ -86,7 +88,8 @@ class S3RealtimeRawDataConverterTest {
         confirmed,
         dlqWriter,
         new S3RealtimeRawDataEncoder(),
-        "node");
+        "node",
+        skippedObjectCounter);
   }
 
   private void stubGetObject(String bucket, String key, byte[] data) {
@@ -175,6 +178,7 @@ class S3RealtimeRawDataConverterTest {
     assertEquals(List.of("r1"), List.copyOf(confirmed));
     verify(dlqWriter)
         .writeToDlq(anyLong(), any(), contains("exceeds maxObjectSizeBytes"), eq("node"));
+    verify(skippedObjectCounter).increase(Map.of("reason", "oversized"));
   }
 
   @Test
@@ -190,11 +194,12 @@ class S3RealtimeRawDataConverterTest {
     ConvertedResult<S3EventMessage> result =
         converter(EncodingType.JSON_OBJECT_LINE, false).convert(msg, ctx);
 
-    // A deleted object is a benign skip: acknowledged (no records), no DLQ.
+    // A deleted object is a benign skip: acknowledged (no records), no DLQ, but counted.
     assertNull(result.error());
     assertEquals(List.of(), result.transformedData());
     assertEquals(List.of("r1"), List.copyOf(confirmed));
     verifyNoInteractions(dlqWriter);
+    verify(skippedObjectCounter).increase(Map.of("reason", "missing"));
   }
 
   @Test

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommandIntegrationTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommandIntegrationTest.java
@@ -1,0 +1,360 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+import io.fleak.zephflow.api.*;
+import io.fleak.zephflow.api.metric.FleakCounter;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.source.*;
+import io.fleak.zephflow.lib.deadletter.DeadLetter;
+import io.fleak.zephflow.lib.dlq.DlqWriter;
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import io.fleak.zephflow.lib.serdes.des.DeserializerFactory;
+import io.fleak.zephflow.lib.serdes.des.FleakDeserializer;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.*;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.Event;
+import software.amazon.awssdk.services.s3.model.NotificationConfiguration;
+import software.amazon.awssdk.services.s3.model.PutBucketNotificationConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.QueueConfiguration;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+@Slf4j
+@Testcontainers
+class S3RealtimeSourceCommandIntegrationTest {
+
+  @Container
+  static LocalStackContainer LOCALSTACK =
+      new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.5"))
+          .withServices(LocalStackContainer.Service.S3, LocalStackContainer.Service.SQS)
+          .withStartupTimeout(Duration.ofMinutes(2));
+
+  private static final String BUCKET = "evt-bucket";
+
+  private S3Client s3;
+  private SqsClient sqs;
+  private String queueUrl;
+  private ExecutorService executor;
+
+  @BeforeEach
+  void setUp() {
+    s3 = newS3Client();
+    sqs = newSqsClient();
+
+    if (s3.listBuckets().buckets().stream().noneMatch(b -> b.name().equals(BUCKET))) {
+      s3.createBucket(CreateBucketRequest.builder().bucket(BUCKET).build());
+    }
+    queueUrl =
+        sqs.createQueue(
+                CreateQueueRequest.builder().queueName("evt-queue-" + UUID.randomUUID()).build())
+            .queueUrl();
+    executor = Executors.newSingleThreadExecutor();
+  }
+
+  @AfterEach
+  void tearDown() {
+    executor.shutdownNow();
+    s3.close();
+    sqs.close();
+  }
+
+  @Test
+  void endToEnd_realS3NotificationTriggersProcessing() throws Exception {
+    // Wire a real S3 -> SQS event notification on the bucket, then create an object. LocalStack
+    // (like real S3) emits the notification into the queue itself — we never call sendMessage here,
+    // so anything the source consumes is a genuine S3 notification in S3's real wire format.
+    enableS3Notifications();
+    String key = "real/data.jsonl";
+    s3.putObject(
+        PutObjectRequest.builder().bucket(BUCKET).key(key).build(),
+        RequestBody.fromString("{\"msg\":\"a\"}\n{\"msg\":\"b\"}"));
+
+    CollectingAcceptor acceptor = new CollectingAcceptor();
+    CapturingDlqWriter dlq = new CapturingDlqWriter();
+    SourceCommand command = runCommand(EncodingType.JSON_OBJECT_LINE, 5, dlq, acceptor);
+
+    waitUntil(() -> acceptor.records.size() >= 2);
+    command.terminate();
+
+    assertEquals(List.of(record(Map.of("msg", "a")), record(Map.of("msg", "b"))), acceptor.records);
+    waitUntil(() -> approxMessages() == 0);
+    assertEquals(0, approxMessages(), "processed notification should be deleted from the queue");
+  }
+
+  @Test
+  void endToEnd_unparseableObjectIsRetryCappedAndDeadLettered() throws Exception {
+    // The object exists but cannot be parsed as JSON, so every attempt fails -> never
+    // committed/deleted by the converter. SQS redelivers it (real ApproximateReceiveCount
+    // increments) until the in-app cap fires, which dead-letters and deletes it. Verifies the cap
+    // works end to end. (A *missing* object is instead skipped gracefully, covered by a unit test.)
+    s3.putObject(
+        PutObjectRequest.builder().bucket(BUCKET).key("bad.jsonl").build(),
+        RequestBody.fromString("this is definitely not json"));
+    sendNotification(BUCKET, "bad.jsonl");
+
+    CollectingAcceptor acceptor = new CollectingAcceptor();
+    CapturingDlqWriter dlq = new CapturingDlqWriter();
+    // maxRetries=2, visibilityTimeout=0 so the poison message reappears immediately.
+    SourceCommand command = runCommand(EncodingType.JSON_OBJECT_LINE, 2, 0, dlq, acceptor);
+
+    waitUntil(() -> approxMessages() == 0);
+    command.terminate();
+
+    assertTrue(
+        acceptor.records.isEmpty(), "no records should be emitted for an unparseable object");
+    assertTrue(
+        dlq.captured.stream().anyMatch(d -> d.getErrorMessage().contains("exceeded maxRetries")),
+        "DLQ should contain the retry-cap dead-letter entry");
+  }
+
+  // ---- helpers ----
+
+  private static S3Client newS3Client() {
+    return S3Client.builder()
+        .endpointOverride(LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.S3))
+        .credentialsProvider(credentials())
+        .region(Region.of(LOCALSTACK.getRegion()))
+        .forcePathStyle(true)
+        .build();
+  }
+
+  private static SqsClient newSqsClient() {
+    return SqsClient.builder()
+        .endpointOverride(LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.SQS))
+        .credentialsProvider(credentials())
+        .region(Region.of(LOCALSTACK.getRegion()))
+        .build();
+  }
+
+  private static StaticCredentialsProvider credentials() {
+    return StaticCredentialsProvider.create(
+        AwsBasicCredentials.create(LOCALSTACK.getAccessKey(), LOCALSTACK.getSecretKey()));
+  }
+
+  private SourceCommand runCommand(
+      EncodingType encodingType,
+      int maxRetries,
+      CapturingDlqWriter dlq,
+      CollectingAcceptor acceptor)
+      throws Exception {
+    return runCommand(encodingType, maxRetries, 30, dlq, acceptor);
+  }
+
+  private SourceCommand runCommand(
+      EncodingType encodingType,
+      int maxRetries,
+      int visibilityTimeout,
+      CapturingDlqWriter dlq,
+      CollectingAcceptor acceptor)
+      throws Exception {
+    Queue<String> confirmed = new ConcurrentLinkedQueue<>();
+    FleakDeserializer<?> deserializer =
+        DeserializerFactory.createDeserializerFactory(encodingType).createDeserializer();
+    // Command-owned clients: terminate() closes these via the fetcher, leaving the test's own
+    // control-plane clients (s3/sqs) untouched for setup and assertions.
+    S3Client commandS3 = newS3Client();
+    SqsClient commandSqs = newSqsClient();
+    RawDataConverter<S3EventMessage> converter =
+        new S3RealtimeRawDataConverter(
+            commandS3, deserializer, null, 256L * 1024 * 1024, false, confirmed);
+    Fetcher<S3EventMessage> fetcher =
+        new S3RealtimeSourceFetcher(
+            commandSqs,
+            commandS3,
+            queueUrl,
+            10,
+            1,
+            visibilityTimeout,
+            maxRetries,
+            dlq,
+            "node",
+            confirmed);
+    SourceExecutionContext<S3EventMessage> ctx =
+        new SourceExecutionContext<>(
+            fetcher,
+            converter,
+            new S3RealtimeRawDataEncoder(),
+            mock(FleakCounter.class),
+            mock(FleakCounter.class),
+            mock(FleakCounter.class),
+            dlq);
+
+    TestS3RealtimeSourceCommand command = new TestS3RealtimeSourceCommand(ctx);
+    command.initialize(mock(MetricClientProvider.class));
+    executor.submit(
+        () -> {
+          try {
+            command.execute("user", acceptor);
+          } catch (Exception e) {
+            log.error("command execution failed", e);
+          }
+        });
+    return command;
+  }
+
+  private void sendNotification(String bucket, String key) {
+    String body =
+        "{\"Records\":[{\"eventName\":\"ObjectCreated:Put\",\"s3\":{\"bucket\":{\"name\":\""
+            + bucket
+            + "\"},\"object\":{\"key\":\""
+            + key
+            + "\"}}}]}";
+    sqs.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody(body).build());
+  }
+
+  private void enableS3Notifications() {
+    String queueArn = queueArn();
+    String policy =
+        "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+            + "\"Principal\":{\"Service\":\"s3.amazonaws.com\"},"
+            + "\"Action\":\"sqs:SendMessage\",\"Resource\":\""
+            + queueArn
+            + "\"}]}";
+    sqs.setQueueAttributes(
+        SetQueueAttributesRequest.builder()
+            .queueUrl(queueUrl)
+            .attributes(Map.of(QueueAttributeName.POLICY, policy))
+            .build());
+    s3.putBucketNotificationConfiguration(
+        PutBucketNotificationConfigurationRequest.builder()
+            .bucket(BUCKET)
+            .notificationConfiguration(
+                NotificationConfiguration.builder()
+                    .queueConfigurations(
+                        QueueConfiguration.builder()
+                            .queueArn(queueArn)
+                            .events(Event.S3_OBJECT_CREATED)
+                            .build())
+                    .build())
+            .build());
+  }
+
+  private String queueArn() {
+    return sqs.getQueueAttributes(
+            GetQueueAttributesRequest.builder()
+                .queueUrl(queueUrl)
+                .attributeNames(QueueAttributeName.QUEUE_ARN)
+                .build())
+        .attributes()
+        .get(QueueAttributeName.QUEUE_ARN);
+  }
+
+  private int approxMessages() {
+    GetQueueAttributesResponse attrs =
+        sqs.getQueueAttributes(
+            GetQueueAttributesRequest.builder()
+                .queueUrl(queueUrl)
+                .attributeNames(
+                    QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES,
+                    QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE)
+                .build());
+    return Integer.parseInt(
+            attrs.attributes().getOrDefault(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES, "0"))
+        + Integer.parseInt(
+            attrs
+                .attributes()
+                .getOrDefault(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE, "0"));
+  }
+
+  private static void waitUntil(java.util.function.BooleanSupplier condition)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + Duration.ofSeconds(30).toNanos();
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.sleep(200);
+    }
+    fail("condition not met within timeout");
+  }
+
+  private static RecordFleakData record(Map<String, Object> payload) {
+    return (RecordFleakData) FleakData.wrap(payload);
+  }
+
+  private static class TestS3RealtimeSourceCommand extends SimpleSourceCommand<S3EventMessage> {
+    private final SourceExecutionContext<S3EventMessage> ctx;
+
+    TestS3RealtimeSourceCommand(SourceExecutionContext<S3EventMessage> ctx) {
+      super("node", io.fleak.zephflow.lib.TestUtils.buildJobContext(new HashMap<>()), null, null);
+      this.ctx = ctx;
+    }
+
+    @Override
+    protected ExecutionContext createExecutionContext(
+        MetricClientProvider metricClientProvider,
+        JobContext jobContext,
+        CommandConfig commandConfig,
+        String nodeId) {
+      return ctx;
+    }
+
+    @Override
+    public String commandName() {
+      return "s3rtsource";
+    }
+
+    @Override
+    public SourceType sourceType() {
+      return SourceType.STREAMING;
+    }
+  }
+
+  private static class CollectingAcceptor implements SourceEventAcceptor {
+    final List<RecordFleakData> records = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void accept(List<RecordFleakData> recordFleakData) {
+      records.addAll(recordFleakData);
+    }
+
+    @Override
+    public void terminate() {}
+  }
+
+  private static class CapturingDlqWriter extends DlqWriter {
+    final List<DeadLetter> captured = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void open() {}
+
+    @Override
+    protected void doWrite(DeadLetter deadLetter) {
+      captured.add(deadLetter);
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommandIntegrationTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommandIntegrationTest.java
@@ -133,9 +133,12 @@ class S3RealtimeSourceCommandIntegrationTest {
 
     assertTrue(
         acceptor.records.isEmpty(), "no records should be emitted for an unparseable object");
+    assertFalse(dlq.captured.isEmpty(), "poison message should be dead-lettered at the retry cap");
+    // No per-attempt duplicates: every DLQ entry is the single retry-cap entry, not a framework
+    // write from each failed convert attempt.
     assertTrue(
-        dlq.captured.stream().anyMatch(d -> d.getErrorMessage().contains("exceeded maxRetries")),
-        "DLQ should contain the retry-cap dead-letter entry");
+        dlq.captured.stream().allMatch(d -> d.getErrorMessage().contains("exceeded maxRetries")),
+        "DLQ should only contain retry-cap entries, not per-attempt convert-failure entries");
   }
 
   // ---- helpers ----
@@ -200,6 +203,8 @@ class S3RealtimeSourceCommandIntegrationTest {
             dlq,
             "node",
             confirmed);
+    // Mirror production: the DLQ is owned by the fetcher (single dead-letter at the retry cap), not
+    // the execution context, so the framework does not write a DLQ entry per failed attempt.
     SourceExecutionContext<S3EventMessage> ctx =
         new SourceExecutionContext<>(
             fetcher,
@@ -208,7 +213,7 @@ class S3RealtimeSourceCommandIntegrationTest {
             mock(FleakCounter.class),
             mock(FleakCounter.class),
             mock(FleakCounter.class),
-            dlq);
+            null);
 
     TestS3RealtimeSourceCommand command = new TestS3RealtimeSourceCommand(ctx);
     command.initialize(mock(MetricClientProvider.class));

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommandIntegrationTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommandIntegrationTest.java
@@ -113,11 +113,10 @@ class S3RealtimeSourceCommandIntegrationTest {
   }
 
   @Test
-  void endToEnd_unparseableObjectIsRetryCappedAndDeadLettered() throws Exception {
-    // The object exists but cannot be parsed as JSON, so every attempt fails -> never
-    // committed/deleted by the converter. SQS redelivers it (real ApproximateReceiveCount
-    // increments) until the in-app cap fires, which dead-letters and deletes it. Verifies the cap
-    // works end to end. (A *missing* object is instead skipped gracefully, covered by a unit test.)
+  void endToEnd_unparseableObjectDlqdAndAcknowledged() throws Exception {
+    // The object exists but cannot be parsed as JSON. This is a terminal failure: the converter
+    // dead-letters it once (with the real error) and the message is acknowledged on the first
+    // attempt -- no retry storm, no generic "exceeded maxRetries" entry.
     s3.putObject(
         PutObjectRequest.builder().bucket(BUCKET).key("bad.jsonl").build(),
         RequestBody.fromString("this is definitely not json"));
@@ -125,20 +124,41 @@ class S3RealtimeSourceCommandIntegrationTest {
 
     CollectingAcceptor acceptor = new CollectingAcceptor();
     CapturingDlqWriter dlq = new CapturingDlqWriter();
-    // maxRetries=2, visibilityTimeout=0 so the poison message reappears immediately.
-    SourceCommand command = runCommand(EncodingType.JSON_OBJECT_LINE, 2, 0, dlq, acceptor);
+    SourceCommand command = runCommand(EncodingType.JSON_OBJECT_LINE, 5, dlq, acceptor);
 
     waitUntil(() -> approxMessages() == 0);
     command.terminate();
 
     assertTrue(
         acceptor.records.isEmpty(), "no records should be emitted for an unparseable object");
-    assertFalse(dlq.captured.isEmpty(), "poison message should be dead-lettered at the retry cap");
-    // No per-attempt duplicates: every DLQ entry is the single retry-cap entry, not a framework
-    // write from each failed convert attempt.
+    assertEquals(1, dlq.captured.size(), "the object should be dead-lettered exactly once");
     assertTrue(
-        dlq.captured.stream().allMatch(d -> d.getErrorMessage().contains("exceeded maxRetries")),
-        "DLQ should only contain retry-cap entries, not per-attempt convert-failure entries");
+        dlq.captured
+            .get(0)
+            .getErrorMessage()
+            .contains("failed to process s3://" + BUCKET + "/bad.jsonl"),
+        "DLQ entry should carry the real parse error, not a generic retry-cap message");
+  }
+
+  @Test
+  void endToEnd_downstreamFailureIsDlqd() throws Exception {
+    // The object parses fine, but the downstream consumer throws. The framework's DLQ (restored)
+    // must capture the record instead of silently dropping it.
+    s3.putObject(
+        PutObjectRequest.builder().bucket(BUCKET).key("good.jsonl").build(),
+        RequestBody.fromString("{\"msg\":\"a\"}"));
+    sendNotification(BUCKET, "good.jsonl");
+
+    ThrowingAcceptor acceptor = new ThrowingAcceptor();
+    CapturingDlqWriter dlq = new CapturingDlqWriter();
+    // maxRetries=2 / visibilityTimeout=0 so the cap drains the queue quickly while accept keeps
+    // failing.
+    SourceCommand command = runCommand(EncodingType.JSON_OBJECT_LINE, 2, 0, dlq, acceptor);
+
+    waitUntil(() -> !dlq.captured.isEmpty());
+    command.terminate();
+
+    assertFalse(dlq.captured.isEmpty(), "downstream accept() failure must be captured in the DLQ");
   }
 
   // ---- helpers ----
@@ -169,7 +189,7 @@ class S3RealtimeSourceCommandIntegrationTest {
       EncodingType encodingType,
       int maxRetries,
       CapturingDlqWriter dlq,
-      CollectingAcceptor acceptor)
+      SourceEventAcceptor acceptor)
       throws Exception {
     return runCommand(encodingType, maxRetries, 30, dlq, acceptor);
   }
@@ -179,7 +199,7 @@ class S3RealtimeSourceCommandIntegrationTest {
       int maxRetries,
       int visibilityTimeout,
       CapturingDlqWriter dlq,
-      CollectingAcceptor acceptor)
+      SourceEventAcceptor acceptor)
       throws Exception {
     Queue<String> confirmed = new ConcurrentLinkedQueue<>();
     FleakDeserializer<?> deserializer =
@@ -188,9 +208,18 @@ class S3RealtimeSourceCommandIntegrationTest {
     // control-plane clients (s3/sqs) untouched for setup and assertions.
     S3Client commandS3 = newS3Client();
     SqsClient commandSqs = newSqsClient();
+    S3RealtimeRawDataEncoder encoder = new S3RealtimeRawDataEncoder();
     RawDataConverter<S3EventMessage> converter =
         new S3RealtimeRawDataConverter(
-            commandS3, deserializer, null, 256L * 1024 * 1024, false, confirmed);
+            commandS3,
+            deserializer,
+            null,
+            256L * 1024 * 1024,
+            false,
+            confirmed,
+            dlq,
+            encoder,
+            "node");
     Fetcher<S3EventMessage> fetcher =
         new S3RealtimeSourceFetcher(
             commandSqs,
@@ -203,17 +232,17 @@ class S3RealtimeSourceCommandIntegrationTest {
             dlq,
             "node",
             confirmed);
-    // Mirror production: the DLQ is owned by the fetcher (single dead-letter at the retry cap), not
-    // the execution context, so the framework does not write a DLQ entry per failed attempt.
+    // Mirror production: the framework DLQ is restored (downstream accept() failures are captured),
+    // while convert failures are dead-lettered terminally by the converter itself.
     SourceExecutionContext<S3EventMessage> ctx =
         new SourceExecutionContext<>(
             fetcher,
             converter,
-            new S3RealtimeRawDataEncoder(),
+            encoder,
             mock(FleakCounter.class),
             mock(FleakCounter.class),
             mock(FleakCounter.class),
-            null);
+            dlq);
 
     TestS3RealtimeSourceCommand command = new TestS3RealtimeSourceCommand(ctx);
     command.initialize(mock(MetricClientProvider.class));
@@ -342,6 +371,16 @@ class S3RealtimeSourceCommandIntegrationTest {
     @Override
     public void accept(List<RecordFleakData> recordFleakData) {
       records.addAll(recordFleakData);
+    }
+
+    @Override
+    public void terminate() {}
+  }
+
+  private static class ThrowingAcceptor implements SourceEventAcceptor {
+    @Override
+    public void accept(List<RecordFleakData> recordFleakData) {
+      throw new RuntimeException("downstream boom");
     }
 
     @Override

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommandIntegrationTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommandIntegrationTest.java
@@ -219,7 +219,8 @@ class S3RealtimeSourceCommandIntegrationTest {
             confirmed,
             dlq,
             encoder,
-            "node");
+            "node",
+            mock(FleakCounter.class));
     Fetcher<S3EventMessage> fetcher =
         new S3RealtimeSourceFetcher(
             commandSqs,

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommandTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceCommandTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.api.SourceCommand.SourceType;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.lib.TestUtils;
+import io.fleak.zephflow.lib.commands.source.SourceExecutionContext;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Exercises the full factory -> parse -> validate -> createExecutionContext wiring. */
+class S3RealtimeSourceCommandTest {
+
+  @Test
+  void buildsStreamingExecutionContext() throws Exception {
+    JobContext jobContext = TestUtils.buildJobContext(new HashMap<>());
+    S3RealtimeSourceCommand command =
+        new S3RealtimeSourceCommandFactory().createCommand("node", jobContext);
+
+    Map<String, Object> config =
+        Map.of(
+            "queueUrl", "https://sqs.us-east-1.amazonaws.com/123456789012/q",
+            "regionStr", "us-east-1",
+            "encodingType", "JSON_OBJECT_LINE");
+    command.parseAndValidateArg(config);
+    command.initialize(mock(MetricClientProvider.class));
+
+    assertEquals(SourceType.STREAMING, command.sourceType());
+    assertEquals("s3rtsource", command.commandName());
+    assertInstanceOf(SourceExecutionContext.class, command.getExecutionContext());
+
+    command.terminate();
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceConfigValidatorTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceConfigValidatorTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.lib.TestUtils;
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class S3RealtimeSourceConfigValidatorTest {
+
+  static final JobContext TEST_JOB_CONTEXT =
+      JobContext.builder()
+          .metricTags(TestUtils.JOB_CONTEXT.getMetricTags())
+          .otherProperties(
+              new HashMap<>(
+                  Map.of(
+                      "example-credential-id",
+                      new HashMap<>(
+                          Map.of("username", "test-access-key", "password", "test-secret-key")))))
+          .build();
+
+  private final S3RealtimeSourceConfigValidator validator = new S3RealtimeSourceConfigValidator();
+
+  private static S3RealtimeSourceDto.Config.ConfigBuilder validConfig() {
+    return S3RealtimeSourceDto.Config.builder()
+        .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+        .regionStr("us-east-1")
+        .encodingType(EncodingType.JSON_OBJECT_LINE)
+        .credentialId("example-credential-id");
+  }
+
+  @Test
+  void validateConfig_validConfig() {
+    assertDoesNotThrow(
+        () -> validator.validateConfig(validConfig().build(), "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_blankQueueUrl() {
+    S3RealtimeSourceDto.Config config = validConfig().queueUrl("").build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_blankRegion() {
+    S3RealtimeSourceDto.Config config = validConfig().regionStr("").build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_invalidMaxNumberOfMessages() {
+    S3RealtimeSourceDto.Config config = validConfig().maxNumberOfMessages(11).build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_invalidWaitTimeSeconds() {
+    S3RealtimeSourceDto.Config config = validConfig().waitTimeSeconds(21).build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_negativeVisibilityTimeout() {
+    S3RealtimeSourceDto.Config config = validConfig().visibilityTimeoutSeconds(-1).build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_nonPositiveMaxObjectSize() {
+    S3RealtimeSourceDto.Config config = validConfig().maxObjectSizeBytes(0L).build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_invalidMaxRetries() {
+    S3RealtimeSourceDto.Config config = validConfig().maxRetries(0).build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_validBoundaryValues() {
+    S3RealtimeSourceDto.Config config =
+        validConfig()
+            .maxNumberOfMessages(10)
+            .waitTimeSeconds(20)
+            .visibilityTimeoutSeconds(0)
+            .maxObjectSizeBytes(1L)
+            .maxRetries(1)
+            .build();
+    assertDoesNotThrow(() -> validator.validateConfig(config, "nodeId", TEST_JOB_CONTEXT));
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceDtoTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceDtoTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.OBJECT_MAPPER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.fleak.zephflow.lib.serdes.CompressionType;
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class S3RealtimeSourceDtoTest {
+
+  @Test
+  void testJsonParsingWithDefaults() {
+    Map<String, Object> jsonMap =
+        Map.of(
+            "queueUrl",
+            "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue",
+            "regionStr",
+            "us-east-1",
+            "encodingType",
+            "JSON_OBJECT_LINE");
+
+    S3RealtimeSourceDto.Config config =
+        OBJECT_MAPPER.convertValue(jsonMap, S3RealtimeSourceDto.Config.class);
+
+    S3RealtimeSourceDto.Config expected =
+        S3RealtimeSourceDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.JSON_OBJECT_LINE)
+            .build();
+    assertEquals(expected, config);
+  }
+
+  @Test
+  void testJsonParsingFullConfig() {
+    Map<String, Object> jsonMap =
+        Map.ofEntries(
+            Map.entry("queueUrl", "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue"),
+            Map.entry("regionStr", "us-east-1"),
+            Map.entry("encodingType", "CSV"),
+            Map.entry("compressionType", "GZIP"),
+            Map.entry("credentialId", "cred"),
+            Map.entry("s3CredentialId", "s3cred"),
+            Map.entry("s3RegionStr", "us-west-2"),
+            Map.entry("s3EndpointOverride", "http://minio:9000"),
+            Map.entry("maxNumberOfMessages", 5),
+            Map.entry("waitTimeSeconds", 10),
+            Map.entry("visibilityTimeoutSeconds", 60),
+            Map.entry("maxObjectSizeBytes", 1024),
+            Map.entry("maxRetries", 3),
+            Map.entry("addS3Metadata", true));
+
+    S3RealtimeSourceDto.Config config =
+        OBJECT_MAPPER.convertValue(jsonMap, S3RealtimeSourceDto.Config.class);
+
+    S3RealtimeSourceDto.Config expected =
+        S3RealtimeSourceDto.Config.builder()
+            .queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
+            .regionStr("us-east-1")
+            .encodingType(EncodingType.CSV)
+            .compressionType(CompressionType.GZIP)
+            .credentialId("cred")
+            .s3CredentialId("s3cred")
+            .s3RegionStr("us-west-2")
+            .s3EndpointOverride("http://minio:9000")
+            .maxNumberOfMessages(5)
+            .waitTimeSeconds(10)
+            .visibilityTimeoutSeconds(60)
+            .maxObjectSizeBytes(1024L)
+            .maxRetries(3)
+            .addS3Metadata(true)
+            .build();
+    assertEquals(expected, config);
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcherTest.java
@@ -159,11 +159,12 @@ class S3RealtimeSourceFetcherTest {
   }
 
   @Test
-  void close_closesClientsAndDlqWriter() throws Exception {
+  void close_closesClients() throws Exception {
     fetcher.close();
     verify(sqsClient).close();
     verify(s3Client).close();
-    verify(dlqWriter).close();
+    // The DLQ writer is owned/closed by the execution context, not the fetcher.
+    verify(dlqWriter, never()).close();
   }
 
   private static DeleteMessageRequest deleteFor(String receiptHandle) {

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcherTest.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import io.fleak.zephflow.lib.dlq.DlqWriter;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+class S3RealtimeSourceFetcherTest {
+
+  private static final String QUEUE_URL =
+      "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue";
+  private static final int MAX_RETRIES = 3;
+
+  private SqsClient sqsClient;
+  private S3Client s3Client;
+  private DlqWriter dlqWriter;
+  private Queue<String> confirmed;
+  private S3RealtimeSourceFetcher fetcher;
+
+  @BeforeEach
+  void setUp() {
+    sqsClient = mock(SqsClient.class);
+    s3Client = mock(S3Client.class);
+    dlqWriter = mock(DlqWriter.class);
+    confirmed = new ConcurrentLinkedQueue<>();
+    fetcher = newFetcher(dlqWriter);
+  }
+
+  private S3RealtimeSourceFetcher newFetcher(DlqWriter dlq) {
+    return new S3RealtimeSourceFetcher(
+        sqsClient, s3Client, QUEUE_URL, 10, 20, 30, MAX_RETRIES, dlq, "nodeId", confirmed);
+  }
+
+  private static Message message(String id, String receipt, int receiveCount, String body) {
+    return Message.builder()
+        .messageId(id)
+        .receiptHandle(receipt)
+        .body(body)
+        .attributes(
+            Map.of(
+                MessageSystemAttributeName.APPROXIMATE_RECEIVE_COUNT, String.valueOf(receiveCount)))
+        .build();
+  }
+
+  private static String objectCreated(String bucket, String key) {
+    return "{\"Records\":[{\"eventName\":\"ObjectCreated:Put\",\"s3\":{\"bucket\":{\"name\":\""
+        + bucket
+        + "\"},\"object\":{\"key\":\""
+        + key
+        + "\"}}}]}";
+  }
+
+  private void stubReceive(Message... messages) {
+    when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class)))
+        .thenReturn(ReceiveMessageResponse.builder().messages(messages).build());
+  }
+
+  @Test
+  void fetch_validObjectCreatedMessage() {
+    stubReceive(message("msg-1", "receipt-1", 1, objectCreated("b", "k.json")));
+
+    List<S3EventMessage> result = fetcher.fetch();
+
+    assertEquals(
+        List.of(new S3EventMessage("msg-1", "receipt-1", List.of(new S3ObjectRef("b", "k.json")))),
+        result);
+    verify(sqsClient, never()).deleteMessage(any(DeleteMessageRequest.class));
+    verifyNoInteractions(dlqWriter);
+  }
+
+  @Test
+  void fetch_testEventDeletedAndNotEmitted() {
+    stubReceive(
+        message("msg-1", "receipt-1", 1, "{\"Service\":\"Amazon S3\",\"Event\":\"s3:TestEvent\"}"));
+
+    List<S3EventMessage> result = fetcher.fetch();
+
+    assertTrue(result.isEmpty());
+    verify(sqsClient).deleteMessage(deleteFor("receipt-1"));
+    verifyNoInteractions(dlqWriter);
+  }
+
+  @Test
+  void fetch_exceededMaxRetriesDeadLetteredAndDeleted() {
+    stubReceive(message("msg-1", "receipt-1", MAX_RETRIES + 1, objectCreated("b", "k.json")));
+
+    List<S3EventMessage> result = fetcher.fetch();
+
+    assertTrue(result.isEmpty());
+    verify(dlqWriter).writeToDlq(anyLong(), any(), contains("exceeded maxRetries"), eq("nodeId"));
+    verify(sqsClient).deleteMessage(deleteFor("receipt-1"));
+  }
+
+  @Test
+  void fetch_exceededMaxRetriesNoDlqStillDeleted() {
+    fetcher = newFetcher(null);
+    stubReceive(message("msg-1", "receipt-1", MAX_RETRIES + 1, objectCreated("b", "k.json")));
+
+    List<S3EventMessage> result = fetcher.fetch();
+
+    assertTrue(result.isEmpty());
+    verify(sqsClient).deleteMessage(deleteFor("receipt-1"));
+  }
+
+  @Test
+  void fetch_malformedMessageDeadLetteredAndDeleted() {
+    stubReceive(message("msg-1", "receipt-1", 1, "not-json"));
+
+    List<S3EventMessage> result = fetcher.fetch();
+
+    assertTrue(result.isEmpty());
+    verify(dlqWriter).writeToDlq(anyLong(), any(), contains("failed to parse"), eq("nodeId"));
+    verify(sqsClient).deleteMessage(deleteFor("receipt-1"));
+  }
+
+  @Test
+  void committer_deletesOnlyConfirmedHandles() throws Exception {
+    confirmed.add("receipt-confirmed");
+
+    fetcher.committer().commit();
+
+    verify(sqsClient).deleteMessage(deleteFor("receipt-confirmed"));
+    verify(sqsClient, never()).deleteMessage(deleteFor("receipt-unprocessed"));
+    assertTrue(confirmed.isEmpty());
+  }
+
+  @Test
+  void isExhausted_alwaysFalse() {
+    assertFalse(fetcher.isExhausted());
+  }
+
+  private static DeleteMessageRequest deleteFor(String receiptHandle) {
+    return argThat(
+        (DeleteMessageRequest r) ->
+            r != null && QUEUE_URL.equals(r.queueUrl()) && receiptHandle.equals(r.receiptHandle()));
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcherTest.java
@@ -86,7 +86,12 @@ class S3RealtimeSourceFetcherTest {
     List<S3EventMessage> result = fetcher.fetch();
 
     assertEquals(
-        List.of(new S3EventMessage("msg-1", "receipt-1", List.of(new S3ObjectRef("b", "k.json")))),
+        List.of(
+            new S3EventMessage(
+                "msg-1",
+                "receipt-1",
+                objectCreated("b", "k.json"),
+                List.of(new S3ObjectRef("b", "k.json")))),
         result);
     verify(sqsClient, never()).deleteMessage(any(DeleteMessageRequest.class));
     verifyNoInteractions(dlqWriter);

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceFetcherTest.java
@@ -153,6 +153,14 @@ class S3RealtimeSourceFetcherTest {
     assertFalse(fetcher.isExhausted());
   }
 
+  @Test
+  void close_closesClientsAndDlqWriter() throws Exception {
+    fetcher.close();
+    verify(sqsClient).close();
+    verify(s3Client).close();
+    verify(dlqWriter).close();
+  }
+
   private static DeleteMessageRequest deleteFor(String receiptHandle) {
     return argThat(
         (DeleteMessageRequest r) ->

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceRealAwsManualTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3realtimesource/S3RealtimeSourceRealAwsManualTest.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.s3realtimesource;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.api.SourceEventAcceptor;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.TestUtils;
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Manual, READ-ONLY end-to-end smoke test against REAL AWS. Disabled unless the required env vars
+ * are set, so it never runs in CI. It does NOT write to S3: it runs the real source against an
+ * existing queue, downloads the referenced objects read-only, and asserts records are emitted.
+ *
+ * <p>Run it explicitly, e.g.:
+ *
+ * <pre>
+ *   export S3RT_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/my-queue
+ *   export S3RT_REGION=us-east-1
+ *   # credentials: rely on the default AWS chain (AWS_ACCESS_KEY_ID/.../profile/IAM role) or set:
+ *   export S3RT_ACCESS_KEY=...               # optional
+ *   export S3RT_SECRET_KEY=...               # optional
+ *   export S3RT_ENCODING=STRING_LINE         # optional, default STRING_LINE (raw line per record)
+ *   export S3RT_COMPRESSION=GZIP             # optional, gzip is auto-detected when unset
+ *   export S3RT_MIN_RECORDS=1                # optional, records to wait for (default 1)
+ *   export S3RT_TIMEOUT_SECONDS=180          # optional, how long to wait (default 180)
+ *   ./gradlew :lib:test --tests \
+ *     io.fleak.zephflow.lib.commands.s3realtimesource.S3RealtimeSourceRealAwsManualTest
+ * </pre>
+ *
+ * <p>Prerequisites: the queue must already be receiving {@code s3:ObjectCreated:*} notifications
+ * (e.g. from VPC flow logs) and have pending/incoming messages during the test window.
+ *
+ * <p>WARNING: the source DELETES every message it successfully processes from the queue. Point this
+ * at a dedicated test queue, not one whose messages are consumed by something else.
+ */
+@Slf4j
+@Tag("manual")
+@EnabledIfEnvironmentVariable(named = "S3RT_QUEUE_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "S3RT_REGION", matches = ".+")
+class S3RealtimeSourceRealAwsManualTest {
+
+  private static final String QUEUE_URL = System.getenv("S3RT_QUEUE_URL");
+  private static final String REGION = System.getenv("S3RT_REGION");
+  private static final String ENCODING = envOrDefault("S3RT_ENCODING", "STRING_LINE");
+  // Optional: force compression (e.g. GZIP). When unset, gzip is auto-detected from object bytes.
+  private static final String COMPRESSION = System.getenv("S3RT_COMPRESSION");
+  private static final String ACCESS_KEY = System.getenv("S3RT_ACCESS_KEY");
+  private static final String SECRET_KEY = System.getenv("S3RT_SECRET_KEY");
+  private static final String CRED_ID = "s3rt-cred";
+  private static final int MIN_RECORDS = Integer.parseInt(envOrDefault("S3RT_MIN_RECORDS", "1"));
+  private static final int TIMEOUT_SECONDS =
+      Integer.parseInt(envOrDefault("S3RT_TIMEOUT_SECONDS", "180"));
+
+  @Test
+  void realAws_consumesRealNotifications() throws Exception {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    S3RealtimeSourceCommand command =
+        new S3RealtimeSourceCommandFactory().createCommand("node", jobContext());
+    command.parseAndValidateArg(config());
+    command.initialize(new MetricClientProvider.NoopMetricClientProvider());
+
+    CollectingAcceptor acceptor = new CollectingAcceptor();
+    try {
+      executor.submit(
+          () -> {
+            try {
+              command.execute("user", acceptor);
+            } catch (Exception e) {
+              log.error("source execution failed", e);
+            }
+          });
+
+      log.info(
+          "polling {} (encoding={}) for up to {}s, expecting >= {} record(s)",
+          QUEUE_URL,
+          ENCODING,
+          TIMEOUT_SECONDS,
+          MIN_RECORDS);
+      waitUntil(() -> acceptor.records.size() >= MIN_RECORDS, Duration.ofSeconds(TIMEOUT_SECONDS));
+
+      log.info(
+          "emitted {} record(s); first record: {}",
+          acceptor.records.size(),
+          acceptor.records.isEmpty() ? "<none>" : acceptor.records.get(0).unwrap());
+      assertTrue(
+          acceptor.records.size() >= MIN_RECORDS,
+          "expected at least "
+              + MIN_RECORDS
+              + " record(s) from real S3 notifications on the queue");
+    } finally {
+      command.terminate();
+      executor.shutdownNow();
+    }
+  }
+
+  private static Map<String, Object> config() {
+    Map<String, Object> config = new HashMap<>();
+    config.put("queueUrl", QUEUE_URL);
+    config.put("regionStr", REGION);
+    config.put("encodingType", ENCODING);
+    if (COMPRESSION != null && !COMPRESSION.isBlank()) {
+      config.put("compressionType", COMPRESSION);
+    }
+    config.put("waitTimeSeconds", 5);
+    if (ACCESS_KEY != null && SECRET_KEY != null) {
+      config.put("credentialId", CRED_ID);
+    }
+    return config;
+  }
+
+  private static JobContext jobContext() {
+    Map<String, Serializable> otherProperties = new HashMap<>();
+    if (ACCESS_KEY != null && SECRET_KEY != null) {
+      otherProperties.put(
+          CRED_ID, new HashMap<>(Map.of("username", ACCESS_KEY, "password", SECRET_KEY)));
+    }
+    return TestUtils.buildJobContext(otherProperties);
+  }
+
+  private static void waitUntil(java.util.function.BooleanSupplier condition, Duration timeout)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + timeout.toNanos();
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.sleep(500);
+    }
+    throw new AssertionError("condition not met within " + timeout);
+  }
+
+  private static String envOrDefault(String name, String defaultValue) {
+    String value = System.getenv(name);
+    return value == null || value.isBlank() ? defaultValue : value;
+  }
+
+  private static class CollectingAcceptor implements SourceEventAcceptor {
+    final List<RecordFleakData> records = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void accept(List<RecordFleakData> recordFleakData) {
+      records.addAll(recordFleakData);
+    }
+
+    @Override
+    public void terminate() {}
+  }
+}


### PR DESCRIPTION
Reads standard S3 event notifications (direct or SNS-wrapped) from SQS, downloads referenced objects, and emits records. Auto-detects gzip, caps retries via ApproximateReceiveCount, and skips deleted objects.