### PR TITLE
Add opt-in store-and-forward for sinks (Kafka, Zerobus)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ angusMail = "2.0.3"
 unboundidLdapsdk = "7.0.1"
 azureStorageBlob = "12.28.0"
 azureCoreHttpOkHttp = "1.12.6"
+chronicle = "2026.2"
 
 nebulaDependencyLock = "17.0.1"
 nebulaMavenPublish = "23.0.0"
@@ -194,6 +195,8 @@ angus-mail = { module = "org.eclipse.angus:angus-mail", version.ref = "angusMail
 unboundid-ldapsdk = { module = "com.unboundid:unboundid-ldapsdk", version.ref = "unboundidLdapsdk" }
 azure-storage-blob = { module = "com.azure:azure-storage-blob", version.ref = "azureStorageBlob" }
 azure-core-http-okhttp = { module = "com.azure:azure-core-http-okhttp", version.ref = "azureCoreHttpOkHttp" }
+chronicle-bom = { module = "net.openhft:chronicle-bom", version.ref = "chronicle" }
+chronicle-queue = { module = "net.openhft:chronicle-queue" }
 
 [plugins]
 nebula-dependency-lock = { id = "com.netflix.nebula.dependency-lock", version.ref = "nebulaDependencyLock" }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -63,6 +63,9 @@ dependencies {
   }
   implementation libs.azure.core.http.okhttp
 
+  implementation platform(libs.chronicle.bom)
+  implementation libs.chronicle.queue
+
   testImplementation libs.unboundid.ldapsdk
   testImplementation libs.jackson.dataformat.yaml
   testImplementation libs.testcontainers.clickhouse
@@ -111,6 +114,17 @@ tasks.named('spotlessJava') {
 tasks.named('test') {
   useJUnitPlatform()
   testLogging.showStandardStreams = true
+  // Chronicle Queue memory-maps files via JDK internals; Java 17+ needs these opened/exported.
+  jvmArgs += [
+    '--add-exports', 'java.base/jdk.internal.ref=ALL-UNNAMED',
+    '--add-exports', 'java.base/sun.nio.ch=ALL-UNNAMED',
+    '--add-exports', 'jdk.unsupported/sun.misc=ALL-UNNAMED',
+    '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+    '--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED',
+    '--add-opens', 'java.base/java.io=ALL-UNNAMED',
+    '--add-opens', 'java.base/java.util=ALL-UNNAMED',
+    '--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED',
+  ]
 }
 
 tasks.named('jar') {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaConnectionFailureClassifier.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaConnectionFailureClassifier.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.kafkasink;
+
+import io.fleak.zephflow.lib.commands.sink.ConnectionFailureClassifier;
+import java.io.IOException;
+import org.apache.kafka.common.errors.RetriableException;
+
+/**
+ * Classifies a Kafka send failure as transient connectivity (buffer + retry) versus permanent (drop
+ * / normal error path). Kafka's own {@link RetriableException} hierarchy — {@code
+ * TimeoutException}, {@code NetworkException}, etc. — is exactly "transient, retry", so we walk the
+ * cause chain for it (or a plain {@link IOException}). Anything else is treated as permanent.
+ */
+public class KafkaConnectionFailureClassifier implements ConnectionFailureClassifier {
+
+  @Override
+  public boolean isConnectionFailure(Throwable t) {
+    for (Throwable cause = t;
+        cause != null && cause != cause.getCause();
+        cause = cause.getCause()) {
+      if (cause instanceof RetriableException || cause instanceof IOException) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkCommand.java
@@ -14,21 +14,26 @@
 package io.fleak.zephflow.lib.commands.kafkasink;
 
 import static io.fleak.zephflow.lib.utils.MiscUtils.COMMAND_NAME_KAFKA_SINK;
+import static io.fleak.zephflow.lib.utils.MiscUtils.basicCommandMetricTags;
 
 import io.fleak.zephflow.api.*;
 import io.fleak.zephflow.api.metric.FleakCounter;
 import io.fleak.zephflow.api.metric.MetricClientProvider;
 import io.fleak.zephflow.api.metric.MetricClientProvider.NoopMetricClientProvider.NoopFleakCounter;
 import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.sink.ChronicleStoreForward;
 import io.fleak.zephflow.lib.commands.sink.PassThroughMessagePreProcessor;
 import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
 import io.fleak.zephflow.lib.commands.sink.SinkExecutionContext;
+import io.fleak.zephflow.lib.commands.sink.SinkStoreForward;
 import io.fleak.zephflow.lib.pathselect.PathExpression;
 import io.fleak.zephflow.lib.serdes.EncodingType;
 import io.fleak.zephflow.lib.serdes.ser.FleakSerializer;
 import io.fleak.zephflow.lib.serdes.ser.SerializerFactory;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import org.apache.commons.lang3.StringUtils;
@@ -67,19 +72,34 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
         createSinkCounters(metricClientProvider, jobContext, commandName(), nodeId);
 
     KafkaSinkDto.Config config = (KafkaSinkDto.Config) commandConfig;
+    KafkaConnectionFailureClassifier classifier =
+        config.isStoreAndForwardEnabled() ? new KafkaConnectionFailureClassifier() : null;
+
     SimpleSinkCommand.Flusher<RecordFleakData> flusher =
         createKafkaFlusher(
             config,
             counters.sinkOutputCounter(),
             counters.outputSizeCounter(),
-            counters.sinkErrorCounter());
+            counters.sinkErrorCounter(),
+            classifier);
 
     SimpleSinkCommand.SinkMessagePreProcessor<RecordFleakData> messagePreProcessor =
         new PassThroughMessagePreProcessor();
 
+    SinkStoreForward storeForward =
+        createStoreForward(
+            metricClientProvider,
+            jobContext,
+            config,
+            nodeId,
+            flusher,
+            messagePreProcessor,
+            classifier);
+
     return new SinkExecutionContext<>(
         flusher,
         messagePreProcessor,
+        storeForward,
         counters.inputMessageCounter(),
         counters.errorCounter(),
         new NoopFleakCounter(),
@@ -91,7 +111,8 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
       KafkaSinkDto.Config config,
       FleakCounter asyncDeliveredCountCounter,
       FleakCounter asyncDeliveredSizeCounter,
-      FleakCounter asyncErrorCounter) {
+      FleakCounter asyncErrorCounter,
+      KafkaConnectionFailureClassifier classifier) {
     Properties props = getProperties(config);
 
     boolean isTestMode =
@@ -99,6 +120,14 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
             && Boolean.TRUE.equals(jobContext.getOtherProperties().get(JobContext.FLAG_TEST_MODE));
     if (isTestMode) {
       props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "10000");
+    }
+
+    if (config.isStoreAndForwardEnabled()) {
+      // Bounded timeouts so an outage surfaces quickly as a thrown failure (-> buffer) instead of
+      // blocking. delivery.timeout.ms must be >= request.timeout.ms + linger.ms.
+      props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "5000");
+      props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, "2000");
+      props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, "5000");
     }
 
     if (config.getProperties() != null) {
@@ -129,7 +158,60 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
         partitionKeyExpression,
         asyncDeliveredCountCounter,
         asyncDeliveredSizeCounter,
-        asyncErrorCounter);
+        asyncErrorCounter,
+        config.isStoreAndForwardEnabled(),
+        classifier);
+  }
+
+  private static final int STORE_FORWARD_DRAIN_CHUNK = 1000;
+  private static final String METRIC_NAME_STORE_FORWARD_BUFFERED = "store_forward_buffered_count";
+  private static final String METRIC_NAME_STORE_FORWARD_REPLAYED = "store_forward_replayed_count";
+  private static final String METRIC_NAME_STORE_FORWARD_DROPPED = "store_forward_dropped_count";
+
+  private SinkStoreForward createStoreForward(
+      MetricClientProvider metricClientProvider,
+      JobContext jobContext,
+      KafkaSinkDto.Config config,
+      String nodeId,
+      SimpleSinkCommand.Flusher<RecordFleakData> flusher,
+      SimpleSinkCommand.SinkMessagePreProcessor<RecordFleakData> preprocessor,
+      KafkaConnectionFailureClassifier classifier) {
+    if (!config.isStoreAndForwardEnabled()) {
+      return SinkStoreForward.noop();
+    }
+
+    Path storePath =
+        (config.getLocalStorePath() != null && !config.getLocalStorePath().isBlank())
+            ? Path.of(config.getLocalStorePath(), nodeId)
+            : Path.of(System.getProperty("java.io.tmpdir"), "zephflow-store-forward", nodeId);
+
+    Map<String, String> metricTags =
+        basicCommandMetricTags(jobContext.getMetricTags(), commandName(), nodeId);
+
+    ChronicleStoreForward storeForward =
+        new ChronicleStoreForward(
+            new ChronicleStoreForward.Config(
+                storePath,
+                config.getLocalStoreMaxBytes(),
+                config.getForwardRetryIntervalMillis(),
+                STORE_FORWARD_DRAIN_CHUNK,
+                nodeId),
+            classifier,
+            metricClientProvider.counter(METRIC_NAME_STORE_FORWARD_BUFFERED, metricTags),
+            metricClientProvider.counter(METRIC_NAME_STORE_FORWARD_REPLAYED, metricTags),
+            metricClientProvider.counter(METRIC_NAME_STORE_FORWARD_DROPPED, metricTags));
+
+    storeForward.start(
+        records -> {
+          SimpleSinkCommand.PreparedInputEvents<RecordFleakData> prepared =
+              new SimpleSinkCommand.PreparedInputEvents<>();
+          long ts = System.currentTimeMillis();
+          for (RecordFleakData record : records) {
+            prepared.add(record, preprocessor.preprocess(record, ts));
+          }
+          flusher.flush(prepared, Map.of());
+        });
+    return storeForward;
   }
 
   private static @NotNull Properties getProperties(KafkaSinkDto.Config config) {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkConfigValidator.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkConfigValidator.java
@@ -38,5 +38,17 @@ public class KafkaSinkConfigValidator implements ConfigValidator {
     if (StringUtils.isNotBlank(config.getPartitionKeyFieldExpressionStr())) {
       PathExpression.fromString(config.getPartitionKeyFieldExpressionStr());
     }
+    if (config.isStoreAndForwardEnabled()) {
+      if (config.getLocalStoreMaxBytes() <= 0) {
+        throw new IllegalArgumentException(
+            "localStoreMaxBytes must be positive when storeAndForwardEnabled. Got: "
+                + config.getLocalStoreMaxBytes());
+      }
+      if (config.getForwardRetryIntervalMillis() <= 0) {
+        throw new IllegalArgumentException(
+            "forwardRetryIntervalMillis must be positive when storeAndForwardEnabled. Got: "
+                + config.getForwardRetryIntervalMillis());
+      }
+    }
   }
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDto.java
@@ -28,5 +28,21 @@ public interface KafkaSinkDto {
     private String partitionKeyFieldExpressionStr;
     @NonNull private String encodingType;
     private Map<String, String> properties;
+
+    /**
+     * Store-and-forward: when enabled, a connectivity failure persists records to a local durable
+     * queue and replays them once the broker is reachable again, instead of dropping them. This
+     * also switches the producer to synchronous delivery so failures are detected at flush time.
+     */
+    @Builder.Default private boolean storeAndForwardEnabled = false;
+
+    /** Directory for the local store-and-forward queue. Defaults to a temp dir keyed by node id. */
+    private String localStorePath;
+
+    /** Hard cap on local store size; once reached, incoming records are dropped. */
+    @Builder.Default private long localStoreMaxBytes = 1_073_741_824L; // 1 GiB
+
+    /** How often the background forwarder retries draining the local queue during an outage. */
+    @Builder.Default private long forwardRetryIntervalMillis = 5_000L;
   }
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkFlusher.java
@@ -18,21 +18,30 @@ import static io.fleak.zephflow.lib.utils.JsonUtils.toJsonString;
 import io.fleak.zephflow.api.ErrorOutput;
 import io.fleak.zephflow.api.metric.FleakCounter;
 import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.sink.ConnectionFailureClassifier;
 import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
 import io.fleak.zephflow.lib.pathselect.PathExpression;
 import io.fleak.zephflow.lib.serdes.ser.FleakSerializer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.PartitionInfo;
 
 /**
- * Fire-and-forget Kafka sink flusher that sends records directly to Kafka producer. Relies on
- * Kafka's native batching (batch.size, linger.ms) for throughput optimization.
+ * Kafka sink flusher. By default it is fire-and-forget (relies on Kafka's native batching for
+ * throughput and reports delivery via async callbacks). When constructed in <b>synchronous</b> mode
+ * (used by store-and-forward), it instead waits for acks and <b>throws</b> a connectivity failure
+ * when delivery fails, so {@link SimpleSinkCommand} can buffer the batch locally and replay it once
+ * the broker is reachable again.
  */
 @Slf4j
 public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakData> {
@@ -45,6 +54,11 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
   private final FleakCounter asyncDeliveredSizeCounter;
   private final FleakCounter asyncErrorCounter;
 
+  // Synchronous delivery: when enabled the flusher waits for acks and throws connectivity failures
+  // (classified via this classifier) so store-and-forward can buffer + replay. Null in async mode.
+  private final boolean synchronousDelivery;
+  private final ConnectionFailureClassifier connectionFailureClassifier;
+
   private volatile boolean closed = false;
 
   public KafkaSinkFlusher(
@@ -55,6 +69,28 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
       @NonNull FleakCounter asyncDeliveredCountCounter,
       @NonNull FleakCounter asyncDeliveredSizeCounter,
       @NonNull FleakCounter asyncErrorCounter) {
+    this(
+        producer,
+        topic,
+        fleakSerializer,
+        partitionKeyExpression,
+        asyncDeliveredCountCounter,
+        asyncDeliveredSizeCounter,
+        asyncErrorCounter,
+        false,
+        null);
+  }
+
+  public KafkaSinkFlusher(
+      @NonNull KafkaProducer<byte[], byte[]> producer,
+      @NonNull String topic,
+      @NonNull FleakSerializer<?> fleakSerializer,
+      PathExpression partitionKeyExpression,
+      @NonNull FleakCounter asyncDeliveredCountCounter,
+      @NonNull FleakCounter asyncDeliveredSizeCounter,
+      @NonNull FleakCounter asyncErrorCounter,
+      boolean synchronousDelivery,
+      ConnectionFailureClassifier connectionFailureClassifier) {
     this.producer = producer;
     this.topic = topic;
     this.fleakSerializer = fleakSerializer;
@@ -62,6 +98,8 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
     this.asyncDeliveredCountCounter = asyncDeliveredCountCounter;
     this.asyncDeliveredSizeCounter = asyncDeliveredSizeCounter;
     this.asyncErrorCounter = asyncErrorCounter;
+    this.synchronousDelivery = synchronousDelivery;
+    this.connectionFailureClassifier = connectionFailureClassifier;
   }
 
   @Override
@@ -79,26 +117,23 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
       return new SimpleSinkCommand.FlushResult(0, 0, List.of());
     }
 
+    return synchronousDelivery
+        ? flushSynchronously(events, metricTags)
+        : flushFireAndForget(events, metricTags);
+  }
+
+  private SimpleSinkCommand.FlushResult flushFireAndForget(
+      List<RecordFleakData> events, Map<String, String> metricTags) {
     List<ErrorOutput> errorOutputs = new ArrayList<>();
     int sentCount = 0;
 
     for (RecordFleakData event : events) {
       try {
-        var serializedEvent = fleakSerializer.serialize(List.of(event));
-        byte[] keyBytesValue = null;
-
-        if (partitionKeyExpression != null) {
-          String keyValue = partitionKeyExpression.getStringValueFromEventOrDefault(event, null);
-          if (keyValue != null) {
-            keyBytesValue = keyValue.getBytes(StandardCharsets.UTF_8);
-          }
-        }
-
-        var eventValue = serializedEvent.value();
-
-        if (eventValue == null || eventValue.length == 0) {
+        byte[] eventValue = serializeValue(event);
+        if (eventValue == null) {
           continue;
         }
+        byte[] keyBytesValue = keyBytes(event);
         producer.send(
             new ProducerRecord<>(topic, keyBytesValue, eventValue),
             (metadata, exception) -> {
@@ -110,11 +145,6 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
               }
               asyncDeliveredCountCounter.increase(metricTags);
               asyncDeliveredSizeCounter.increase(eventValue.length, metricTags);
-              log.debug(
-                  "Sent event to Kafka: topic={}, partition={}, offset={}",
-                  metadata.topic(),
-                  metadata.partition(),
-                  metadata.offset());
             });
         sentCount++;
       } catch (Exception e) {
@@ -122,13 +152,99 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
         errorOutputs.add(new ErrorOutput(event, e.getMessage()));
       }
     }
-
-    log.debug(
-        "Flush completed: {} records sent to producer, {} sync errors",
-        sentCount,
-        errorOutputs.size());
-
     return new SimpleSinkCommand.FlushResult(sentCount, 0, errorOutputs);
+  }
+
+  /**
+   * Sends the batch and waits for acks. A connectivity failure is rethrown so the whole batch is
+   * buffered by store-and-forward; a permanent per-record failure stays an {@link ErrorOutput}.
+   */
+  private SimpleSinkCommand.FlushResult flushSynchronously(
+      List<RecordFleakData> events, Map<String, String> metricTags) throws Exception {
+    // One bounded metadata probe up front. If the broker is unreachable it throws a connectivity
+    // failure after a single wait, buffering the whole batch at once. Without it, on a cold start
+    // each send() below would separately block max.block.ms waiting for metadata (N x the cost).
+    ensureBrokerReachable();
+
+    List<ErrorOutput> errorOutputs = new ArrayList<>();
+    List<Inflight> inflight = new ArrayList<>();
+
+    for (RecordFleakData event : events) {
+      try {
+        byte[] eventValue = serializeValue(event);
+        if (eventValue == null) {
+          continue;
+        }
+        Future<RecordMetadata> future =
+            producer.send(new ProducerRecord<>(topic, keyBytes(event), eventValue));
+        inflight.add(new Inflight(event, eventValue.length, future));
+      } catch (Exception e) {
+        rethrowIfConnectivity(e); // never reached the broker
+        errorOutputs.add(new ErrorOutput(event, e.getMessage()));
+      }
+    }
+
+    producer.flush(); // ensure every send has been attempted before we wait on the acks
+
+    long deliveredSize = 0;
+    int delivered = 0;
+    for (Inflight item : inflight) {
+      try {
+        item.future.get();
+        delivered++;
+        deliveredSize += item.size;
+        asyncDeliveredCountCounter.increase(metricTags);
+        asyncDeliveredSizeCounter.increase(item.size, metricTags);
+      } catch (ExecutionException e) {
+        rethrowIfConnectivity(e.getCause());
+        errorOutputs.add(new ErrorOutput(item.event, e.getCause().getMessage()));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw e;
+      }
+    }
+    return new SimpleSinkCommand.FlushResult(delivered, deliveredSize, errorOutputs);
+  }
+
+  /**
+   * Single bounded check that the broker is reachable (metadata for the topic is obtainable). If it
+   * is not, throw the connectivity failure so the caller buffers the whole batch after one wait
+   * rather than paying {@code max.block.ms} on every per-record {@code send()}.
+   */
+  private void ensureBrokerReachable() {
+    try {
+      List<PartitionInfo> partitions = producer.partitionsFor(topic);
+      if (partitions == null || partitions.isEmpty()) {
+        throw new org.apache.kafka.common.errors.TimeoutException(
+            "No partition metadata available for topic " + topic);
+      }
+    } catch (Exception e) {
+      rethrowIfConnectivity(e);
+      // Not a connectivity failure: let the per-record send loop surface it as needed.
+    }
+  }
+
+  private void rethrowIfConnectivity(Throwable t) {
+    if (connectionFailureClassifier != null && connectionFailureClassifier.isConnectionFailure(t)) {
+      if (t instanceof RuntimeException re) {
+        throw re;
+      }
+      throw new RuntimeException(t);
+    }
+  }
+
+  private byte[] serializeValue(RecordFleakData event) throws Exception {
+    var serializedEvent = fleakSerializer.serialize(List.of(event));
+    byte[] eventValue = serializedEvent.value();
+    return (eventValue == null || eventValue.length == 0) ? null : eventValue;
+  }
+
+  private byte[] keyBytes(RecordFleakData event) {
+    if (partitionKeyExpression == null) {
+      return null;
+    }
+    String keyValue = partitionKeyExpression.getStringValueFromEventOrDefault(event, null);
+    return keyValue == null ? null : keyValue.getBytes(StandardCharsets.UTF_8);
   }
 
   @Override
@@ -136,9 +252,12 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
     if (closed) {
       return;
     }
-
     closed = true;
-    producer.close();
+    // Bound shutdown: a wedged producer (e.g. broker unreachable) must not hang terminate()
+    // indefinitely while it retries to flush undelivered records.
+    producer.close(Duration.ofSeconds(10));
     log.info("KafkaSinkFlusher closed successfully");
   }
+
+  private record Inflight(RecordFleakData event, int size, Future<RecordMetadata> future) {}
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/ChronicleStoreForward.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/ChronicleStoreForward.java
@@ -1,0 +1,397 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sink;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.fleak.zephflow.api.metric.FleakCounter;
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.utils.JsonUtils;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.extern.slf4j.Slf4j;
+import net.openhft.chronicle.core.io.SingleThreadedChecked;
+import net.openhft.chronicle.queue.ChronicleQueue;
+import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
+import net.openhft.chronicle.wire.DocumentContext;
+
+/**
+ * Chronicle-Queue-backed {@link SinkStoreForward}. Persists raw records to an append-only disk
+ * queue during a connectivity outage, and a single background worker drains them back to the remote
+ * oldest-first once it recovers.
+ *
+ * <p>State machine (held entirely here; the sink command just asks {@link #isBuffering()}):
+ *
+ * <ul>
+ *   <li><b>DIRECT</b> ({@code buffering == false}) — healthy; the sink writes straight to remote.
+ *   <li><b>BUFFERING</b> ({@code buffering == true}) — outage; {@link #offer} appends to disk and
+ *       the worker keeps trying to drain. When the queue empties (confirmed under {@code stateLock}
+ *       so a concurrent {@link #offer} cannot leapfrog it), it flips back to DIRECT.
+ * </ul>
+ *
+ * <p>Durability across restarts uses an explicit <i>delivered watermark</i> written to a small ack
+ * file, advanced only after a chunk is successfully delivered (or permanently dropped). We do not
+ * use a named Chronicle tailer, whose auto-persisted read position would advance past records that
+ * were read but not yet delivered — losing them on a mid-outage restart.
+ */
+@Slf4j
+public class ChronicleStoreForward implements SinkStoreForward {
+
+  public record Config(
+      Path storePath, long maxBytes, long retryIntervalMs, int drainChunkSize, String nodeId) {}
+
+  private static final String PAYLOAD_KEY = "r";
+  private static final String ACK_FILE_NAME = "sf-ack.idx";
+  private static final String ACK_CAUGHT_UP = "END";
+
+  private final long maxBytes;
+  private final long retryIntervalMs;
+  private final int drainChunkSize;
+  private final String nodeId;
+  private final ConnectionFailureClassifier classifier;
+
+  private final FleakCounter bufferedCounter;
+  private final FleakCounter replayedCounter;
+  private final FleakCounter droppedCounter;
+
+  private final ChronicleQueue queue;
+  private final ExcerptAppender appender;
+  private final ExcerptTailer tailer;
+  private final Path ackFile;
+
+  // Outstanding bytes still on disk (appended minus drained). Bounds disk use against maxBytes.
+  // Reset to 0 on restart: the cap then applies to newly appended data only.
+  private final AtomicLong outstandingBytes = new AtomicLong(0);
+
+  private final Object stateLock = new Object();
+  private volatile boolean buffering = false;
+  private volatile boolean closed = false;
+
+  private ReplayTarget replayTarget;
+  private Thread worker;
+
+  public ChronicleStoreForward(
+      Config config,
+      ConnectionFailureClassifier classifier,
+      FleakCounter bufferedCounter,
+      FleakCounter replayedCounter,
+      FleakCounter droppedCounter) {
+    this.maxBytes = config.maxBytes();
+    this.retryIntervalMs = config.retryIntervalMs();
+    this.drainChunkSize = config.drainChunkSize();
+    this.nodeId = config.nodeId();
+    this.classifier = classifier;
+    this.bufferedCounter = bufferedCounter;
+    this.replayedCounter = replayedCounter;
+    this.droppedCounter = droppedCounter;
+    this.queue = SingleChronicleQueueBuilder.single(config.storePath().toFile()).build();
+    this.appender = queue.createAppender();
+    this.tailer = queue.createTailer();
+    this.ackFile = config.storePath().resolve(ACK_FILE_NAME);
+    // We manage threading ourselves: the appender is only touched from offer() under stateLock, the
+    // tailer only from the worker (and from start() before the worker exists). Chronicle's
+    // single-thread ownership check is too strict for that controlled hand-off, so disable it.
+    ((SingleThreadedChecked) appender).singleThreadedCheckDisabled(true);
+    ((SingleThreadedChecked) tailer).singleThreadedCheckDisabled(true);
+  }
+
+  @Override
+  public boolean isBuffering() {
+    return buffering;
+  }
+
+  @Override
+  public boolean shouldBuffer(Throwable t) {
+    return classifier.isConnectionFailure(t);
+  }
+
+  @Override
+  public int offer(List<RecordFleakData> records) {
+    if (records.isEmpty()) {
+      return 0;
+    }
+    int stored = 0;
+    synchronized (stateLock) {
+      for (RecordFleakData record : records) {
+        byte[] payload = encode(record);
+        long need = payload.length + (long) Integer.BYTES;
+        if (outstandingBytes.get() + need > maxBytes) {
+          break; // cap reached; drop the remaining tail
+        }
+        append(payload);
+        outstandingBytes.addAndGet(need);
+        stored++;
+      }
+      inc(bufferedCounter, stored);
+      int dropped = records.size() - stored;
+      if (dropped > 0) {
+        inc(droppedCounter, dropped);
+        log.warn(
+            "store-and-forward [{}] local store full (cap {} bytes); dropped {} records",
+            nodeId,
+            maxBytes,
+            dropped);
+      }
+      buffering = true;
+      stateLock.notifyAll();
+    }
+    return stored;
+  }
+
+  @Override
+  public void start(ReplayTarget target) {
+    this.replayTarget = target;
+    positionFromAck();
+    // Resume a backlog from a previous run before the sink does any direct write.
+    if (peekHasMore()) {
+      buffering = true;
+      log.info("store-and-forward [{}] found a backlog on startup; resuming drain", nodeId);
+    }
+    worker = new Thread(this::drainLoop, "sink-store-forward-" + nodeId);
+    worker.setDaemon(true);
+    worker.start();
+  }
+
+  @Override
+  public void close() {
+    synchronized (stateLock) {
+      closed = true;
+      stateLock.notifyAll();
+    }
+    if (worker != null) {
+      try {
+        worker.join(TimeUnit.SECONDS.toMillis(30));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+    queue.close();
+  }
+
+  // ===== worker =====
+
+  private enum DrainOutcome {
+    DELIVERED,
+    CONN_FAILURE,
+    DRAINED
+  }
+
+  private void drainLoop() {
+    while (true) {
+      synchronized (stateLock) {
+        while (!buffering && !closed) {
+          try {
+            stateLock.wait();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+        }
+        if (closed) {
+          return;
+        }
+      }
+      try {
+        if (drainOnce() == DrainOutcome.CONN_FAILURE) {
+          sleepBeforeRetry();
+        }
+      } catch (RuntimeException e) {
+        // Never let the worker die silently: log, back off, and try again.
+        log.error("store-and-forward [{}] unexpected drain error", nodeId, e);
+        sleepBeforeRetry();
+      }
+    }
+  }
+
+  private DrainOutcome drainOnce() {
+    Chunk chunk = readChunk();
+    if (chunk.records.isEmpty()) {
+      // Nothing to read. Confirm the queue is truly empty under the lock so an offer() racing the
+      // flip cannot slip a record behind us, then return to DIRECT.
+      synchronized (stateLock) {
+        if (!peekHasMore()) {
+          buffering = false;
+          return DrainOutcome.DRAINED;
+        }
+      }
+      return DrainOutcome.DELIVERED;
+    }
+    try {
+      replayTarget.deliver(chunk.records);
+      outstandingBytes.addAndGet(-chunk.bytes);
+      inc(replayedCounter, chunk.records.size());
+      advanceAck();
+      return DrainOutcome.DELIVERED;
+    } catch (Exception e) {
+      if (classifier.isConnectionFailure(e)) {
+        tailer.moveToIndex(chunk.startIndex); // rewind; keep the records for the next attempt
+        log.warn(
+            "store-and-forward [{}] replay hit a connectivity failure, will retry: {}",
+            nodeId,
+            e.getMessage());
+        return DrainOutcome.CONN_FAILURE;
+      }
+      // Permanent failure: these records can never be delivered. The tailer has already advanced
+      // past them, so account for the drop and advance the watermark so we don't re-read them.
+      outstandingBytes.addAndGet(-chunk.bytes);
+      inc(droppedCounter, chunk.records.size());
+      advanceAck();
+      log.error(
+          "store-and-forward [{}] dropping {} records after a non-connectivity replay failure",
+          nodeId,
+          chunk.records.size(),
+          e);
+      return DrainOutcome.DELIVERED;
+    }
+  }
+
+  private Chunk readChunk() {
+    List<RecordFleakData> records = new ArrayList<>();
+    long bytes = 0;
+    long startIndex = -1;
+    for (int i = 0; i < drainChunkSize; i++) {
+      try (DocumentContext dc = tailer.readingDocument()) {
+        if (!dc.isPresent()) {
+          break;
+        }
+        if (startIndex == -1) {
+          startIndex = dc.index();
+        }
+        byte[] arr = dc.wire().read(PAYLOAD_KEY).bytes();
+        records.add(decode(arr));
+        bytes += arr.length + (long) Integer.BYTES;
+      }
+    }
+    return new Chunk(records, bytes, startIndex);
+  }
+
+  /** Worker-thread / pre-worker only. True if an unread excerpt exists, without consuming it. */
+  private boolean peekHasMore() {
+    return peekNextIndex() != -1;
+  }
+
+  /** Reads the next excerpt's index without consuming it (rewinds the tailer to it); -1 if none. */
+  private long peekNextIndex() {
+    long index;
+    try (DocumentContext dc = tailer.readingDocument()) {
+      if (!dc.isPresent()) {
+        return -1;
+      }
+      index = dc.index();
+    }
+    // moveToIndex must be called after the reading context is closed, otherwise it is ignored.
+    tailer.moveToIndex(index);
+    return index;
+  }
+
+  // ===== delivered watermark (restart durability) =====
+
+  /** Positions the tailer at the persisted delivered watermark, or leaves it at the queue start. */
+  private void positionFromAck() {
+    String token = readAck();
+    if (token == null) {
+      return; // fresh queue: tailer is at the start
+    }
+    if (ACK_CAUGHT_UP.equals(token)) {
+      tailer.toEnd();
+      return;
+    }
+    try {
+      if (!tailer.moveToIndex(Long.parseLong(token))) {
+        log.warn("store-and-forward [{}] could not seek to ack index {}", nodeId, token);
+      }
+    } catch (NumberFormatException e) {
+      log.warn("store-and-forward [{}] ignoring malformed ack token: {}", nodeId, token);
+    }
+  }
+
+  /** Records the next undelivered index (or caught-up) as the durable watermark after a chunk. */
+  private void advanceAck() {
+    long next = peekNextIndex();
+    writeAck(next >= 0 ? Long.toString(next) : ACK_CAUGHT_UP);
+  }
+
+  private String readAck() {
+    try {
+      if (!Files.exists(ackFile)) {
+        return null;
+      }
+      return Files.readString(ackFile, StandardCharsets.UTF_8).trim();
+    } catch (Exception e) {
+      log.warn("store-and-forward [{}] could not read ack file", nodeId, e);
+      return null;
+    }
+  }
+
+  private void writeAck(String token) {
+    try {
+      Files.writeString(ackFile, token, StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      log.warn("store-and-forward [{}] could not persist ack watermark", nodeId, e);
+    }
+  }
+
+  private void sleepBeforeRetry() {
+    synchronized (stateLock) {
+      if (closed) {
+        return;
+      }
+      try {
+        stateLock.wait(retryIntervalMs);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  private void append(byte[] payload) {
+    try (DocumentContext dc = appender.writingDocument()) {
+      dc.wire().write(PAYLOAD_KEY).bytes(payload);
+    }
+  }
+
+  private static byte[] encode(RecordFleakData record) {
+    try {
+      return JsonUtils.OBJECT_MAPPER.writeValueAsBytes(record.unwrap());
+    } catch (Exception e) {
+      throw new RuntimeException("failed to serialize record for store-and-forward", e);
+    }
+  }
+
+  private static RecordFleakData decode(byte[] bytes) {
+    try {
+      Map<String, Object> map =
+          JsonUtils.OBJECT_MAPPER.readValue(bytes, new TypeReference<Map<String, Object>>() {});
+      return (RecordFleakData) FleakData.wrap(map);
+    } catch (Exception e) {
+      throw new RuntimeException("failed to deserialize record for store-and-forward", e);
+    }
+  }
+
+  private static void inc(FleakCounter counter, long n) {
+    if (counter != null && n > 0) {
+      counter.increase(n, Map.of());
+    }
+  }
+
+  private record Chunk(List<RecordFleakData> records, long bytes, long startIndex) {}
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/ConnectionFailureClassifier.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/ConnectionFailureClassifier.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sink;
+
+/**
+ * Decides whether a flush failure is a transient connectivity failure (which store-and-forward
+ * should buffer and retry) rather than a permanent one (bad record, auth, schema). This is
+ * per-sink: each SDK surfaces connectivity differently, so the owning sink supplies the rule.
+ *
+ * <p>Implementations should default to {@code false} for anything they don't recognize, so an
+ * unknown failure stays on the normal error path rather than being hoarded forever.
+ */
+@FunctionalInterface
+public interface ConnectionFailureClassifier {
+  boolean isConnectionFailure(Throwable t);
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/NoOpSinkStoreForward.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/NoOpSinkStoreForward.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sink;
+
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import java.util.List;
+
+/**
+ * Null Object implementation. A sink wired with this behaves exactly as if store-and-forward did
+ * not exist.
+ */
+class NoOpSinkStoreForward implements SinkStoreForward {
+
+  static final NoOpSinkStoreForward INSTANCE = new NoOpSinkStoreForward();
+
+  private NoOpSinkStoreForward() {}
+
+  @Override
+  public boolean isBuffering() {
+    return false;
+  }
+
+  @Override
+  public boolean shouldBuffer(Throwable t) {
+    return false;
+  }
+
+  @Override
+  public int offer(List<RecordFleakData> records) {
+    return 0;
+  }
+
+  @Override
+  public void start(ReplayTarget target) {}
+
+  @Override
+  public void close() {}
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/RetriableConnectionException.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/RetriableConnectionException.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sink;
+
+/**
+ * Marker for a clean transient connectivity failure where nothing was sent to the remote (e.g. the
+ * sink could not (re)establish its connection). Safe for store-and-forward to buffer and replay.
+ */
+public class RetriableConnectionException extends RuntimeException {
+  public RetriableConnectionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SimpleSinkCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SimpleSinkCommand.java
@@ -49,6 +49,15 @@ public abstract class SimpleSinkCommand<T> extends ScalarSinkCommand {
       List<RecordFleakData> events, @NonNull String callingUser, ExecutionContext context) {
     Map<String, String> tags =
         getCallingUserTagAndEventTags(callingUser, events.isEmpty() ? null : events.getFirst());
+
+    //noinspection unchecked
+    SinkExecutionContext<T> sinkContext = (SinkExecutionContext<T>) context;
+    // Outage fast-path: while store-and-forward is buffering, route everything straight to disk
+    // (no remote attempt) so we don't reorder ahead of already-queued records.
+    if (sinkContext.storeForward().isBuffering()) {
+      return bufferDuringOutage(events, tags, sinkContext);
+    }
+
     List<List<RecordFleakData>> batches = Lists.partition(events, batchSize());
     long ts = System.currentTimeMillis();
 
@@ -122,11 +131,19 @@ public abstract class SimpleSinkCommand<T> extends ScalarSinkCommand {
     FlushResult flushResult;
     try {
       flushResult = sinkContext.flusher().flush(preparedInputEvents, callingUserTag);
-    } catch (UnknownSinkCommitStateException e) {
-      // Records may already be committed; we cannot honestly report them as failed (in the non-DLQ
-      // path failed records are silently dropped). Let it propagate as a fatal node/job error.
-      throw e;
     } catch (Exception e) {
+      // Connectivity failure with store-and-forward enrolled: persist the prepared records to local
+      // storage instead of dropping them. Only records that preprocessed successfully are buffered;
+      // preprocess errors stay on the normal error path.
+      if (sinkContext.storeForward().shouldBuffer(e)) {
+        return bufferFailedBatch(
+            batch, preparedInputEvents, errorOutputs, callingUserTag, sinkContext);
+      }
+      if (e instanceof UnknownSinkCommitStateException unknownState) {
+        // Records may already be committed; we cannot honestly report them as failed (in the
+        // non-DLQ path failed records are silently dropped). Let it propagate as a fatal job error.
+        throw unknownState;
+      }
       log.debug("failed to write to sink", e);
       // if error is thrown, it's a complete failure
       List<ErrorOutput> error =
@@ -141,6 +158,49 @@ public abstract class SimpleSinkCommand<T> extends ScalarSinkCommand {
     SinkResult sinkResult = new SinkResult(batch.size(), flushResult.successCount, errorOutputs);
     sinkContext.sinkErrorCounter().increase(sinkResult.errorCount(), callingUserTag);
     return sinkResult;
+  }
+
+  private static final String STORE_FORWARD_FULL_MSG =
+      "store-and-forward local buffer is full; record dropped";
+
+  /**
+   * Outage path from {@link #writeToSink}: persist all events to local storage, none sent to
+   * remote.
+   */
+  private SinkResult bufferDuringOutage(
+      List<RecordFleakData> events, Map<String, String> tags, SinkExecutionContext<T> sinkContext) {
+    sinkContext.inputMessageCounter().increase(events.size(), tags);
+    int stored = sinkContext.storeForward().offer(events);
+    List<ErrorOutput> errors = new ArrayList<>();
+    for (int i = stored; i < events.size(); i++) {
+      errors.add(new ErrorOutput(events.get(i), STORE_FORWARD_FULL_MSG));
+    }
+    // Buffered records are safely persisted, so they count as success and the pipeline proceeds.
+    SinkResult result = new SinkResult(events.size(), stored, errors);
+    sinkContext.sinkErrorCounter().increase(result.errorCount(), tags);
+    return result;
+  }
+
+  /**
+   * Failure path from {@link #writeOneBatch}: buffer the prepared records of a batch that hit a
+   * connectivity failure.
+   */
+  private SinkResult bufferFailedBatch(
+      List<RecordFleakData> batch,
+      PreparedInputEvents<T> preparedInputEvents,
+      List<ErrorOutput> preprocessErrors,
+      Map<String, String> tags,
+      SinkExecutionContext<T> sinkContext) {
+    List<RecordFleakData> raws =
+        preparedInputEvents.rawAndPreparedList().stream().map(Pair::getKey).toList();
+    int stored = sinkContext.storeForward().offer(raws);
+    List<ErrorOutput> errors = new ArrayList<>(preprocessErrors);
+    for (int i = stored; i < raws.size(); i++) {
+      errors.add(new ErrorOutput(raws.get(i), STORE_FORWARD_FULL_MSG));
+    }
+    SinkResult result = new SinkResult(batch.size(), stored, errors);
+    sinkContext.sinkErrorCounter().increase(result.errorCount(), tags);
+    return result;
   }
 
   public interface SinkMessagePreProcessor<T> {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SinkExecutionContext.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SinkExecutionContext.java
@@ -20,12 +20,15 @@ import java.io.IOException;
 /**
  * Created by bolei on 9/3/24
  *
+ * @param storeForward store-and-forward collaborator; {@link SinkStoreForward#noop()} for sinks
+ *     that have not enrolled (the default), so they keep their exact current behavior.
  * @param errorCounter error count during preparation phase
  * @param sinkErrorCounter error count during flushing phase
  */
 public record SinkExecutionContext<T>(
     SimpleSinkCommand.Flusher<T> flusher,
     SimpleSinkCommand.SinkMessagePreProcessor<T> messagePreProcessor,
+    SinkStoreForward storeForward,
     FleakCounter inputMessageCounter,
     FleakCounter errorCounter,
     FleakCounter sinkOutputCounter,
@@ -33,10 +36,33 @@ public record SinkExecutionContext<T>(
     FleakCounter sinkErrorCounter)
     implements ExecutionContext {
 
+  /** Convenience constructor for sinks that have not enrolled in store-and-forward. */
+  public SinkExecutionContext(
+      SimpleSinkCommand.Flusher<T> flusher,
+      SimpleSinkCommand.SinkMessagePreProcessor<T> messagePreProcessor,
+      FleakCounter inputMessageCounter,
+      FleakCounter errorCounter,
+      FleakCounter sinkOutputCounter,
+      FleakCounter outputSizeCounter,
+      FleakCounter sinkErrorCounter) {
+    this(
+        flusher,
+        messagePreProcessor,
+        SinkStoreForward.noop(),
+        inputMessageCounter,
+        errorCounter,
+        sinkOutputCounter,
+        outputSizeCounter,
+        sinkErrorCounter);
+  }
+
   @Override
   public void close() throws IOException {
     if (flusher != null) {
       flusher.close();
+    }
+    if (storeForward != null) {
+      storeForward.close();
     }
   }
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SinkStoreForward.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SinkStoreForward.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sink;
+
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import java.io.Closeable;
+import java.util.List;
+
+/**
+ * Store-and-forward collaborator for a sink. A sink holds a reference to one of these; when a flush
+ * fails because the remote is unreachable, the records are persisted to local durable storage and
+ * replayed once connectivity is restored, instead of being dropped.
+ *
+ * <p>This is composition + Null Object: every sink gets a {@link #noop()} by default, which does
+ * nothing and short-circuits both {@link #isBuffering()} and {@link #shouldBuffer(Throwable)} to
+ * {@code false}, so non-enrolled sinks keep their exact current behavior. A sink opts in by
+ * injecting a real implementation (e.g. {@link ChronicleStoreForward}).
+ *
+ * <p>The replay unit is the raw {@link RecordFleakData}, so the on-disk format is identical across
+ * all sinks and replay re-runs the normal preprocess+flush path (re-encoding against the current
+ * schema).
+ */
+public interface SinkStoreForward extends Closeable {
+
+  /**
+   * Whether the sink is currently in an outage and new records should be routed straight to disk.
+   */
+  boolean isBuffering();
+
+  /**
+   * Whether the given flush failure is a transient connectivity failure that should be buffered.
+   */
+  boolean shouldBuffer(Throwable t);
+
+  /**
+   * Persists the given raw records to local storage (oldest-first) and flips into buffering mode.
+   *
+   * @return the number of records stored from the front of the list; any remainder was dropped
+   *     because the local store hit its size cap.
+   */
+  int offer(List<RecordFleakData> records);
+
+  /**
+   * Starts the background forwarder. {@code target} delivers a chunk of buffered records back to
+   * the remote; it must throw on failure so the forwarder can keep the records and retry.
+   */
+  void start(ReplayTarget target);
+
+  /** Re-delivers a chunk of buffered records to the remote sink. */
+  @FunctionalInterface
+  interface ReplayTarget {
+    void deliver(List<RecordFleakData> records) throws Exception;
+  }
+
+  /** The do-nothing Null Object injected into every sink that has not enrolled. */
+  static SinkStoreForward noop() {
+    return NoOpSinkStoreForward.INSTANCE;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusConnectionFailureClassifier.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusConnectionFailureClassifier.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.zerobussink;
+
+import io.fleak.zephflow.lib.commands.sink.ConnectionFailureClassifier;
+import io.fleak.zephflow.lib.commands.sink.RetriableConnectionException;
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Classifies a Zerobus flush failure as a transient connectivity failure (buffer + retry) versus a
+ * permanent one (drop / normal error path).
+ *
+ * <p>The Zerobus flusher collapses mid-stream send failures into {@code
+ * UnknownSinkCommitStateException} and reconnect failures into {@link
+ * RetriableConnectionException}, so we walk the whole cause chain and look for the underlying
+ * network signal: an {@link IOException}, a {@link RetriableConnectionException}, or a gRPC status
+ * with a retryable code. Anything we don't recognize is treated as permanent.
+ */
+public class ZerobusConnectionFailureClassifier implements ConnectionFailureClassifier {
+
+  // gRPC status codes that mean "transient, retry": the call never reached a definitive answer.
+  private static final Set<String> RETRYABLE_GRPC_CODES =
+      Set.of("UNAVAILABLE", "DEADLINE_EXCEEDED", "RESOURCE_EXHAUSTED");
+
+  @Override
+  public boolean isConnectionFailure(Throwable t) {
+    for (Throwable cause = t;
+        cause != null && cause != cause.getCause();
+        cause = cause.getCause()) {
+      if (cause instanceof RetriableConnectionException || cause instanceof IOException) {
+        return true;
+      }
+      if (isRetryableGrpcStatus(cause)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * gRPC's {@code StatusRuntimeException} is not on our compile classpath as a hard dependency, so
+   * match it structurally: the class name ends with {@code StatusRuntimeException}/{@code
+   * StatusException} and the message starts with a retryable status code (gRPC formats it as {@code
+   * "UNAVAILABLE: ..."}).
+   */
+  private static boolean isRetryableGrpcStatus(Throwable cause) {
+    String className = cause.getClass().getName();
+    if (!className.endsWith("StatusRuntimeException") && !className.endsWith("StatusException")) {
+      return false;
+    }
+    String message = cause.getMessage();
+    if (message == null) {
+      return false;
+    }
+    int colon = message.indexOf(':');
+    String code = (colon >= 0 ? message.substring(0, colon) : message).trim();
+    return RETRYABLE_GRPC_CODES.contains(code);
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkCommand.java
@@ -17,9 +17,13 @@ import static io.fleak.zephflow.lib.utils.MiscUtils.*;
 
 import io.fleak.zephflow.api.*;
 import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.sink.ChronicleStoreForward;
 import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
 import io.fleak.zephflow.lib.commands.sink.SinkExecutionContext;
+import io.fleak.zephflow.lib.commands.sink.SinkStoreForward;
 import io.fleak.zephflow.lib.credentials.DatabricksCredential;
+import java.nio.file.Path;
 import java.util.Map;
 
 public class ZerobusSinkCommand extends SimpleSinkCommand<Map<String, Object>> {
@@ -50,15 +54,68 @@ public class ZerobusSinkCommand extends SimpleSinkCommand<Map<String, Object>> {
 
     SinkMessagePreProcessor<Map<String, Object>> preprocessor = new ZerobusMessageProcessor();
 
+    SinkStoreForward storeForward =
+        createStoreForward(metricClientProvider, jobContext, config, nodeId, flusher, preprocessor);
+
     return new SinkExecutionContext<>(
         flusher,
         preprocessor,
+        storeForward,
         counters.inputMessageCounter(),
         counters.errorCounter(),
         counters.sinkOutputCounter(),
         counters.outputSizeCounter(),
         counters.sinkErrorCounter());
   }
+
+  private SinkStoreForward createStoreForward(
+      MetricClientProvider metricClientProvider,
+      JobContext jobContext,
+      ZerobusSinkDto.Config config,
+      String nodeId,
+      Flusher<Map<String, Object>> flusher,
+      SinkMessagePreProcessor<Map<String, Object>> preprocessor) {
+    if (!config.isStoreAndForwardEnabled()) {
+      return SinkStoreForward.noop();
+    }
+
+    Path storePath =
+        (config.getLocalStorePath() != null && !config.getLocalStorePath().isBlank())
+            ? Path.of(config.getLocalStorePath(), nodeId)
+            : Path.of(System.getProperty("java.io.tmpdir"), "zephflow-store-forward", nodeId);
+
+    Map<String, String> metricTags =
+        basicCommandMetricTags(jobContext.getMetricTags(), commandName(), nodeId);
+
+    ChronicleStoreForward storeForward =
+        new ChronicleStoreForward(
+            new ChronicleStoreForward.Config(
+                storePath,
+                config.getLocalStoreMaxBytes(),
+                config.getForwardRetryIntervalMillis(),
+                batchSize(),
+                nodeId),
+            new ZerobusConnectionFailureClassifier(),
+            metricClientProvider.counter(METRIC_NAME_STORE_FORWARD_BUFFERED, metricTags),
+            metricClientProvider.counter(METRIC_NAME_STORE_FORWARD_REPLAYED, metricTags),
+            metricClientProvider.counter(METRIC_NAME_STORE_FORWARD_DROPPED, metricTags));
+
+    // Replay re-runs the normal preprocess+flush; the flusher reconnects its stream as needed.
+    storeForward.start(
+        records -> {
+          PreparedInputEvents<Map<String, Object>> prepared = new PreparedInputEvents<>();
+          long ts = System.currentTimeMillis();
+          for (RecordFleakData record : records) {
+            prepared.add(record, preprocessor.preprocess(record, ts));
+          }
+          flusher.flush(prepared, Map.of());
+        });
+    return storeForward;
+  }
+
+  private static final String METRIC_NAME_STORE_FORWARD_BUFFERED = "store_forward_buffered_count";
+  private static final String METRIC_NAME_STORE_FORWARD_REPLAYED = "store_forward_replayed_count";
+  private static final String METRIC_NAME_STORE_FORWARD_DROPPED = "store_forward_dropped_count";
 
   @Override
   public String commandName() {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkConfigValidator.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkConfigValidator.java
@@ -40,6 +40,7 @@ public class ZerobusSinkConfigValidator implements ConfigValidator {
     validateZerobusEndpoint(config.getZerobusEndpoint(), errors);
     validateTableName(config.getTableName(), errors);
     validateEncodingType(config.getEncodingType(), errors);
+    validateStoreAndForward(config, errors);
 
     // avroSchema is only used to build the protobuf descriptor. In JSON mode the stream is created
     // without a descriptor (sdk.createJsonStream), so a schema is neither required nor used.
@@ -118,6 +119,22 @@ public class ZerobusSinkConfigValidator implements ConfigValidator {
     String[] parts = tableName.split("\\.", -1);
     if (parts.length != 3 || Arrays.stream(parts).anyMatch(p -> p.trim().isEmpty())) {
       errors.add("tableName must match pattern: <catalog>.<schema>.<table>. Got: " + tableName);
+    }
+  }
+
+  private void validateStoreAndForward(Config config, List<String> errors) {
+    if (!config.isStoreAndForwardEnabled()) {
+      return;
+    }
+    if (config.getLocalStoreMaxBytes() <= 0) {
+      errors.add(
+          "localStoreMaxBytes must be positive when storeAndForwardEnabled. Got: "
+              + config.getLocalStoreMaxBytes());
+    }
+    if (config.getForwardRetryIntervalMillis() <= 0) {
+      errors.add(
+          "forwardRetryIntervalMillis must be positive when storeAndForwardEnabled. Got: "
+              + config.getForwardRetryIntervalMillis());
     }
   }
 

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkDto.java
@@ -47,5 +47,20 @@ public class ZerobusSinkDto {
 
     /** Wire encoding: {@code protobuf} (default) or {@code json}. */
     @Builder.Default private String encodingType = ENCODING_PROTOBUF;
+
+    /**
+     * Store-and-forward: when enabled, a connectivity failure persists records to a local durable
+     * queue and replays them once the connection recovers, instead of dropping them.
+     */
+    @Builder.Default private boolean storeAndForwardEnabled = false;
+
+    /** Directory for the local store-and-forward queue. Defaults to a temp dir keyed by node id. */
+    private String localStorePath;
+
+    /** Hard cap on local store size; once reached, incoming records are dropped. */
+    @Builder.Default private long localStoreMaxBytes = 1_073_741_824L; // 1 GiB
+
+    /** How often the background forwarder retries draining the local queue during an outage. */
+    @Builder.Default private long forwardRetryIntervalMillis = 5_000L;
   }
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkFlusher.java
@@ -21,6 +21,7 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 import io.fleak.zephflow.api.ErrorOutput;
 import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.sink.RetriableConnectionException;
 import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand.FlushResult;
 import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand.Flusher;
 import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand.PreparedInputEvents;
@@ -47,23 +48,35 @@ import org.apache.commons.lang3.tuple.Pair;
  *
  * <p>Delivery is at-least-once; on reconnect the SDK re-sends unacknowledged records, so downstream
  * consumers should dedupe if they need exactly-once.
+ *
+ * <p>When constructed with a {@code config} + {@code credential} (the production path), the flusher
+ * can rebuild its stream after a connectivity failure: a failed flush marks the stream unhealthy
+ * and the next flush reconnects. This is what lets the store-and-forward forwarder replay buffered
+ * records after an outage.
  */
 @Slf4j
 public class ZerobusSinkFlusher implements Flusher<Map<String, Object>> {
 
-  private final ZerobusSdk sdk;
+  // Present only on the production path; enables reconnect. Null in unit tests (mocked streams).
+  private final ZerobusSinkDto.Config config;
+  private final DatabricksCredential credential;
+
+  private ZerobusSdk sdk;
 
   // protobuf mode
-  private final ZerobusProtoStream protoStream;
-  private final Schema avroSchema;
-  private final Descriptors.Descriptor protoDescriptor;
+  private ZerobusProtoStream protoStream;
+  private Schema avroSchema;
+  private Descriptors.Descriptor protoDescriptor;
 
   // json mode
-  private final ZerobusJsonStream jsonStream;
+  private ZerobusJsonStream jsonStream;
+
+  // Set to false when a flush fails; the next flush reconnects (production path only).
+  private volatile boolean healthy = true;
 
   // The Zerobus SDK documents that ZerobusSdk and the stream classes are NOT thread-safe and must
   // be used from a single thread. We hold one long-lived stream per execution context, so serialize
-  // all stream/SDK access (incl. close) to prevent interleaved ingests or a close racing a flush.
+  // all stream/SDK access (incl. close and reconnect) to prevent interleaved ingests.
   private final Object streamLock = new Object();
 
   ZerobusSinkFlusher(
@@ -72,6 +85,8 @@ public class ZerobusSinkFlusher implements Flusher<Map<String, Object>> {
       Schema avroSchema,
       Descriptors.Descriptor protoDescriptor,
       ZerobusJsonStream jsonStream) {
+    this.config = null;
+    this.credential = null;
     this.sdk = sdk;
     this.protoStream = protoStream;
     this.avroSchema = avroSchema;
@@ -79,43 +94,68 @@ public class ZerobusSinkFlusher implements Flusher<Map<String, Object>> {
     this.jsonStream = jsonStream;
   }
 
+  private ZerobusSinkFlusher(ZerobusSinkDto.Config config, DatabricksCredential credential) {
+    this.config = config;
+    this.credential = credential;
+  }
+
   /** Opens the appropriate stream and constructs a ready-to-use flusher. */
   static ZerobusSinkFlusher create(ZerobusSinkDto.Config config, DatabricksCredential credential) {
-    ZerobusSdk sdk = ZerobusClientFactory.createClient(config.getZerobusEndpoint(), credential);
+    ZerobusSinkFlusher flusher = new ZerobusSinkFlusher(config, credential);
+    flusher.connect();
+    return flusher;
+  }
+
+  /**
+   * Opens a fresh SDK + stream from config/credential and installs them. Caller must hold {@link
+   * #streamLock} or be the constructor.
+   */
+  private void connect() {
+    ZerobusSdk newSdk = ZerobusClientFactory.createClient(config.getZerobusEndpoint(), credential);
     // Use the SDK's default stream configuration (incl. its own in-flight defaults); we don't
     // override tuning knobs the user never configured.
     StreamConfigurationOptions options = StreamConfigurationOptions.getDefault();
     try {
       if (ZerobusSinkDto.ENCODING_JSON.equalsIgnoreCase(config.getEncodingType())) {
-        ZerobusJsonStream jsonStream =
-            sdk.createJsonStream(
+        ZerobusJsonStream newJsonStream =
+            newSdk
+                .createJsonStream(
                     config.getTableName(),
                     credential.getClientId(),
                     credential.getClientSecret(),
                     options)
                 .join();
-        return new ZerobusSinkFlusher(sdk, null, null, null, jsonStream);
+        this.jsonStream = newJsonStream;
+        this.protoStream = null;
+        this.avroSchema = null;
+        this.protoDescriptor = null;
+      } else {
+        Schema schema = AvroToProtoDescriptorConverter.parseAvro(config.getAvroSchema());
+        var descriptorProto =
+            AvroToProtoDescriptorConverter.toDescriptorProto(
+                config.getAvroSchema(), config.getTableName());
+        Descriptors.Descriptor descriptor =
+            AvroToProtoDescriptorConverter.toDescriptor(descriptorProto);
+        ZerobusProtoStream newProtoStream =
+            newSdk
+                .createProtoStream(
+                    config.getTableName(),
+                    descriptorProto,
+                    credential.getClientId(),
+                    credential.getClientSecret(),
+                    options)
+                .join();
+        this.protoStream = newProtoStream;
+        this.avroSchema = schema;
+        this.protoDescriptor = descriptor;
+        this.jsonStream = null;
       }
-
-      Schema avroSchema = AvroToProtoDescriptorConverter.parseAvro(config.getAvroSchema());
-      var descriptorProto =
-          AvroToProtoDescriptorConverter.toDescriptorProto(
-              config.getAvroSchema(), config.getTableName());
-      Descriptors.Descriptor descriptor =
-          AvroToProtoDescriptorConverter.toDescriptor(descriptorProto);
-      ZerobusProtoStream protoStream =
-          sdk.createProtoStream(
-                  config.getTableName(),
-                  descriptorProto,
-                  credential.getClientId(),
-                  credential.getClientSecret(),
-                  options)
-              .join();
-      return new ZerobusSinkFlusher(sdk, protoStream, avroSchema, descriptor, null);
+      this.sdk = newSdk;
+      this.healthy = true;
     } catch (RuntimeException e) {
       // stream creation failed: clean up the SDK before surfacing
       try {
-        sdk.close();
+        newSdk.close();
       } catch (RuntimeException closeError) {
         log.warn("Failed to close Zerobus SDK after stream creation failure", closeError);
       }
@@ -127,6 +167,38 @@ public class ZerobusSinkFlusher implements Flusher<Map<String, Object>> {
   public FlushResult flush(
       PreparedInputEvents<Map<String, Object>> preparedInputEvents, Map<String, String> metricTags)
       throws Exception {
+    synchronized (streamLock) {
+      ensureConnected();
+      try {
+        return doFlushLocked(preparedInputEvents);
+      } catch (RuntimeException e) {
+        // A flush failure may have broken the stream; force a reconnect on the next attempt so the
+        // store-and-forward forwarder can recover once the network is back.
+        healthy = false;
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Reconnects if a previous flush marked the stream unhealthy. Only possible on the production
+   * path (config present); a connection failure here means nothing was sent, so it surfaces as a
+   * {@link RetriableConnectionException} for the store-and-forward classifier.
+   */
+  private void ensureConnected() {
+    if (healthy || config == null) {
+      return;
+    }
+    log.info("Zerobus stream unhealthy; reconnecting before flush");
+    closeStreamsQuietly();
+    try {
+      connect();
+    } catch (RuntimeException e) {
+      throw new RetriableConnectionException("Zerobus reconnect failed", e);
+    }
+  }
+
+  private FlushResult doFlushLocked(PreparedInputEvents<Map<String, Object>> preparedInputEvents) {
     // Encode every payload BEFORE touching the stream. A per-record encoding failure becomes an
     // ErrorOutput for that record only; it must not fail the whole batch (which would happen if we
     // threw after some records had already been enqueued — the Flusher contract says a thrown
@@ -134,48 +206,46 @@ public class ZerobusSinkFlusher implements Flusher<Map<String, Object>> {
     List<ErrorOutput> errors = new ArrayList<>();
     long flushedDataSize = 0;
 
-    synchronized (streamLock) {
-      if (jsonStream != null) {
-        List<String> payloads = new ArrayList<>();
-        for (Pair<RecordFleakData, Map<String, Object>> pair :
-            preparedInputEvents.rawAndPreparedList()) {
-          try {
-            String json = JsonUtils.OBJECT_MAPPER.writeValueAsString(pair.getRight());
-            payloads.add(json);
-            flushedDataSize += json.getBytes(StandardCharsets.UTF_8).length;
-          } catch (Exception e) {
-            errors.add(
-                new ErrorOutput(pair.getLeft(), "Zerobus JSON encode failed: " + e.getMessage()));
-          }
-        }
-        Optional<Long> offset =
-            ingestWithUnknownCommitState(
-                !payloads.isEmpty(), () -> jsonStream.ingestRecordsOffset(payloads));
-        awaitDurability(offset, jsonStream::waitForOffset);
-        return new FlushResult(payloads.size(), flushedDataSize, errors);
-      }
-
-      List<byte[]> payloads = new ArrayList<>();
+    if (jsonStream != null) {
+      List<String> payloads = new ArrayList<>();
       for (Pair<RecordFleakData, Map<String, Object>> pair :
           preparedInputEvents.rawAndPreparedList()) {
         try {
-          DynamicMessage message =
-              AvroToProtoDescriptorConverter.toDynamicMessage(
-                  pair.getRight(), avroSchema, protoDescriptor);
-          byte[] bytes = message.toByteArray();
-          payloads.add(bytes);
-          flushedDataSize += bytes.length;
+          String json = JsonUtils.OBJECT_MAPPER.writeValueAsString(pair.getRight());
+          payloads.add(json);
+          flushedDataSize += json.getBytes(StandardCharsets.UTF_8).length;
         } catch (Exception e) {
           errors.add(
-              new ErrorOutput(pair.getLeft(), "Zerobus protobuf encode failed: " + e.getMessage()));
+              new ErrorOutput(pair.getLeft(), "Zerobus JSON encode failed: " + e.getMessage()));
         }
       }
       Optional<Long> offset =
           ingestWithUnknownCommitState(
-              !payloads.isEmpty(), () -> protoStream.ingestRecordsOffset(payloads));
-      awaitDurability(offset, protoStream::waitForOffset);
+              !payloads.isEmpty(), () -> jsonStream.ingestRecordsOffset(payloads));
+      awaitDurability(offset, jsonStream::waitForOffset);
       return new FlushResult(payloads.size(), flushedDataSize, errors);
     }
+
+    List<byte[]> payloads = new ArrayList<>();
+    for (Pair<RecordFleakData, Map<String, Object>> pair :
+        preparedInputEvents.rawAndPreparedList()) {
+      try {
+        DynamicMessage message =
+            AvroToProtoDescriptorConverter.toDynamicMessage(
+                pair.getRight(), avroSchema, protoDescriptor);
+        byte[] bytes = message.toByteArray();
+        payloads.add(bytes);
+        flushedDataSize += bytes.length;
+      } catch (Exception e) {
+        errors.add(
+            new ErrorOutput(pair.getLeft(), "Zerobus protobuf encode failed: " + e.getMessage()));
+      }
+    }
+    Optional<Long> offset =
+        ingestWithUnknownCommitState(
+            !payloads.isEmpty(), () -> protoStream.ingestRecordsOffset(payloads));
+    awaitDurability(offset, protoStream::waitForOffset);
+    return new FlushResult(payloads.size(), flushedDataSize, errors);
   }
 
   /**
@@ -233,25 +303,31 @@ public class ZerobusSinkFlusher implements Flusher<Map<String, Object>> {
     void waitForOffset(long offset) throws Exception;
   }
 
+  private void closeStreamsQuietly() {
+    try {
+      if (protoStream != null) {
+        protoStream.close();
+      }
+      if (jsonStream != null) {
+        jsonStream.close();
+      }
+    } catch (Exception e) {
+      log.warn("Error closing Zerobus stream", e);
+    } finally {
+      try {
+        if (sdk != null) {
+          sdk.close();
+        }
+      } catch (RuntimeException e) {
+        log.warn("Error closing Zerobus SDK", e);
+      }
+    }
+  }
+
   @Override
   public void close() {
     synchronized (streamLock) {
-      try {
-        if (protoStream != null) {
-          protoStream.close();
-        }
-        if (jsonStream != null) {
-          jsonStream.close();
-        }
-      } catch (Exception e) {
-        log.warn("Error closing Zerobus stream", e);
-      } finally {
-        try {
-          sdk.close();
-        } catch (RuntimeException e) {
-          log.warn("Error closing Zerobus SDK", e);
-        }
-      }
+      closeStreamsQuietly();
     }
   }
 }

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkFlusherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkFlusherTest.java
@@ -285,7 +285,8 @@ class KafkaSinkFlusherTest {
   void testResourceManagement_ProperCleanup() {
     flusher.close();
 
-    verify(mockProducer, times(1)).close();
+    // Shutdown is bounded so a wedged producer can't hang terminate() (see KafkaSinkFlusher.close).
+    verify(mockProducer, times(1)).close(any(java.time.Duration.class));
 
     // Verify close() is idempotent
     assertDoesNotThrow(

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkStoreForwardIntegrationTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkStoreForwardIntegrationTest.java
@@ -1,0 +1,433 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.kafkasink;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.*;
+import static io.fleak.zephflow.lib.utils.MiscUtils.METRIC_TAG_ENV;
+import static io.fleak.zephflow.lib.utils.MiscUtils.METRIC_TAG_SERVICE;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.api.metric.FleakCounter;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.sink.SinkExecutionContext;
+import io.fleak.zephflow.lib.commands.sink.SinkStoreForward;
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+import java.util.stream.StreamSupport;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+
+/**
+ * Blackbox integration test for store-and-forward on the Kafka sink against a <b>real broker</b>.
+ * The outage is a real {@code docker pause} of the broker container, and recovery is {@code
+ * unpause}. We verify: nothing is delivered while the broker is down, records accumulate in the
+ * local on-disk store, and after recovery every record arrives in the topic (no loss).
+ */
+@Tag("integration")
+@Testcontainers
+class KafkaSinkStoreForwardIntegrationTest {
+
+  private static final String TOPIC = "store_forward_topic";
+  private static final int HEALTHY = 50; // ids 1..50, delivered before the outage
+  private static final int OUTAGE = 100; // ids 51..150, buffered during the outage
+  private static final int TOTAL = HEALTHY + OUTAGE;
+
+  @Container
+  private static final KafkaContainer KAFKA = new KafkaContainer("apache/kafka-native:3.8.0");
+
+  @BeforeAll
+  static void setup() throws Exception {
+    createTopic(TOPIC);
+  }
+
+  /** Single partition so a consumer reading by offset sees one totally-ordered stream. */
+  private static void createTopic(String name) throws Exception {
+    Properties props = new Properties();
+    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
+    try (AdminClient admin = AdminClient.create(props)) {
+      admin
+          .createTopics(Collections.singleton(new NewTopic(name, 1, (short) 1)))
+          .all()
+          .get(30, TimeUnit.SECONDS);
+    }
+  }
+
+  @AfterAll
+  static void stop() {
+    if (KAFKA.isRunning()) {
+      KAFKA.stop();
+    }
+  }
+
+  @Test
+  void bufferLocallyDuringBrokerOutageThenDeliverEverythingOnRecovery(@TempDir Path storeDir)
+      throws Exception {
+    CapturingMetrics metrics = new CapturingMetrics();
+    String nodeId = "kafka-sf-node";
+
+    KafkaSinkCommand sink =
+        (KafkaSinkCommand) new KafkaSinkCommandFactory().createCommand(nodeId, jobContext());
+    KafkaSinkDto.Config config =
+        KafkaSinkDto.Config.builder()
+            .topic(TOPIC)
+            .broker(KAFKA.getBootstrapServers())
+            .encodingType(EncodingType.JSON_OBJECT.toString())
+            .storeAndForwardEnabled(true)
+            .localStorePath(storeDir.toString())
+            .forwardRetryIntervalMillis(1_000)
+            .build();
+    sink.parseAndValidateArg(OBJECT_MAPPER.convertValue(config, new TypeReference<>() {}));
+    sink.initialize(metrics);
+
+    var ctx = (SinkExecutionContext<RecordFleakData>) sink.getExecutionContext();
+    SinkStoreForward storeForward = ctx.storeForward();
+
+    // 1) Healthy: deliver ids 1..HEALTHY straight to the broker.
+    sink.writeToSink(records(1, HEALTHY), "user", ctx);
+    assertFalse(storeForward.isBuffering());
+    assertEquals(HEALTHY, new TreeSet<>(consumeIds(Duration.ofSeconds(10))).size());
+
+    // 2) Cut the network: pause the broker container while the producer is idle.
+    pauseBroker();
+    try {
+      // first outage write trips into BUFFERING (a bounded sync flush fails fast);
+      sink.writeToSink(records(HEALTHY + 1, HEALTHY + 60), "user", ctx);
+      // subsequent writes take the outage fast-path straight to disk.
+      sink.writeToSink(records(HEALTHY + 61, TOTAL), "user", ctx);
+
+      assertTrue(storeForward.isBuffering(), "sink should be buffering during the outage");
+      assertEquals(OUTAGE, metrics.total(METRIC_BUFFERED), "all outage records written locally");
+      assertTrue(storeDirBytes(storeDir) > 0, "local store should hold data on disk");
+    } finally {
+      // 3) Restore the network.
+      unpauseBroker();
+    }
+
+    // 4) Recovery: the forwarder drains the backlog back to the broker.
+    await(() -> !storeForward.isBuffering(), 90);
+    assertEquals(OUTAGE, metrics.total(METRIC_REPLAYED), "all buffered records replayed");
+    assertEquals(0, metrics.total(METRIC_DROPPED), "nothing dropped");
+
+    // 5) Every record (healthy + replayed) is in the topic exactly once, no loss.
+    TreeSet<Integer> all = new TreeSet<>(consumeAllIds());
+    assertEquals(TOTAL, all.size());
+    assertEquals(1, all.first());
+    assertEquals(TOTAL, all.last());
+
+    sink.terminate();
+  }
+
+  @Test
+  void streamContinuouslyThroughRecoveryPreservesEveryRecordInOrder(@TempDir Path storeDir)
+      throws Exception {
+    String topic = "stream_through_recovery_topic";
+    createTopic(topic);
+    CapturingMetrics metrics = new CapturingMetrics();
+    // Idempotent producer so Kafka's own retries can't reorder independently of store-and-forward;
+    // that isolates the ordering assertion to OUR buffer->drain->direct handoff.
+    KafkaSinkCommand sink =
+        initSink(
+            "kafka-sf-stream",
+            topic,
+            storeDir,
+            metrics,
+            Map.of("enable.idempotence", "true", "acks", "all"));
+    var ctx = (SinkExecutionContext<RecordFleakData>) sink.getExecutionContext();
+    SinkStoreForward storeForward = ctx.storeForward();
+
+    // A producer that never stops: it writes monotonically increasing ids the whole time, including
+    // while the broker is down and while the backlog is draining.
+    AtomicInteger nextId = new AtomicInteger(1);
+    AtomicInteger lastIssued = new AtomicInteger(0);
+    AtomicReference<Throwable> error = new AtomicReference<>();
+    AtomicBoolean running = new AtomicBoolean(true);
+    Thread producer =
+        new Thread(
+            () -> {
+              while (running.get()) {
+                int id = nextId.getAndIncrement();
+                try {
+                  sink.writeToSink(records(id, id), "user", ctx);
+                  lastIssued.set(id);
+                  Thread.sleep(2);
+                } catch (InterruptedException e) {
+                  return;
+                } catch (Throwable t) {
+                  error.set(t);
+                  return;
+                }
+              }
+            },
+            "test-producer");
+
+    boolean paused = false;
+    try {
+      producer.start();
+      Thread.sleep(1_500); // stream healthy
+      pauseBroker();
+      paused = true;
+      Thread.sleep(7_000); // keep streaming through the outage (first outage write blocks ~5s)
+      unpauseBroker();
+      paused = false;
+      Thread.sleep(3_000); // keep streaming while the backlog drains
+    } finally {
+      running.set(false);
+      producer.join(TimeUnit.SECONDS.toMillis(15));
+      if (paused) {
+        try {
+          unpauseBroker();
+        } catch (RuntimeException ignore) {
+          // already running
+        }
+      }
+    }
+
+    assertNull(error.get(), "producer thread should not throw");
+    await(() -> !storeForward.isBuffering(), 90);
+
+    int totalSent = lastIssued.get();
+    assertTrue(totalSent > 50, "expected a meaningful stream, got " + totalSent);
+
+    List<Integer> consumed =
+        drain("stream-final-" + System.nanoTime(), topic, Duration.ofSeconds(30), totalSent);
+
+    // No loss: every id 1..totalSent reached the topic.
+    TreeSet<Integer> distinct = new TreeSet<>(consumed);
+    assertEquals(totalSent, distinct.size(), "no loss");
+    assertEquals(1, distinct.first());
+    assertEquals(totalSent, distinct.last());
+    // No reordering across the buffer->drain->direct handoff (single partition = offset order).
+    // Duplicates from at-least-once are tolerated, so the check is non-decreasing, not strictly so.
+    for (int i = 1; i < consumed.size(); i++) {
+      assertTrue(
+          consumed.get(i) >= consumed.get(i - 1),
+          "out of order at index " + i + ": " + consumed.get(i - 1) + " -> " + consumed.get(i));
+    }
+    assertEquals(0, metrics.total(METRIC_DROPPED), "nothing dropped");
+
+    sink.terminate();
+  }
+
+  @Test
+  void bufferFromColdStartWhenBrokerDownAtStartup(@TempDir Path storeDir) throws Exception {
+    String topic = "startup_down_topic";
+    createTopic(topic); // broker is up here
+    int n = 80;
+    CapturingMetrics metrics = new CapturingMetrics();
+
+    // Bring the broker down BEFORE the sink is initialized: the first write must take the
+    // cold-metadata path (no cached metadata) and buffer the whole batch.
+    pauseBroker();
+    KafkaSinkCommand sink = initSink("kafka-sf-coldstart", topic, storeDir, metrics, null);
+    var ctx = (SinkExecutionContext<RecordFleakData>) sink.getExecutionContext();
+    SinkStoreForward storeForward = ctx.storeForward();
+    try {
+      sink.writeToSink(records(1, n), "user", ctx);
+      assertTrue(storeForward.isBuffering(), "should buffer when the broker is down at startup");
+      assertEquals(n, metrics.total(METRIC_BUFFERED), "all records written locally");
+      assertTrue(storeDirBytes(storeDir) > 0, "local store should hold data on disk");
+    } finally {
+      unpauseBroker();
+    }
+
+    await(() -> !storeForward.isBuffering(), 90);
+    assertEquals(n, metrics.total(METRIC_REPLAYED), "all buffered records replayed");
+    assertEquals(0, metrics.total(METRIC_DROPPED), "nothing dropped");
+
+    TreeSet<Integer> all =
+        new TreeSet<>(
+            drain("coldstart-final-" + System.nanoTime(), topic, Duration.ofSeconds(20), n));
+    assertEquals(n, all.size());
+    assertEquals(1, all.first());
+    assertEquals(n, all.last());
+
+    sink.terminate();
+  }
+
+  // ===== helpers =====
+
+  private KafkaSinkCommand initSink(
+      String nodeId,
+      String topic,
+      Path storeDir,
+      MetricClientProvider metrics,
+      Map<String, String> extraProps) {
+    KafkaSinkCommand sink =
+        (KafkaSinkCommand) new KafkaSinkCommandFactory().createCommand(nodeId, jobContext());
+    KafkaSinkDto.Config config =
+        KafkaSinkDto.Config.builder()
+            .topic(topic)
+            .broker(KAFKA.getBootstrapServers())
+            .encodingType(EncodingType.JSON_OBJECT.toString())
+            .storeAndForwardEnabled(true)
+            .localStorePath(storeDir.toString())
+            .forwardRetryIntervalMillis(1_000)
+            .properties(extraProps)
+            .build();
+    sink.parseAndValidateArg(OBJECT_MAPPER.convertValue(config, new TypeReference<>() {}));
+    sink.initialize(metrics);
+    return sink;
+  }
+
+  private static List<RecordFleakData> records(int fromInclusive, int toInclusive) {
+    List<RecordFleakData> out = new ArrayList<>();
+    for (int id = fromInclusive; id <= toInclusive; id++) {
+      out.add((RecordFleakData) FleakData.wrap(Map.of("id", id)));
+    }
+    return out;
+  }
+
+  /** Consumes from the current group offset and returns the ids seen. */
+  private List<Integer> consumeIds(Duration timeout) {
+    return drain("running-consumer", TOPIC, timeout, HEALTHY);
+  }
+
+  /** Fresh consumer from the beginning of the topic; returns all ids currently present. */
+  private List<Integer> consumeAllIds() {
+    return drain("final-consumer-" + System.nanoTime(), TOPIC, Duration.ofSeconds(20), TOTAL);
+  }
+
+  /** Reads up to {@code expected} ids from {@code topic} in offset (delivery) order. */
+  private List<Integer> drain(String group, String topic, Duration overall, int expected) {
+    Properties props = new Properties();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, group);
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+    props.put(
+        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+    List<Integer> ids = new ArrayList<>();
+    try (KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(props)) {
+      consumer.subscribe(Collections.singletonList(topic));
+      long deadline = System.nanoTime() + overall.toNanos();
+      // Stop on distinct count, not raw size, so at-least-once duplicates don't hide a tail.
+      while (System.nanoTime() < deadline && new HashSet<>(ids).size() < expected) {
+        ConsumerRecords<byte[], byte[]> polled = consumer.poll(Duration.ofMillis(500));
+        StreamSupport.stream(polled.spliterator(), false)
+            .map(
+                r -> fromJsonString(new String(r.value()), new TypeReference<RecordFleakData>() {}))
+            .map(rec -> ((Number) rec.unwrap().get("id")).intValue())
+            .forEach(ids::add);
+      }
+    }
+    return ids;
+  }
+
+  private static long storeDirBytes(Path dir) throws Exception {
+    try (var paths = Files.walk(dir)) {
+      return paths
+          .filter(Files::isRegularFile)
+          .mapToLong(KafkaSinkStoreForwardIntegrationTest::size)
+          .sum();
+    }
+  }
+
+  private static long size(Path p) {
+    try {
+      return Files.size(p);
+    } catch (Exception e) {
+      return 0;
+    }
+  }
+
+  private static void pauseBroker() {
+    DockerClientFactory.instance().client().pauseContainerCmd(KAFKA.getContainerId()).exec();
+  }
+
+  private static void unpauseBroker() {
+    DockerClientFactory.instance().client().unpauseContainerCmd(KAFKA.getContainerId()).exec();
+  }
+
+  private static JobContext jobContext() {
+    return JobContext.builder()
+        .metricTags(Map.of(METRIC_TAG_SERVICE, "test_service", METRIC_TAG_ENV, "test_env"))
+        .otherProperties(Map.of())
+        .build();
+  }
+
+  private static void await(BooleanSupplier condition, int timeoutSeconds) throws Exception {
+    long deadline = System.nanoTime() + Duration.ofSeconds(timeoutSeconds).toNanos();
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.sleep(200);
+    }
+    fail("condition not met within " + timeoutSeconds + "s");
+  }
+
+  private static final String METRIC_BUFFERED = "store_forward_buffered_count";
+  private static final String METRIC_REPLAYED = "store_forward_replayed_count";
+  private static final String METRIC_DROPPED = "store_forward_dropped_count";
+
+  /** Captures counter totals by metric name; gauges/stopwatches fall back to the no-op base. */
+  private static final class CapturingMetrics
+      extends MetricClientProvider.NoopMetricClientProvider {
+    private final Map<String, AtomicLong> totals = new ConcurrentHashMap<>();
+
+    long total(String name) {
+      return totals.getOrDefault(name, new AtomicLong()).get();
+    }
+
+    @Override
+    public FleakCounter counter(String name, Map<String, String> tags) {
+      AtomicLong total = totals.computeIfAbsent(name, k -> new AtomicLong());
+      return new FleakCounter() {
+        @Override
+        public void increase(Map<String, String> additionalTags) {
+          total.incrementAndGet();
+        }
+
+        @Override
+        public void increase(long n, Map<String, String> additionalTags) {
+          total.addAndGet(n);
+        }
+      };
+    }
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/ChronicleStoreForwardTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/ChronicleStoreForwardTest.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sink;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.fleak.zephflow.api.metric.FleakCounter;
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ChronicleStoreForwardTest {
+
+  // IOException == connectivity; anything else == permanent.
+  private static final ConnectionFailureClassifier IO_IS_CONNECTION =
+      t -> {
+        for (Throwable c = t; c != null && c != c.getCause(); c = c.getCause()) {
+          if (c instanceof IOException) {
+            return true;
+          }
+        }
+        return false;
+      };
+
+  private static RecordFleakData record(String value) {
+    return (RecordFleakData) FleakData.wrap(Map.of("v", value));
+  }
+
+  private static List<String> values(List<RecordFleakData> records) {
+    return records.stream().map(r -> (String) r.unwrap().get("v")).toList();
+  }
+
+  private ChronicleStoreForward.Config config(Path dir, long maxBytes, int chunk) {
+    return new ChronicleStoreForward.Config(dir, maxBytes, 50, chunk, "node-1");
+  }
+
+  @Test
+  void offerBuffersThenWorkerDrainsInOrderAndReturnsToDirect(@TempDir Path dir) throws Exception {
+    CountingCounter buffered = new CountingCounter();
+    CountingCounter replayed = new CountingCounter();
+    List<RecordFleakData> delivered = new CopyOnWriteArrayList<>();
+
+    ChronicleStoreForward sf =
+        new ChronicleStoreForward(
+            config(dir, 1_000_000, 2), IO_IS_CONNECTION, buffered, replayed, null);
+    sf.start(delivered::addAll);
+
+    List<RecordFleakData> input = List.of(record("a"), record("b"), record("c"));
+    assertEquals(3, sf.offer(input));
+    assertTrue(sf.isBuffering());
+
+    await(() -> !sf.isBuffering());
+
+    assertEquals(List.of("a", "b", "c"), values(delivered));
+    assertEquals(3, buffered.total());
+    assertEquals(3, replayed.total());
+    sf.close();
+  }
+
+  @Test
+  void replayRetriesOnConnectionFailureThenSucceeds(@TempDir Path dir) throws Exception {
+    List<RecordFleakData> delivered = new CopyOnWriteArrayList<>();
+    AtomicInteger attempts = new AtomicInteger();
+    SinkStoreForward.ReplayTarget target =
+        records -> {
+          // fail the first two delivery attempts with a connectivity error, then succeed
+          if (attempts.getAndIncrement() < 2) {
+            throw new IOException("connection down");
+          }
+          delivered.addAll(records);
+        };
+
+    ChronicleStoreForward sf =
+        new ChronicleStoreForward(config(dir, 1_000_000, 10), IO_IS_CONNECTION, null, null, null);
+    sf.start(target);
+    sf.offer(List.of(record("x"), record("y")));
+
+    await(() -> !sf.isBuffering());
+    assertEquals(List.of("x", "y"), values(delivered));
+    assertTrue(attempts.get() >= 3);
+    sf.close();
+  }
+
+  @Test
+  void permanentFailureDropsRecords(@TempDir Path dir) throws Exception {
+    CountingCounter dropped = new CountingCounter();
+    SinkStoreForward.ReplayTarget target =
+        records -> {
+          throw new IllegalStateException("bad table"); // not an IOException -> permanent
+        };
+
+    ChronicleStoreForward sf =
+        new ChronicleStoreForward(
+            config(dir, 1_000_000, 10), IO_IS_CONNECTION, null, null, dropped);
+    sf.start(target);
+    sf.offer(List.of(record("x"), record("y")));
+
+    await(() -> !sf.isBuffering());
+    assertEquals(2, dropped.total());
+    sf.close();
+  }
+
+  @Test
+  void capDropsExcessAndReportsStoredCount(@TempDir Path dir) throws Exception {
+    CountingCounter dropped = new CountingCounter();
+    // Block delivery so nothing drains while we assert what was stored vs dropped.
+    ChronicleStoreForward sf =
+        new ChronicleStoreForward(config(dir, 30, 10), IO_IS_CONNECTION, null, null, dropped);
+    sf.start(
+        records -> {
+          throw new IOException("hold the line"); // keep it buffering
+        });
+
+    // each {"v":"a"} payload is ~9 bytes + 4-byte length prefix; cap 30 fits 2, drops the 3rd.
+    int stored = sf.offer(List.of(record("a"), record("b"), record("c")));
+    assertEquals(2, stored);
+    assertEquals(1, dropped.total());
+    sf.close();
+  }
+
+  @Test
+  void restartResumesBacklogFromDisk(@TempDir Path dir) throws Exception {
+    // First run: deliveries always fail (connectivity), so the 3 records stay on disk.
+    ChronicleStoreForward first =
+        new ChronicleStoreForward(config(dir, 1_000_000, 10), IO_IS_CONNECTION, null, null, null);
+    first.start(
+        records -> {
+          throw new IOException("down for the whole first run");
+        });
+    first.offer(List.of(record("a"), record("b"), record("c")));
+    await(first::isBuffering);
+    first.close();
+
+    // Second run on the SAME directory: connection restored, backlog must drain in order.
+    List<RecordFleakData> delivered = new CopyOnWriteArrayList<>();
+    ChronicleStoreForward second =
+        new ChronicleStoreForward(config(dir, 1_000_000, 10), IO_IS_CONNECTION, null, null, null);
+    second.start(delivered::addAll);
+
+    await(() -> !second.isBuffering());
+    assertEquals(List.of("a", "b", "c"), values(delivered));
+    second.close();
+  }
+
+  private static void await(BooleanSupplier condition) throws InterruptedException {
+    long deadline = System.nanoTime() + java.time.Duration.ofSeconds(10).toNanos();
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.sleep(20);
+    }
+    fail("condition not met within timeout");
+  }
+
+  private static final class CountingCounter implements FleakCounter {
+    private final AtomicLong total = new AtomicLong();
+
+    long total() {
+      return total.get();
+    }
+
+    @Override
+    public void increase(Map<String, String> additionalTags) {
+      total.incrementAndGet();
+    }
+
+    @Override
+    public void increase(long n, Map<String, String> additionalTags) {
+      total.addAndGet(n);
+    }
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/SimpleSinkCommandStoreForwardTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/SimpleSinkCommandStoreForwardTest.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sink;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.fleak.zephflow.api.ErrorOutput;
+import io.fleak.zephflow.api.ScalarSinkCommand.SinkResult;
+import io.fleak.zephflow.api.metric.FleakCounter;
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Covers the two store-and-forward touch points in {@link SimpleSinkCommand}. */
+class SimpleSinkCommandStoreForwardTest {
+
+  private static RecordFleakData record(int val) {
+    return (RecordFleakData) FleakData.wrap(Map.of("val", val));
+  }
+
+  @Test
+  void connectivityFailureBuffersPreparedRecords() {
+    FakeStoreForward storeForward = new FakeStoreForward();
+    storeForward.shouldBuffer = true;
+    FakeFlusher flusher = new FakeFlusher(true); // always throws -> connectivity
+    SinkExecutionContext<Integer> ctx = context(flusher, storeForward);
+
+    List<RecordFleakData> input = List.of(record(0), record(3));
+    SinkResult result = new FakeSink().writeToSink(input, "user", ctx);
+
+    // both records preprocessed cleanly, flush failed, both buffered -> counted as success
+    assertEquals(new SinkResult(2, 2, new ArrayList<>()), result);
+    assertEquals(input, storeForward.offered);
+    assertTrue(flusher.flushAttempted);
+  }
+
+  @Test
+  void whileBufferingEventsGoStraightToDiskWithoutFlushing() {
+    FakeStoreForward storeForward = new FakeStoreForward();
+    storeForward.buffering = true;
+    FakeFlusher flusher = new FakeFlusher(false);
+    SinkExecutionContext<Integer> ctx = context(flusher, storeForward);
+
+    List<RecordFleakData> input = List.of(record(0), record(3));
+    SinkResult result = new FakeSink().writeToSink(input, "user", ctx);
+
+    assertEquals(new SinkResult(2, 2, new ArrayList<>()), result);
+    assertEquals(input, storeForward.offered);
+    assertFalse(flusher.flushAttempted);
+  }
+
+  @Test
+  void capDropOverflowIsReportedAsErrors() {
+    FakeStoreForward storeForward = new FakeStoreForward();
+    storeForward.buffering = true;
+    storeForward.storeLimit = 1; // only the first record fits
+    SinkExecutionContext<Integer> ctx = context(new FakeFlusher(false), storeForward);
+
+    List<RecordFleakData> input = List.of(record(0), record(3));
+    SinkResult result = new FakeSink().writeToSink(input, "user", ctx);
+
+    SinkResult expected =
+        new SinkResult(
+            2,
+            1,
+            List.of(
+                new ErrorOutput(
+                    record(3), "store-and-forward local buffer is full; record dropped")));
+    assertEquals(expected, result);
+  }
+
+  private SinkExecutionContext<Integer> context(
+      FakeFlusher flusher, SinkStoreForward storeForward) {
+    FleakCounter noop = new NoopCounter();
+    return new SinkExecutionContext<>(
+        flusher,
+        (event, ts) -> ((Number) event.unwrap().get("val")).intValue(),
+        storeForward,
+        noop,
+        noop,
+        noop,
+        noop,
+        noop);
+  }
+
+  private static final class FakeSink extends SimpleSinkCommand<Integer> {
+    FakeSink() {
+      super("node", null, null, null);
+    }
+
+    @Override
+    protected int batchSize() {
+      return 100;
+    }
+
+    @Override
+    public String commandName() {
+      return "fake";
+    }
+
+    @Override
+    protected io.fleak.zephflow.api.ExecutionContext createExecutionContext(
+        io.fleak.zephflow.api.metric.MetricClientProvider metricClientProvider,
+        io.fleak.zephflow.api.JobContext jobContext,
+        io.fleak.zephflow.api.CommandConfig commandConfig,
+        String nodeId) {
+      return null;
+    }
+  }
+
+  private static final class FakeFlusher implements SimpleSinkCommand.Flusher<Integer> {
+    private final boolean fail;
+    boolean flushAttempted = false;
+
+    FakeFlusher(boolean fail) {
+      this.fail = fail;
+    }
+
+    @Override
+    public SimpleSinkCommand.FlushResult flush(
+        SimpleSinkCommand.PreparedInputEvents<Integer> preparedInputEvents,
+        Map<String, String> metricTags) {
+      flushAttempted = true;
+      if (fail) {
+        throw new RuntimeException("connection down");
+      }
+      return new SimpleSinkCommand.FlushResult(
+          preparedInputEvents.preparedList().size(), 0, new ArrayList<>());
+    }
+
+    @Override
+    public void close() {}
+  }
+
+  private static final class FakeStoreForward implements SinkStoreForward {
+    boolean buffering = false;
+    boolean shouldBuffer = false;
+    int storeLimit = Integer.MAX_VALUE;
+    final List<RecordFleakData> offered = new ArrayList<>();
+
+    @Override
+    public boolean isBuffering() {
+      return buffering;
+    }
+
+    @Override
+    public boolean shouldBuffer(Throwable t) {
+      return shouldBuffer;
+    }
+
+    @Override
+    public int offer(List<RecordFleakData> records) {
+      int stored = Math.min(records.size(), storeLimit);
+      offered.addAll(records.subList(0, stored));
+      return stored;
+    }
+
+    @Override
+    public void start(ReplayTarget target) {}
+
+    @Override
+    public void close() {}
+  }
+
+  private static final class NoopCounter implements FleakCounter {
+    @Override
+    public void increase(Map<String, String> additionalTags) {}
+
+    @Override
+    public void increase(long n, Map<String, String> additionalTags) {}
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusConnectionFailureClassifierTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusConnectionFailureClassifierTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.zerobussink;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.fleak.zephflow.lib.commands.sink.RetriableConnectionException;
+import io.fleak.zephflow.lib.commands.sink.UnknownSinkCommitStateException;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class ZerobusConnectionFailureClassifierTest {
+
+  private final ZerobusConnectionFailureClassifier classifier =
+      new ZerobusConnectionFailureClassifier();
+
+  /** Stand-in for gRPC's StatusRuntimeException, matched structurally by class name + message. */
+  static class StatusRuntimeException extends RuntimeException {
+    StatusRuntimeException(String message) {
+      super(message);
+    }
+  }
+
+  @Test
+  void ioExceptionInCauseChainIsConnectionFailure() {
+    Throwable wrapped =
+        new UnknownSinkCommitStateException("commit state unknown", new IOException("broken pipe"));
+    assertTrue(classifier.isConnectionFailure(wrapped));
+  }
+
+  @Test
+  void retriableConnectionExceptionIsConnectionFailure() {
+    assertTrue(
+        classifier.isConnectionFailure(
+            new RetriableConnectionException("reconnect failed", new RuntimeException("nope"))));
+  }
+
+  @Test
+  void retryableGrpcStatusIsConnectionFailure() {
+    assertTrue(
+        classifier.isConnectionFailure(new StatusRuntimeException("UNAVAILABLE: io timeout")));
+    assertTrue(
+        classifier.isConnectionFailure(
+            new UnknownSinkCommitStateException(
+                "unknown", new StatusRuntimeException("DEADLINE_EXCEEDED: deadline"))));
+  }
+
+  @Test
+  void nonRetryableGrpcStatusIsNotConnectionFailure() {
+    assertFalse(
+        classifier.isConnectionFailure(new StatusRuntimeException("INVALID_ARGUMENT: bad schema")));
+  }
+
+  @Test
+  void plainPermanentFailureIsNotConnectionFailure() {
+    assertFalse(classifier.isConnectionFailure(new IllegalArgumentException("table not found")));
+    assertFalse(
+        classifier.isConnectionFailure(
+            new UnknownSinkCommitStateException("unknown", new IllegalStateException("schema"))));
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkBlackboxTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkBlackboxTest.java
@@ -1,0 +1,250 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.zerobussink;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.databricks.zerobus.ZerobusJsonStream;
+import com.databricks.zerobus.ZerobusSdk;
+import io.fleak.zephflow.api.CommandConfig;
+import io.fleak.zephflow.api.ExecutionContext;
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.api.metric.FleakCounter;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.sink.ChronicleStoreForward;
+import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
+import io.fleak.zephflow.lib.commands.sink.SinkExecutionContext;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentMatchers;
+
+/**
+ * Blackbox-style test of the Zerobus sink's store-and-forward behavior. It runs the whole real
+ * production path — {@link io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand}, the real {@link
+ * ChronicleStoreForward}, the real {@link ZerobusConnectionFailureClassifier}, the real {@link
+ * ZerobusSinkFlusher} (JSON mode) and {@link ZerobusMessageProcessor} — against a {@link
+ * FakeZerobusEndpoint} that records what it receives and can be disconnected/reconnected.
+ *
+ * <p><b>Why the disconnection is injected at the stream seam:</b> the real Zerobus SDK transport is
+ * a closed-source native library (TLS + Databricks OAuth over gRPC), so a faithful socket-level
+ * fake server that the real client connects to is not feasible in a unit test. The native client
+ * surfaces a connection loss as an ingest exception; this test reproduces exactly that at the only
+ * seam the SDK exposes to Java. A true socket-level test belongs against a real/staging Zerobus
+ * endpoint.
+ */
+class ZerobusSinkBlackboxTest {
+
+  // A backlog larger than the drain chunk, so recovery drains over many chunks — exercising
+  // multi-cycle replay and ordering rather than a single trivial drain.
+  private static final int HEALTHY = 100;
+  private static final int OUTAGE = 800;
+  private static final int POST = 100;
+  private static final int TOTAL = HEALTHY + OUTAGE + POST; // 1000
+  private static final int STREAM_BATCH = 20;
+  private static final int DRAIN_CHUNK = 64;
+
+  @Test
+  void streamThroughOutageBuffersLocallyThenDeliversEverythingOnRecovery(@TempDir Path dir)
+      throws Exception {
+    FakeZerobusEndpoint endpoint = new FakeZerobusEndpoint();
+
+    // The mocked stream is the wire to the endpoint: forward on success, throw a connectivity
+    // error when the endpoint is unreachable — exactly how the native client surfaces a drop.
+    ZerobusJsonStream stream = mock(ZerobusJsonStream.class);
+    when(stream.ingestRecordsOffset(ArgumentMatchers.<String>anyIterable()))
+        .thenAnswer(inv -> endpoint.ingest(inv.getArgument(0)));
+
+    ZerobusSinkFlusher flusher =
+        new ZerobusSinkFlusher(mock(ZerobusSdk.class), null, null, null, stream);
+    ZerobusMessageProcessor preprocessor = new ZerobusMessageProcessor();
+
+    AtomicLong buffered = new AtomicLong();
+    AtomicLong replayed = new AtomicLong();
+    ChronicleStoreForward storeForward =
+        new ChronicleStoreForward(
+            new ChronicleStoreForward.Config(dir, 100_000_000, 50, DRAIN_CHUNK, "blackbox-node"),
+            new ZerobusConnectionFailureClassifier(),
+            counter(buffered),
+            counter(replayed),
+            null);
+    storeForward.start(
+        records -> {
+          SimpleSinkCommand.PreparedInputEvents<Map<String, Object>> prepared =
+              new SimpleSinkCommand.PreparedInputEvents<>();
+          for (RecordFleakData r : records) {
+            prepared.add(r, preprocessor.preprocess(r, 0L));
+          }
+          flusher.flush(prepared, Map.of());
+        });
+
+    FleakCounter noop = counter(new AtomicLong());
+    SinkExecutionContext<Map<String, Object>> ctx =
+        new SinkExecutionContext<>(
+            flusher, preprocessor, storeForward, noop, noop, noop, noop, noop);
+    TestSink sink = new TestSink();
+
+    // ---- the streaming script ----
+
+    // healthy: stream records 1..HEALTHY, each delivered straight to the endpoint
+    stream(sink, ctx, 1, HEALTHY);
+    assertEquals(idRange(1, HEALTHY), endpoint.received());
+    assertFalse(storeForward.isBuffering());
+
+    // ---- network goes down ----
+    endpoint.disconnect();
+    long receivedAtOutageStart = endpoint.receivedCount();
+
+    // keep streaming during the outage; these must be written locally, not delivered
+    stream(sink, ctx, HEALTHY + 1, HEALTHY + OUTAGE);
+    assertTrue(storeForward.isBuffering(), "sink should be buffering during the outage");
+    assertEquals(OUTAGE, buffered.get(), "every outage record must be written locally");
+    // verify nothing was delivered to the endpoint while the network was down
+    assertEquals(receivedAtOutageStart, endpoint.receivedCount());
+    assertEquals(idRange(1, HEALTHY), endpoint.received());
+
+    // ---- network is restored: the backlog drains over many chunks ----
+    endpoint.reconnect();
+    await(() -> !storeForward.isBuffering());
+    assertEquals(idRange(1, HEALTHY + OUTAGE), endpoint.received());
+    assertEquals(OUTAGE, replayed.get(), "every buffered record was replayed");
+
+    // ---- back to DIRECT: streaming resumes straight to the endpoint ----
+    stream(sink, ctx, HEALTHY + OUTAGE + 1, TOTAL);
+
+    // every record, across the whole run, in order, exactly once — no loss, no dupes, no reorder
+    assertEquals(idRange(1, TOTAL), endpoint.received());
+    assertEquals(TOTAL, endpoint.receivedCount());
+
+    storeForward.close();
+  }
+
+  /** Streams ids [from, to] through the sink in batches, like an upstream producer. */
+  private static void stream(
+      TestSink sink, SinkExecutionContext<Map<String, Object>> ctx, int from, int to) {
+    List<RecordFleakData> batch = new ArrayList<>(STREAM_BATCH);
+    for (int id = from; id <= to; id++) {
+      batch.add(record(id));
+      if (batch.size() == STREAM_BATCH || id == to) {
+        sink.writeToSink(List.copyOf(batch), "user", ctx);
+        batch.clear();
+      }
+    }
+  }
+
+  // ===== fake endpoint =====
+
+  /** A stand-in Zerobus endpoint: records received JSON payloads and can be disconnected. */
+  private static final class FakeZerobusEndpoint {
+    private final AtomicBoolean connected = new AtomicBoolean(true);
+    private final List<String> received = new ArrayList<>();
+
+    synchronized Optional<Long> ingest(Iterable<String> payloads) {
+      if (!connected.get()) {
+        throw new RuntimeException("endpoint unreachable", new IOException("connection refused"));
+      }
+      payloads.forEach(received::add);
+      return Optional.of((long) received.size());
+    }
+
+    void disconnect() {
+      connected.set(false);
+    }
+
+    void reconnect() {
+      connected.set(true);
+    }
+
+    synchronized List<String> received() {
+      return new ArrayList<>(received);
+    }
+
+    synchronized long receivedCount() {
+      return received.size();
+    }
+  }
+
+  private static RecordFleakData record(int id) {
+    return (RecordFleakData) FleakData.wrap(Map.of("id", id));
+  }
+
+  private static List<String> idRange(int from, int to) {
+    List<String> out = new ArrayList<>();
+    for (int id = from; id <= to; id++) {
+      out.add("{\"id\":" + id + "}");
+    }
+    return out;
+  }
+
+  private static FleakCounter counter(AtomicLong sink) {
+    return new FleakCounter() {
+      @Override
+      public void increase(Map<String, String> additionalTags) {
+        sink.incrementAndGet();
+      }
+
+      @Override
+      public void increase(long n, Map<String, String> additionalTags) {
+        sink.addAndGet(n);
+      }
+    };
+  }
+
+  private static void await(BooleanSupplier condition) throws InterruptedException {
+    long deadline = System.nanoTime() + java.time.Duration.ofSeconds(10).toNanos();
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.sleep(20);
+    }
+    fail("condition not met within timeout");
+  }
+
+  private static final class TestSink extends SimpleSinkCommand<Map<String, Object>> {
+    TestSink() {
+      super("blackbox-node", null, null, null);
+    }
+
+    @Override
+    protected int batchSize() {
+      return 100;
+    }
+
+    @Override
+    public String commandName() {
+      return "test_zerobus_blackbox";
+    }
+
+    @Override
+    protected ExecutionContext createExecutionContext(
+        MetricClientProvider metricClientProvider,
+        JobContext jobContext,
+        CommandConfig commandConfig,
+        String nodeId) {
+      return null;
+    }
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkStoreForwardSoakTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkStoreForwardSoakTest.java
@@ -1,0 +1,269 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.zerobussink;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.databricks.zerobus.ZerobusJsonStream;
+import com.databricks.zerobus.ZerobusSdk;
+import io.fleak.zephflow.api.CommandConfig;
+import io.fleak.zephflow.api.ExecutionContext;
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.api.metric.FleakCounter;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.sink.ChronicleStoreForward;
+import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
+import io.fleak.zephflow.lib.commands.sink.SinkExecutionContext;
+import io.fleak.zephflow.lib.utils.JsonUtils;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentMatchers;
+
+/**
+ * Heavy soak variant of {@link ZerobusSinkBlackboxTest}: streams a large volume of fat-payload
+ * records through a long outage so the backlog spans many drain chunks and a real amount of data
+ * lands on disk. Verifies under load that no record is lost, duplicated, or reordered.
+ *
+ * <p>Opt-in only — it is slow and disk-heavy, so it runs only when {@code RUN_SOAK=true} is set in
+ * the environment (env vars propagate to the Gradle test worker). Tune size with {@code
+ * SOAK_RECORDS}. Example:
+ *
+ * <pre>RUN_SOAK=true SOAK_RECORDS=200000 ./gradlew :lib:test \
+ *   --tests io.fleak.zephflow.lib.commands.zerobussink.ZerobusSinkStoreForwardSoakTest</pre>
+ */
+@Tag("soak")
+@EnabledIfEnvironmentVariable(named = "RUN_SOAK", matches = "true")
+class ZerobusSinkStoreForwardSoakTest {
+
+  private static final int TOTAL = envInt("SOAK_RECORDS", 100_000);
+  private static final int HEALTHY = TOTAL / 20; // ~5%
+  private static final int POST = TOTAL / 20; // ~5%
+  private static final int OUTAGE = TOTAL - HEALTHY - POST; // ~90%
+  private static final int STREAM_BATCH = 500;
+  private static final int DRAIN_CHUNK = 1_000;
+  // ~480-byte filler so each JSON record is ~0.5 KB; the whole outage backlog is tens of MB on
+  // disk.
+  private static final String BLOB = "x".repeat(480);
+
+  @Test
+  void soakStreamThroughLongOutageLosesNothing(@TempDir Path dir) throws Exception {
+    SoakEndpoint endpoint = new SoakEndpoint();
+
+    ZerobusJsonStream stream = mock(ZerobusJsonStream.class);
+    when(stream.ingestRecordsOffset(ArgumentMatchers.<String>anyIterable()))
+        .thenAnswer(inv -> endpoint.ingest(inv.getArgument(0)));
+
+    ZerobusSinkFlusher flusher =
+        new ZerobusSinkFlusher(mock(ZerobusSdk.class), null, null, null, stream);
+    ZerobusMessageProcessor preprocessor = new ZerobusMessageProcessor();
+
+    AtomicLong buffered = new AtomicLong();
+    AtomicLong replayed = new AtomicLong();
+    ChronicleStoreForward storeForward =
+        new ChronicleStoreForward(
+            new ChronicleStoreForward.Config(dir, 4_000_000_000L, 50, DRAIN_CHUNK, "soak-node"),
+            new ZerobusConnectionFailureClassifier(),
+            counter(buffered),
+            counter(replayed),
+            null);
+    storeForward.start(
+        records -> {
+          SimpleSinkCommand.PreparedInputEvents<Map<String, Object>> prepared =
+              new SimpleSinkCommand.PreparedInputEvents<>();
+          for (RecordFleakData r : records) {
+            prepared.add(r, preprocessor.preprocess(r, 0L));
+          }
+          flusher.flush(prepared, Map.of());
+        });
+
+    FleakCounter noop = counter(new AtomicLong());
+    SinkExecutionContext<Map<String, Object>> ctx =
+        new SinkExecutionContext<>(
+            flusher, preprocessor, storeForward, noop, noop, noop, noop, noop);
+    TestSink sink = new TestSink();
+
+    // healthy
+    stream(sink, ctx, 1, HEALTHY);
+    assertEquals(HEALTHY, endpoint.total(), "all healthy records delivered directly");
+
+    // outage: stream a large backlog to disk
+    endpoint.disconnect();
+    long deliveredAtOutageStart = endpoint.total();
+    stream(sink, ctx, HEALTHY + 1, HEALTHY + OUTAGE);
+    assertTrue(storeForward.isBuffering(), "buffering during outage");
+    assertEquals(OUTAGE, buffered.get(), "every outage record written locally");
+    assertEquals(deliveredAtOutageStart, endpoint.total(), "nothing delivered during the outage");
+
+    // recovery: drain the whole backlog (many chunks)
+    endpoint.reconnect();
+    await(() -> !storeForward.isBuffering(), 300);
+    assertEquals(OUTAGE, replayed.get(), "every buffered record replayed");
+    assertEquals(HEALTHY + OUTAGE, endpoint.total());
+
+    // back to direct
+    stream(sink, ctx, HEALTHY + OUTAGE + 1, TOTAL);
+
+    // global invariants across the whole run
+    assertEquals(TOTAL, endpoint.total(), "exactly TOTAL records received");
+    assertEquals(TOTAL, endpoint.distinctReceived(), "no duplicates, no gaps");
+    assertEquals(0, endpoint.outOfOrder(), "delivered strictly in order");
+
+    storeForward.close();
+  }
+
+  private static void stream(
+      TestSink sink, SinkExecutionContext<Map<String, Object>> ctx, int from, int to) {
+    List<RecordFleakData> batch = new ArrayList<>(STREAM_BATCH);
+    for (int id = from; id <= to; id++) {
+      batch.add(record(id));
+      if (batch.size() == STREAM_BATCH || id == to) {
+        sink.writeToSink(List.copyOf(batch), "user", ctx);
+        batch.clear();
+      }
+    }
+  }
+
+  /**
+   * Memory-light endpoint: tracks order/dupes/gaps via a BitSet instead of keeping every payload.
+   */
+  private static final class SoakEndpoint {
+    private final AtomicBoolean connected = new AtomicBoolean(true);
+    private final BitSet seen = new BitSet(TOTAL + 1);
+    private long total = 0;
+    private int expectedNext = 1;
+    private int outOfOrder = 0;
+
+    synchronized Optional<Long> ingest(Iterable<String> payloads) {
+      if (!connected.get()) {
+        throw new RuntimeException("endpoint unreachable", new IOException("connection refused"));
+      }
+      for (String payload : payloads) {
+        int id = parseId(payload);
+        if (id != expectedNext) {
+          outOfOrder++;
+        }
+        expectedNext = id + 1;
+        seen.set(id);
+        total++;
+      }
+      return Optional.of(total);
+    }
+
+    void disconnect() {
+      connected.set(false);
+    }
+
+    void reconnect() {
+      connected.set(true);
+    }
+
+    synchronized long total() {
+      return total;
+    }
+
+    synchronized int distinctReceived() {
+      return seen.cardinality();
+    }
+
+    synchronized int outOfOrder() {
+      return outOfOrder;
+    }
+  }
+
+  private static int parseId(String payload) {
+    try {
+      Map<String, Object> map =
+          JsonUtils.OBJECT_MAPPER.readValue(
+              payload, new com.fasterxml.jackson.core.type.TypeReference<Map<String, Object>>() {});
+      return ((Number) map.get("id")).intValue();
+    } catch (Exception e) {
+      throw new RuntimeException("bad payload: " + payload, e);
+    }
+  }
+
+  private static RecordFleakData record(int id) {
+    return (RecordFleakData) FleakData.wrap(Map.of("id", id, "blob", BLOB));
+  }
+
+  private static int envInt(String name, int dflt) {
+    String v = System.getenv(name);
+    return v == null ? dflt : Integer.parseInt(v.trim());
+  }
+
+  private static FleakCounter counter(AtomicLong sink) {
+    return new FleakCounter() {
+      @Override
+      public void increase(Map<String, String> additionalTags) {
+        sink.incrementAndGet();
+      }
+
+      @Override
+      public void increase(long n, Map<String, String> additionalTags) {
+        sink.addAndGet(n);
+      }
+    };
+  }
+
+  private static void await(BooleanSupplier condition, int timeoutSeconds)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + java.time.Duration.ofSeconds(timeoutSeconds).toNanos();
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.sleep(50);
+    }
+    fail("condition not met within timeout");
+  }
+
+  private static final class TestSink extends SimpleSinkCommand<Map<String, Object>> {
+    TestSink() {
+      super("soak-node", null, null, null);
+    }
+
+    @Override
+    protected int batchSize() {
+      return 1_000;
+    }
+
+    @Override
+    public String commandName() {
+      return "test_zerobus_soak";
+    }
+
+    @Override
+    protected ExecutionContext createExecutionContext(
+        MetricClientProvider metricClientProvider,
+        JobContext jobContext,
+        CommandConfig commandConfig,
+        String nodeId) {
+      return null;
+    }
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusStoreForwardE2ETest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusStoreForwardE2ETest.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.zerobussink;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.databricks.zerobus.ZerobusJsonStream;
+import com.databricks.zerobus.ZerobusSdk;
+import io.fleak.zephflow.api.CommandConfig;
+import io.fleak.zephflow.api.ExecutionContext;
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.api.ScalarSinkCommand.SinkResult;
+import io.fleak.zephflow.api.metric.FleakCounter;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.sink.ChronicleStoreForward;
+import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
+import io.fleak.zephflow.lib.commands.sink.SinkExecutionContext;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentMatchers;
+
+/**
+ * End-to-end test of the store-and-forward path for the Zerobus sink: a real {@link
+ * SimpleSinkCommand} wired with a real {@link ChronicleStoreForward}, the real {@link
+ * ZerobusConnectionFailureClassifier}, the real {@link ZerobusSinkFlusher} (JSON mode) and {@link
+ * ZerobusMessageProcessor}. Only the gRPC stream is mocked — it fails while "down" and records
+ * payloads while "up", so we can drive a full outage → recovery → replay and assert delivery order.
+ */
+class ZerobusStoreForwardE2ETest {
+
+  private static RecordFleakData record(int id) {
+    return (RecordFleakData) FleakData.wrap(Map.of("id", id));
+  }
+
+  @Test
+  void bufferDuringOutageThenReplayInOrderOnRecovery(@TempDir Path dir) throws Exception {
+    AtomicBoolean streamUp = new AtomicBoolean(false);
+    List<String> delivered = new CopyOnWriteArrayList<>();
+
+    ZerobusJsonStream stream = mock(ZerobusJsonStream.class);
+    when(stream.ingestRecordsOffset(ArgumentMatchers.<String>anyIterable()))
+        .thenAnswer(
+            inv -> {
+              if (!streamUp.get()) {
+                // simulate a connectivity failure: nothing reaches the server
+                throw new RuntimeException("stream down", new IOException("connection refused"));
+              }
+              Iterable<String> payloads = inv.getArgument(0);
+              payloads.forEach(delivered::add);
+              return Optional.of((long) delivered.size());
+            });
+
+    // JSON-mode flusher with a mocked stream; config==null so it never tries a real reconnect.
+    ZerobusSinkFlusher flusher =
+        new ZerobusSinkFlusher(mock(ZerobusSdk.class), null, null, null, stream);
+    ZerobusMessageProcessor preprocessor = new ZerobusMessageProcessor();
+
+    ChronicleStoreForward storeForward =
+        new ChronicleStoreForward(
+            new ChronicleStoreForward.Config(dir, 1_000_000, 50, 2, "node-e2e"),
+            new ZerobusConnectionFailureClassifier(),
+            null,
+            null,
+            null);
+    // ReplayTarget mirrors ZerobusSinkCommand: preprocess raw records, then flush.
+    storeForward.start(
+        records -> {
+          SimpleSinkCommand.PreparedInputEvents<Map<String, Object>> prepared =
+              new SimpleSinkCommand.PreparedInputEvents<>();
+          for (RecordFleakData r : records) {
+            prepared.add(r, preprocessor.preprocess(r, 0L));
+          }
+          flusher.flush(prepared, Map.of());
+        });
+
+    FleakCounter noop = new NoopCounter();
+    SinkExecutionContext<Map<String, Object>> ctx =
+        new SinkExecutionContext<>(
+            flusher, preprocessor, storeForward, noop, noop, noop, noop, noop);
+    TestZerobusSink sink = new TestZerobusSink();
+
+    // 1) Outage: the first write fails to reach the stream and is buffered, not delivered.
+    SinkResult r1 = sink.writeToSink(List.of(record(1), record(2)), "user", ctx);
+    assertEquals(2, r1.getSuccessCount()); // safely persisted
+    assertTrue(storeForward.isBuffering());
+    assertTrue(delivered.isEmpty());
+
+    // 2) Still down: subsequent writes go straight to disk via the outage fast-path.
+    sink.writeToSink(List.of(record(3)), "user", ctx);
+    assertTrue(storeForward.isBuffering());
+    assertTrue(delivered.isEmpty());
+
+    // 3) Recovery: the forwarder drains the backlog oldest-first, then returns to DIRECT.
+    streamUp.set(true);
+    await(() -> !storeForward.isBuffering());
+    assertEquals(List.of("{\"id\":1}", "{\"id\":2}", "{\"id\":3}"), delivered);
+
+    // 4) Back to DIRECT: a new write is delivered straight through.
+    SinkResult r4 = sink.writeToSink(List.of(record(4)), "user", ctx);
+    assertEquals(1, r4.getSuccessCount());
+    assertEquals(List.of("{\"id\":1}", "{\"id\":2}", "{\"id\":3}", "{\"id\":4}"), delivered);
+
+    storeForward.close();
+  }
+
+  private static void await(BooleanSupplier condition) throws InterruptedException {
+    long deadline = System.nanoTime() + java.time.Duration.ofSeconds(10).toNanos();
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.sleep(20);
+    }
+    fail("condition not met within timeout");
+  }
+
+  private static final class TestZerobusSink extends SimpleSinkCommand<Map<String, Object>> {
+    TestZerobusSink() {
+      super("node-e2e", null, null, null);
+    }
+
+    @Override
+    protected int batchSize() {
+      return 2;
+    }
+
+    @Override
+    public String commandName() {
+      return "test_zerobus";
+    }
+
+    @Override
+    protected ExecutionContext createExecutionContext(
+        MetricClientProvider metricClientProvider,
+        JobContext jobContext,
+        CommandConfig commandConfig,
+        String nodeId) {
+      return null;
+    }
+  }
+
+  private static final class NoopCounter implements FleakCounter {
+    @Override
+    public void increase(Map<String, String> additionalTags) {}
+
+    @Override
+    public void increase(long n, Map<String, String> additionalTags) {}
+  }
+}


### PR DESCRIPTION
Chronicle-Queue-backed local buffer that persists records on a connectivity failure and replays them on recovery; generic framework with a no-op default, enrolled for the Kafka and Zerobus sinks.