### PR TITLE
Buffer transient ZerobusException in store-and-forward

### DIFF
--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusConnectionFailureClassifier.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusConnectionFailureClassifier.java
@@ -13,6 +13,8 @@
  */
 package io.fleak.zephflow.lib.commands.zerobussink;
 
+import com.databricks.zerobus.NonRetriableException;
+import com.databricks.zerobus.ZerobusException;
 import io.fleak.zephflow.lib.commands.sink.ConnectionFailureClassifier;
 import io.fleak.zephflow.lib.commands.sink.RetriableConnectionException;
 import java.io.IOException;
@@ -26,7 +28,15 @@ import java.util.Set;
  * UnknownSinkCommitStateException} and reconnect failures into {@link
  * RetriableConnectionException}, so we walk the whole cause chain and look for the underlying
  * network signal: an {@link IOException}, a {@link RetriableConnectionException}, or a gRPC status
- * with a retryable code. Anything we don't recognize is treated as permanent.
+ * with a retryable code.
+ *
+ * <p>When offline, the SDK's native (JNI) {@code waitForOffset}/{@code ingestRecordsOffset} surface
+ * a {@link ZerobusException} carrying only a message — gRPC status objects never cross the JNI
+ * boundary, so none of the signals above are present. We therefore also treat any {@link
+ * ZerobusException} as transient, since that is the SDK's own contract: {@link
+ * NonRetriableException} is its "do not retry" marker (schema/auth/permanent), and the SDK
+ * auto-recovers from every other {@code ZerobusException}. Anything we don't recognize is treated
+ * as permanent.
  */
 public class ZerobusConnectionFailureClassifier implements ConnectionFailureClassifier {
 
@@ -40,6 +50,16 @@ public class ZerobusConnectionFailureClassifier implements ConnectionFailureClas
         cause != null && cause != cause.getCause();
         cause = cause.getCause()) {
       if (cause instanceof RetriableConnectionException || cause instanceof IOException) {
+        return true;
+      }
+      // The SDK's own retriability signal. NonRetriableException is authoritative "permanent" — a
+      // waitForOffset failure here means the batch may already be committed, but buffering+replay
+      // (at-least-once, downstream dedupes) beats dropping it. NonRetriableException is checked
+      // first since it IS-A ZerobusException.
+      if (cause instanceof NonRetriableException) {
+        return false;
+      }
+      if (cause instanceof ZerobusException) {
         return true;
       }
       if (isRetryableGrpcStatus(cause)) {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkDto.java
@@ -62,5 +62,17 @@ public class ZerobusSinkDto {
 
     /** How often the background forwarder retries draining the local queue during an outage. */
     @Builder.Default private long forwardRetryIntervalMillis = 5_000L;
+
+    /**
+     * Max time to wait for a server ack before treating the connection as down. Lower than the SDK
+     * default (60s) so an outage is detected in seconds rather than minutes.
+     */
+    @Builder.Default private int ackTimeoutMillis = 20_000;
+
+    /**
+     * Max time a flush blocks waiting for queued records to be acknowledged. Lower than the SDK
+     * default (5min) to bound how long a flush parks the native thread when offline.
+     */
+    @Builder.Default private int flushTimeoutMillis = 60_000;
   }
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkFlusher.java
@@ -112,9 +112,14 @@ public class ZerobusSinkFlusher implements Flusher<Map<String, Object>> {
    */
   private void connect() {
     ZerobusSdk newSdk = ZerobusClientFactory.createClient(config.getZerobusEndpoint(), credential);
-    // Use the SDK's default stream configuration (incl. its own in-flight defaults); we don't
-    // override tuning knobs the user never configured.
-    StreamConfigurationOptions options = StreamConfigurationOptions.getDefault();
+    // Builder seeds from getDefault(), so maxInflightRecords (50_000) and recovery settings stay
+    // intact; we only tighten the ack/flush timeouts so an outage is detected in seconds, not the
+    // SDK's default minutes (60s ack / 5min flush).
+    StreamConfigurationOptions options =
+        StreamConfigurationOptions.builder()
+            .setServerLackOfAckTimeoutMs(config.getAckTimeoutMillis())
+            .setFlushTimeoutMs(config.getFlushTimeoutMillis())
+            .build();
     try {
       if (ZerobusSinkDto.ENCODING_JSON.equalsIgnoreCase(config.getEncodingType())) {
         ZerobusJsonStream newJsonStream =

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/ChronicleStoreForwardTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/ChronicleStoreForwardTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BooleanSupplier;
@@ -63,12 +64,25 @@ class ChronicleStoreForwardTest {
     ChronicleStoreForward sf =
         new ChronicleStoreForward(
             config(dir, 1_000_000, 2), IO_IS_CONNECTION, buffered, replayed, null);
-    sf.start(delivered::addAll);
+    // Gate delivery so the worker can't drain (and flip buffering back to false) before we observe
+    // the buffering state; releasing the latch then lets it drain to completion.
+    CountDownLatch release = new CountDownLatch(1);
+    sf.start(
+        records -> {
+          try {
+            release.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+          delivered.addAll(records);
+        });
 
     List<RecordFleakData> input = List.of(record("a"), record("b"), record("c"));
     assertEquals(3, sf.offer(input));
     assertTrue(sf.isBuffering());
 
+    release.countDown();
     await(() -> !sf.isBuffering());
 
     assertEquals(List.of("a", "b", "c"), values(delivered));

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusConnectionFailureClassifierTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusConnectionFailureClassifierTest.java
@@ -15,6 +15,8 @@ package io.fleak.zephflow.lib.commands.zerobussink;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.databricks.zerobus.NonRetriableException;
+import com.databricks.zerobus.ZerobusException;
 import io.fleak.zephflow.lib.commands.sink.RetriableConnectionException;
 import io.fleak.zephflow.lib.commands.sink.UnknownSinkCommitStateException;
 import java.io.IOException;
@@ -60,6 +62,23 @@ class ZerobusConnectionFailureClassifierTest {
   void nonRetryableGrpcStatusIsNotConnectionFailure() {
     assertFalse(
         classifier.isConnectionFailure(new StatusRuntimeException("INVALID_ARGUMENT: bad schema")));
+  }
+
+  @Test
+  void bareZerobusExceptionIsConnectionFailure() {
+    // Real offline behavior: the native layer throws a message-only ZerobusException (no cause).
+    assertTrue(
+        classifier.isConnectionFailure(
+            new UnknownSinkCommitStateException(
+                "commit state unknown", new ZerobusException("server lack of ack timeout"))));
+  }
+
+  @Test
+  void nonRetriableExceptionIsNotConnectionFailure() {
+    assertFalse(
+        classifier.isConnectionFailure(
+            new UnknownSinkCommitStateException(
+                "commit state unknown", new NonRetriableException("invalid schema"))));
   }
 
   @Test

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkBlackboxTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkBlackboxTest.java
@@ -16,6 +16,7 @@ package io.fleak.zephflow.lib.commands.zerobussink;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.databricks.zerobus.ZerobusException;
 import com.databricks.zerobus.ZerobusJsonStream;
 import com.databricks.zerobus.ZerobusSdk;
 import io.fleak.zephflow.api.CommandConfig;
@@ -28,7 +29,6 @@ import io.fleak.zephflow.api.structure.RecordFleakData;
 import io.fleak.zephflow.lib.commands.sink.ChronicleStoreForward;
 import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
 import io.fleak.zephflow.lib.commands.sink.SinkExecutionContext;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -161,9 +161,11 @@ class ZerobusSinkBlackboxTest {
     private final AtomicBoolean connected = new AtomicBoolean(true);
     private final List<String> received = new ArrayList<>();
 
-    synchronized Optional<Long> ingest(Iterable<String> payloads) {
+    synchronized Optional<Long> ingest(Iterable<String> payloads) throws ZerobusException {
       if (!connected.get()) {
-        throw new RuntimeException("endpoint unreachable", new IOException("connection refused"));
+        // Faithful to the native client: an offline failure surfaces as a message-only
+        // ZerobusException with no IOException/gRPC cause.
+        throw new ZerobusException("server lack of ack timeout");
       }
       payloads.forEach(received::add);
       return Optional.of((long) received.size());

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkStoreForwardSoakTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkStoreForwardSoakTest.java
@@ -16,6 +16,7 @@ package io.fleak.zephflow.lib.commands.zerobussink;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.databricks.zerobus.ZerobusException;
 import com.databricks.zerobus.ZerobusJsonStream;
 import com.databricks.zerobus.ZerobusSdk;
 import io.fleak.zephflow.api.CommandConfig;
@@ -29,7 +30,6 @@ import io.fleak.zephflow.lib.commands.sink.ChronicleStoreForward;
 import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
 import io.fleak.zephflow.lib.commands.sink.SinkExecutionContext;
 import io.fleak.zephflow.lib.utils.JsonUtils;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -159,9 +159,11 @@ class ZerobusSinkStoreForwardSoakTest {
     private int expectedNext = 1;
     private int outOfOrder = 0;
 
-    synchronized Optional<Long> ingest(Iterable<String> payloads) {
+    synchronized Optional<Long> ingest(Iterable<String> payloads) throws ZerobusException {
       if (!connected.get()) {
-        throw new RuntimeException("endpoint unreachable", new IOException("connection refused"));
+        // Faithful to the native client: an offline failure surfaces as a message-only
+        // ZerobusException with no IOException/gRPC cause.
+        throw new ZerobusException("server lack of ack timeout");
       }
       for (String payload : payloads) {
         int id = parseId(payload);


### PR DESCRIPTION
Classify a non-NonRetriable ZerobusException as a connectivity failure so offline waitForOffset/ingest failures engage store-and-forward instead of failing the batch. gRPC status never crosses the SDK's JNI boundary, so the classifier matches the SDK's own retriability signal directly. Also tighten the default ack/flush timeouts so an outage is detected in seconds.