### PR TITLE
FLE-2069: don't log node config errors at ERROR in DagCompiler

### DIFF
--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/parser/ParserConfigValidator.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/parser/ParserConfigValidator.java
@@ -24,7 +24,8 @@ public class ParserConfigValidator implements ConfigValidator {
   @Override
   public void validateConfig(CommandConfig commandConfig, String nodeId, JobContext jobContext) {
     var parserConfig = ((ParserConfigs.ParserConfig) commandConfig);
-    Preconditions.checkNotNull(parserConfig.getTargetField(), "targetField is missing");
-    Preconditions.checkNotNull(parserConfig.getExtractionConfig(), "extractionConfig is missing");
+    Preconditions.checkArgument(parserConfig.getTargetField() != null, "targetField is missing");
+    Preconditions.checkArgument(
+        parserConfig.getExtractionConfig() != null, "extractionConfig is missing");
   }
 }

--- a/runner/src/main/java/io/fleak/zephflow/runner/DagCompiler.java
+++ b/runner/src/main/java/io/fleak/zephflow/runner/DagCompiler.java
@@ -78,7 +78,13 @@ public record DagCompiler(Map<String, CommandFactory> commandFactoryMap) {
                         .id(n.getId())
                         .build();
                   } catch (Exception e) {
-                    log.error("dag compilation error at node {}: {}", n.getId(), rdn, e);
+                    // config errors are expected user-input failures; the exception is wrapped
+                    // and rethrown for the caller to handle, so don't log at ERROR
+                    log.warn(
+                        "dag compilation error at node {}: {}, reason: {}",
+                        n.getId(),
+                        rdn,
+                        e.getMessage());
                     throw new DagCompilationException(
                         DagCompilationException.ErrorType.NODE_COMPILATION,
                         n.getId(),


### PR DESCRIPTION
Config validation failures are expected user-input errors, already wrapped in DagCompilationException for callers; the ERROR log with throwable created noisy Sentry issues. Also make ParserConfigValidator throw IllegalArgumentException instead of NPE for missing fields.