### PR TITLE
FLE-2245: deep-copy step output snapshots in DagResult so downstream …

### DIFF
--- a/api/src/main/java/io/fleak/zephflow/api/structure/RecordFleakData.java
+++ b/api/src/main/java/io/fleak/zephflow/api/structure/RecordFleakData.java
@@ -48,6 +48,15 @@ public class RecordFleakData implements FleakData {
     return new RecordFleakData(new HashMap<>(newPayload));
   }
 
+  /**
+   * Returns a fully independent copy of this record. Unlike {@link #copy()}, which shares the
+   * nested {@link FleakData} values with the original, mutations on the returned record can never
+   * affect this record.
+   */
+  public RecordFleakData deepCopy() {
+    return (RecordFleakData) FleakData.wrap(unwrap());
+  }
+
   public RecordFleakData copyAndMerge(Map<String, FleakData> additionalPayload) {
     RecordFleakData copy = this.copy();
     copy.payload.putAll(additionalPayload);

--- a/api/src/test/java/io/fleak/zephflow/api/structure/RecordFleakDataTest.java
+++ b/api/src/test/java/io/fleak/zephflow/api/structure/RecordFleakDataTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.api.structure;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RecordFleakDataTest {
+
+  @Test
+  void deepCopyIsEqualButFullyIndependent() {
+    RecordFleakData original =
+        (RecordFleakData)
+            FleakData.wrap(
+                Map.of(
+                    "id",
+                    "event1",
+                    "count",
+                    42L,
+                    "nested",
+                    Map.of("email", "a@b.com"),
+                    "tags",
+                    List.of("x", "y")));
+
+    RecordFleakData copy = original.deepCopy();
+    assertEquals(original, copy);
+
+    ((StringPrimitiveFleakData) copy.getPayload().get("id")).setStringValue("[MASKED]");
+    ((StringPrimitiveFleakData)
+            ((RecordFleakData) copy.getPayload().get("nested")).getPayload().get("email"))
+        .setStringValue("[EMAIL]");
+
+    RecordFleakData expectedOriginal =
+        (RecordFleakData)
+            FleakData.wrap(
+                Map.of(
+                    "id",
+                    "event1",
+                    "count",
+                    42L,
+                    "nested",
+                    Map.of("email", "a@b.com"),
+                    "tags",
+                    List.of("x", "y")));
+    assertEquals(expectedOriginal, original);
+  }
+}

--- a/runner/src/main/java/io/fleak/zephflow/runner/DagResult.java
+++ b/runner/src/main/java/io/fleak/zephflow/runner/DagResult.java
@@ -69,7 +69,11 @@ public class DagResult {
       recordDebugInfo(nodeId, upstreamNodeId, failureEvents, errorByStep, false);
     }
     if (runConfig.includeOutputByStep()) {
-      recordDebugInfo(nodeId, upstreamNodeId, output, outputByStep, true);
+      // snapshot with deep copies: downstream commands may mutate events in place,
+      // which would otherwise retroactively corrupt the recorded step outputs
+      List<RecordFleakData> copies =
+          output == null ? null : output.stream().map(RecordFleakData::deepCopy).toList();
+      recordDebugInfo(nodeId, upstreamNodeId, copies, outputByStep, true);
     }
   }
 

--- a/runner/src/test/java/io/fleak/zephflow/runner/NoSourceDagRunnerTest.java
+++ b/runner/src/test/java/io/fleak/zephflow/runner/NoSourceDagRunnerTest.java
@@ -837,6 +837,49 @@ class NoSourceDagRunnerTest {
     }
 
     @Test
+    @DisplayName("step output snapshots should not be affected by downstream in-place mutation")
+    void run_shouldSnapshotStepOutputAgainstDownstreamMutation() {
+      Node<OperatorCommand> node1 =
+          Node.<OperatorCommand>builder().id(NODE_ID_1).nodeContent(mockScalarCmd1).build();
+      Node<OperatorCommand> node2 =
+          Node.<OperatorCommand>builder().id(NODE_ID_2).nodeContent(mockScalarCmd2).build();
+      List<Node<OperatorCommand>> nodes = List.of(node1, node2);
+      List<Edge> edges = List.of(Edge.builder().from(NODE_ID_1).to(NODE_ID_2).build());
+      Dag<OperatorCommand> compiledDag = new Dag<>(nodes, edges);
+
+      // node2 mutates the incoming events in place (like piimask) and returns the same instances
+      when(mockScalarCmd2.process(anyList(), eq(CALLING_USER), any(ExecutionContext.class)))
+          .thenAnswer(
+              invocation -> {
+                List<RecordFleakData> events = invocation.getArgument(0);
+                for (RecordFleakData e : events) {
+                  ((StringPrimitiveFleakData) e.getPayload().get("id")).setStringValue("[MASKED]");
+                }
+                return new ScalarCommand.ProcessResult(
+                    new ArrayList<>(events), Collections.emptyList());
+              });
+
+      noSourceDagRunner =
+          new NoSourceDagRunner(
+              edgesFromSource, compiledDag, mockMetricProvider, mockCounters, false);
+
+      DagResult result = noSourceDagRunner.run(inputEvents, CALLING_USER, runConfigIncludeAll);
+
+      assertDebugInfo(
+          result.outputByStep,
+          NODE_ID_1,
+          SOURCE_NODE_ID,
+          List.of(createEvent("event1"), createEvent("event2")),
+          "outputByStep");
+      assertDebugInfo(
+          result.outputByStep,
+          NODE_ID_2,
+          NODE_ID_1,
+          List.of(createEvent("[MASKED]"), createEvent("[MASKED]")),
+          "outputByStep");
+    }
+
+    @Test
     @DisplayName("should include sink output in outputEvents even when step output is excluded")
     void run_shouldIncludeSinkOutputInOutputEventsWhenStepOutputIsExcluded() {
 


### PR DESCRIPTION
…in-place mutation can't corrupt them