### PR TITLE
FLE-2236 Destination Node: add credential support for Kafka/MSK sink

### DIFF
--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkCommand.java
@@ -15,7 +15,9 @@ package io.fleak.zephflow.lib.commands.kafkasink;
 
 import static io.fleak.zephflow.lib.utils.MiscUtils.COMMAND_NAME_KAFKA_SINK;
 import static io.fleak.zephflow.lib.utils.MiscUtils.basicCommandMetricTags;
+import static io.fleak.zephflow.lib.utils.MiscUtils.lookupUsernamePasswordCredential;
 
+import com.google.common.base.Preconditions;
 import io.fleak.zephflow.api.*;
 import io.fleak.zephflow.api.metric.FleakCounter;
 import io.fleak.zephflow.api.metric.MetricClientProvider;
@@ -27,6 +29,7 @@ import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
 import io.fleak.zephflow.lib.commands.sink.SinkExecutionContext;
 import io.fleak.zephflow.lib.commands.sink.SinkStoreForward;
 import io.fleak.zephflow.lib.commands.sink.StoreForwardPaths;
+import io.fleak.zephflow.lib.credentials.UsernamePasswordCredential;
 import io.fleak.zephflow.lib.pathselect.PathExpression;
 import io.fleak.zephflow.lib.serdes.EncodingType;
 import io.fleak.zephflow.lib.serdes.ser.FleakSerializer;
@@ -38,9 +41,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.plain.PlainLoginModule;
+import org.apache.kafka.common.security.scram.ScramLoginModule;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.jetbrains.annotations.NotNull;
 
@@ -135,6 +142,8 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
       props.putAll(config.getProperties());
     }
 
+    applyCredentialSasl(props, config);
+
     EncodingType encodingType = EncodingType.valueOf(config.getEncodingType().toUpperCase());
     SerializerFactory<?> serializerFactory =
         SerializerFactory.createSerializerFactory(encodingType);
@@ -210,6 +219,42 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
           flusher.flush(prepared, Map.of());
         });
     return storeForward;
+  }
+
+  private void applyCredentialSasl(Properties props, KafkaSinkDto.Config config) {
+    String protocol = StringUtils.trimToNull(config.getSecurityProtocol());
+    if (protocol == null) {
+      return;
+    }
+    props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, protocol);
+    if (!protocol.startsWith("SASL_")) {
+      return;
+    }
+    String mechanism = StringUtils.trimToNull(config.getSaslMechanism());
+    Preconditions.checkArgument(
+        mechanism != null, "saslMechanism is required when securityProtocol is %s", protocol);
+    props.put(SaslConfigs.SASL_MECHANISM, mechanism);
+    UsernamePasswordCredential cred =
+        lookupUsernamePasswordCredential(jobContext, config.getCredentialId());
+    props.put(
+        SaslConfigs.SASL_JAAS_CONFIG,
+        buildJaasConfig(mechanism, cred.getUsername(), cred.getPassword()));
+  }
+
+  private static String buildJaasConfig(String mechanism, String username, String password) {
+    String loginModule =
+        switch (mechanism) {
+          case "PLAIN" -> PlainLoginModule.class.getName();
+          case "SCRAM-SHA-256", "SCRAM-SHA-512" -> ScramLoginModule.class.getName();
+          default -> throw new IllegalArgumentException("Unsupported SASL mechanism: " + mechanism);
+        };
+    return String.format(
+        "%s required username=\"%s\" password=\"%s\";",
+        loginModule, escapeJaas(username), escapeJaas(password));
+  }
+
+  private static String escapeJaas(String v) {
+    return v.replace("\\", "\\\\").replace("\"", "\\\"");
   }
 
   private static @NotNull Properties getProperties(KafkaSinkDto.Config config) {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkConfigValidator.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkConfigValidator.java
@@ -13,15 +13,34 @@
  */
 package io.fleak.zephflow.lib.commands.kafkasink;
 
-import static io.fleak.zephflow.lib.utils.MiscUtils.parseEnum;
+import static io.fleak.zephflow.lib.utils.MiscUtils.*;
 
 import io.fleak.zephflow.api.*;
 import io.fleak.zephflow.lib.pathselect.PathExpression;
 import io.fleak.zephflow.lib.serdes.EncodingType;
 import io.fleak.zephflow.lib.serdes.ser.SerializerFactory;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 
 public class KafkaSinkConfigValidator implements ConfigValidator {
+
+  private static final Set<String> SUPPORTED_SASL_MECHANISMS =
+      Set.of("PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512");
+
+  private static final Set<String> MANAGED_PROPERTY_KEYS =
+      Set.of(
+          SaslConfigs.SASL_JAAS_CONFIG,
+          SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
+          SslConfigs.SSL_KEY_PASSWORD_CONFIG,
+          SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG,
+          CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
+          SaslConfigs.SASL_MECHANISM);
 
   @Override
   public void validateConfig(CommandConfig commandConfig, String nodeId, JobContext jobContext) {
@@ -48,6 +67,48 @@ public class KafkaSinkConfigValidator implements ConfigValidator {
         throw new IllegalArgumentException(
             "forwardRetryIntervalMillis must be positive when storeAndForwardEnabled. Got: "
                 + config.getForwardRetryIntervalMillis());
+      }
+    }
+
+    validateAssetManagedSecurity(config, jobContext);
+  }
+
+  private void validateAssetManagedSecurity(KafkaSinkDto.Config config, JobContext jobContext) {
+    String protocol = StringUtils.trimToNull(config.getSecurityProtocol());
+    if (protocol == null) {
+      return;
+    }
+    parseEnum(SecurityProtocol.class, protocol);
+    if (protocol.startsWith("SASL_")) {
+      String mechanism = StringUtils.trimToNull(config.getSaslMechanism());
+      if (mechanism == null || !SUPPORTED_SASL_MECHANISMS.contains(mechanism)) {
+        throw new IllegalArgumentException(
+            "saslMechanism must be one of "
+                + SUPPORTED_SASL_MECHANISMS
+                + " when securityProtocol is "
+                + protocol);
+      }
+      if (StringUtils.isBlank(config.getCredentialId())) {
+        throw new IllegalArgumentException(
+            "credentialId is required when securityProtocol is " + protocol);
+      }
+      if (enforceCredentials(jobContext)) {
+        lookupUsernamePasswordCredential(jobContext, config.getCredentialId());
+      }
+    }
+    rejectManagedProperties(config.getProperties());
+  }
+
+  private static void rejectManagedProperties(Map<String, String> properties) {
+    if (properties == null) {
+      return;
+    }
+    for (String key : properties.keySet()) {
+      if (key != null && MANAGED_PROPERTY_KEYS.contains(key.toLowerCase(Locale.ROOT))) {
+        throw new IllegalArgumentException(
+            "property '"
+                + key
+                + "' is managed by the connection profile/credential and must not be set in properties");
       }
     }
   }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDto.java
@@ -29,6 +29,10 @@ public interface KafkaSinkDto {
     @NonNull private String encodingType;
     private Map<String, String> properties;
 
+    private String credentialId;
+    private String securityProtocol;
+    private String saslMechanism;
+
     /**
      * Store-and-forward: when enabled, a connectivity failure persists records to a local durable
      * queue and replays them once the broker is reachable again, instead of dropping them. This

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkConfigValidatorTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkConfigValidatorTest.java
@@ -13,10 +13,18 @@
  */
 package io.fleak.zephflow.lib.commands.kafkasink;
 
+import static io.fleak.zephflow.lib.utils.JsonUtils.OBJECT_MAPPER;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.lib.TestUtils;
 import io.fleak.zephflow.lib.serdes.EncodingType;
 import io.fleak.zephflow.lib.serdes.ser.SerializerFactory;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class KafkaSinkConfigValidatorTest {
@@ -144,5 +152,143 @@ class KafkaSinkConfigValidatorTest {
 
       assertDoesNotThrow(() -> validator.validateConfig(config, "test-node", null));
     }
+  }
+
+  private static KafkaSinkDto.Config.ConfigBuilder base() {
+    return KafkaSinkDto.Config.builder()
+        .broker("localhost:9092")
+        .topic("test-topic")
+        .encodingType(EncodingType.JSON_OBJECT.name());
+  }
+
+  @Test
+  void validateConfig_noSecurityProtocol_ok() {
+    assertDoesNotThrow(() -> validator.validateConfig(base().build(), "test-node", null));
+  }
+
+  @Test
+  void validateConfig_saslWithCredentialAndEnforce_ok() {
+    Map<String, Serializable> other = new HashMap<>();
+    other.put("enforce_cred", Boolean.TRUE);
+    other.put(
+        "credential_2",
+        OBJECT_MAPPER.convertValue(
+            TestUtils.USERNAME_PASSWORD_CREDENTIAL, new TypeReference<>() {}));
+    JobContext jobContext = TestUtils.buildJobContext(other);
+
+    KafkaSinkDto.Config config =
+        base()
+            .securityProtocol("SASL_SSL")
+            .saslMechanism("SCRAM-SHA-512")
+            .credentialId("credential_2")
+            .build();
+
+    assertDoesNotThrow(() -> validator.validateConfig(config, "test-node", jobContext));
+  }
+
+  @Test
+  void validateConfig_saslWithoutCredentialId_throws() {
+    KafkaSinkDto.Config config = base().securityProtocol("SASL_SSL").saslMechanism("PLAIN").build();
+
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", null));
+    assertTrue(exception.getMessage().contains("credentialId is required"));
+  }
+
+  @Test
+  void validateConfig_unsupportedSaslMechanism_throws() {
+    KafkaSinkDto.Config config =
+        base()
+            .securityProtocol("SASL_SSL")
+            .saslMechanism("MD5")
+            .credentialId("credential_2")
+            .build();
+
+    assertThrows(
+        IllegalArgumentException.class, () -> validator.validateConfig(config, "test-node", null));
+  }
+
+  @Test
+  void validateConfig_saslWithBlankMechanism_throwsActionable() {
+    KafkaSinkDto.Config config =
+        base().securityProtocol("SASL_SSL").credentialId("credential_2").build();
+
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", null));
+    assertTrue(exception.getMessage().contains("saslMechanism must be one of"));
+  }
+
+  @Test
+  void validateConfig_invalidSecurityProtocol_throws() {
+    KafkaSinkDto.Config config = base().securityProtocol("BOGUS").build();
+
+    assertThrows(
+        IllegalArgumentException.class, () -> validator.validateConfig(config, "test-node", null));
+  }
+
+  @Test
+  void validateConfig_assetManagedRejectsSecretProperties() {
+    for (String key :
+        List.of(
+            "sasl.jaas.config", "ssl.truststore.password", "security.protocol", "sasl.mechanism")) {
+      KafkaSinkDto.Config config =
+          base()
+              .securityProtocol("SASL_SSL")
+              .saslMechanism("SCRAM-SHA-512")
+              .credentialId("credential_2")
+              .properties(Map.of(key, "x"))
+              .build();
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> validator.validateConfig(config, "test-node", TestUtils.JOB_CONTEXT),
+          "expected rejection for property " + key);
+    }
+  }
+
+  @Test
+  void validateConfig_assetManagedRejectsSecretProperties_caseInsensitive() {
+    KafkaSinkDto.Config config =
+        base()
+            .securityProtocol("SASL_SSL")
+            .saslMechanism("SCRAM-SHA-512")
+            .credentialId("credential_2")
+            .properties(Map.of("SASL.JAAS.Config", "x"))
+            .build();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> validator.validateConfig(config, "test-node", TestUtils.JOB_CONTEXT));
+  }
+
+  @Test
+  void validateConfig_legacyRawSaslProperties_ok() {
+    KafkaSinkDto.Config config =
+        base()
+            .properties(
+                Map.of(
+                    "security.protocol", "SASL_SSL",
+                    "sasl.mechanism", "SCRAM-SHA-512",
+                    "sasl.jaas.config",
+                        "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"u\" password=\"p\";"))
+            .build();
+
+    assertDoesNotThrow(() -> validator.validateConfig(config, "test-node", null));
+  }
+
+  @Test
+  void validateConfig_saslCredentialAbsentButEnforceOff_ok() {
+    KafkaSinkDto.Config config =
+        base()
+            .securityProtocol("SASL_SSL")
+            .saslMechanism("SCRAM-SHA-512")
+            .credentialId("absent_cred")
+            .build();
+
+    assertDoesNotThrow(() -> validator.validateConfig(config, "test-node", TestUtils.JOB_CONTEXT));
   }
 }

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkSaslCommandTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkSaslCommandTest.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.kafkasink;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.OBJECT_MAPPER;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.lib.TestUtils;
+import io.fleak.zephflow.lib.credentials.UsernamePasswordCredential;
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.plain.PlainLoginModule;
+import org.apache.kafka.common.security.scram.ScramLoginModule;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class KafkaSinkSaslCommandTest {
+
+  private static final String CREDENTIAL_ID = "credential_2";
+
+  static class CapturingProducerFactory extends KafkaProducerClientFactory {
+    Properties captured;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    KafkaProducer<byte[], byte[]> createKafkaProducer(Properties props) {
+      this.captured = props;
+      return (KafkaProducer<byte[], byte[]>) Mockito.mock(KafkaProducer.class);
+    }
+  }
+
+  private static Properties captureProps(KafkaSinkDto.Config config, JobContext jobContext) {
+    CapturingProducerFactory factory = new CapturingProducerFactory();
+    KafkaSinkCommand cmd =
+        (KafkaSinkCommand) new KafkaSinkCommandFactory(factory).createCommand("node", jobContext);
+    cmd.parseAndValidateArg(OBJECT_MAPPER.convertValue(config, new TypeReference<>() {}));
+    cmd.initialize(new MetricClientProvider.NoopMetricClientProvider());
+    return factory.captured;
+  }
+
+  private static KafkaSinkDto.Config.ConfigBuilder baseConfig() {
+    return KafkaSinkDto.Config.builder()
+        .broker("localhost:9092")
+        .topic("t")
+        .encodingType(EncodingType.JSON_OBJECT.name());
+  }
+
+  @Test
+  void scramPath_buildsScramJaasConfig() {
+    KafkaSinkDto.Config config =
+        baseConfig()
+            .securityProtocol("SASL_SSL")
+            .saslMechanism("SCRAM-SHA-512")
+            .credentialId(CREDENTIAL_ID)
+            .build();
+
+    Properties props = captureProps(config, TestUtils.JOB_CONTEXT);
+
+    assertEquals("SASL_SSL", props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+    assertEquals("SCRAM-SHA-512", props.getProperty(SaslConfigs.SASL_MECHANISM));
+    assertEquals(
+        ScramLoginModule.class.getName()
+            + " required username=\"MY_USER_NAME\" password=\"MY_PASSWORD\";",
+        props.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+  }
+
+  @Test
+  void plainPath_buildsPlainJaasConfig() {
+    KafkaSinkDto.Config config =
+        baseConfig()
+            .securityProtocol("SASL_SSL")
+            .saslMechanism("PLAIN")
+            .credentialId(CREDENTIAL_ID)
+            .build();
+
+    Properties props = captureProps(config, TestUtils.JOB_CONTEXT);
+
+    assertEquals("SASL_SSL", props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+    assertEquals("PLAIN", props.getProperty(SaslConfigs.SASL_MECHANISM));
+    assertEquals(
+        PlainLoginModule.class.getName()
+            + " required username=\"MY_USER_NAME\" password=\"MY_PASSWORD\";",
+        props.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+  }
+
+  @Test
+  void jaasConfig_escapesQuotesAndBackslashes() {
+    Map<String, Serializable> other =
+        new HashMap<>(
+            Map.of(
+                "cred_special",
+                OBJECT_MAPPER.convertValue(
+                    new UsernamePasswordCredential("a\"b", "c\\d"), new TypeReference<>() {})));
+    JobContext jobContext = TestUtils.buildJobContext(other);
+
+    KafkaSinkDto.Config config =
+        baseConfig()
+            .securityProtocol("SASL_PLAINTEXT")
+            .saslMechanism("PLAIN")
+            .credentialId("cred_special")
+            .build();
+
+    Properties props = captureProps(config, jobContext);
+
+    assertEquals(
+        PlainLoginModule.class.getName() + " required username=\"a\\\"b\" password=\"c\\\\d\";",
+        props.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+  }
+
+  @Test
+  void applyCredentialSasl_isLastMutation_preservesUserProps() {
+    KafkaSinkDto.Config config =
+        baseConfig()
+            .securityProtocol("SASL_SSL")
+            .saslMechanism("SCRAM-SHA-512")
+            .credentialId(CREDENTIAL_ID)
+            .properties(Map.of("acks", "all"))
+            .build();
+
+    Properties props = captureProps(config, TestUtils.JOB_CONTEXT);
+
+    assertEquals("all", props.getProperty("acks"));
+    assertEquals("SASL_SSL", props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+    assertEquals("SCRAM-SHA-512", props.getProperty(SaslConfigs.SASL_MECHANISM));
+    assertNotNull(props.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+  }
+
+  @Test
+  void legacy_noSecurityProtocol_isNoOp() {
+    KafkaSinkDto.Config config = baseConfig().build();
+
+    Properties props = captureProps(config, TestUtils.JOB_CONTEXT);
+
+    assertNull(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+    assertNull(props.getProperty(SaslConfigs.SASL_MECHANISM));
+    assertNull(props.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+  }
+
+  @Test
+  void legacy_rawSaslInProperties_isPreserved() {
+    String rawJaas = ScramLoginModule.class.getName() + " required username=\"u\" password=\"p\";";
+    Map<String, String> rawProps = new HashMap<>();
+    rawProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+    rawProps.put(SaslConfigs.SASL_MECHANISM, "SCRAM-SHA-512");
+    rawProps.put(SaslConfigs.SASL_JAAS_CONFIG, rawJaas);
+    KafkaSinkDto.Config config = baseConfig().properties(rawProps).build();
+
+    Properties props = captureProps(config, TestUtils.JOB_CONTEXT);
+
+    assertEquals("SASL_SSL", props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+    assertEquals("SCRAM-SHA-512", props.getProperty(SaslConfigs.SASL_MECHANISM));
+    assertEquals(rawJaas, props.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+  }
+
+  @Test
+  void missingCredentialAtRuntime_throws() {
+    KafkaSinkDto.Config config =
+        baseConfig()
+            .securityProtocol("SASL_SSL")
+            .saslMechanism("SCRAM-SHA-512")
+            .credentialId("does_not_exist")
+            .build();
+
+    CapturingProducerFactory factory = new CapturingProducerFactory();
+    KafkaSinkCommand cmd =
+        (KafkaSinkCommand)
+            new KafkaSinkCommandFactory(factory).createCommand("node", TestUtils.JOB_CONTEXT);
+    cmd.parseAndValidateArg(OBJECT_MAPPER.convertValue(config, new TypeReference<>() {}));
+
+    assertThrows(
+        RuntimeException.class,
+        () -> cmd.initialize(new MetricClientProvider.NoopMetricClientProvider()));
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkSaslIntegrationTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkSaslIntegrationTest.java
@@ -1,0 +1,303 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.kafkasink;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.*;
+import static io.fleak.zephflow.lib.utils.MiscUtils.METRIC_TAG_ENV;
+import static io.fleak.zephflow.lib.utils.MiscUtils.METRIC_TAG_SERVICE;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.credentials.UsernamePasswordCredential;
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.StreamSupport;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.ScramCredentialInfo;
+import org.apache.kafka.clients.admin.ScramMechanism;
+import org.apache.kafka.clients.admin.UserScramCredentialUpsertion;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+
+/**
+ * Integration test for SASL auth on the Kafka sink against a <b>real broker</b>. Uses a {@code
+ * SASL_PLAINTEXT} + {@code PLAIN} listener (no TLS certs, no SCRAM provisioning) so the test is
+ * deterministic. The broker-side JAAS declares a fixed user/pass; the same user/pass is provided to
+ * the sink as a {@link UsernamePasswordCredential} keyed by {@code credentialId}, and the engine
+ * assembles the SASL config in memory at runtime. Covers {@code PLAIN} and {@code
+ * SCRAM-SHA-256}/{@code SCRAM-SHA-512} on the same listener; full {@code SASL_SSL} (TLS) is
+ * deferred to a live-stack phase. Tagged {@code integration}; requires Docker.
+ */
+@Tag("integration")
+@Testcontainers
+class KafkaSinkSaslIntegrationTest {
+
+  private static final String TOPIC = "sasl_topic";
+  private static final String TOPIC_NEG = "sasl_topic_neg";
+  private static final String TOPIC_SCRAM_512 = "scram_topic_512";
+  private static final String TOPIC_SCRAM_256 = "scram_topic_256";
+  private static final String USERNAME = "kafkauser";
+  private static final String PASSWORD = "kafkapass";
+  private static final String CREDENTIAL_ID = "kafka_sasl_cred";
+
+  private static final String BROKER_JAAS =
+      "org.apache.kafka.common.security.plain.PlainLoginModule required "
+          + "username=\""
+          + USERNAME
+          + "\" password=\""
+          + PASSWORD
+          + "\" user_"
+          + USERNAME
+          + "=\""
+          + PASSWORD
+          + "\";";
+
+  @Container
+  private static final KafkaContainer KAFKA =
+      new KafkaContainer("apache/kafka-native:3.8.0")
+          .withEnv(
+              "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
+              "BROKER:PLAINTEXT,CONTROLLER:PLAINTEXT,PLAINTEXT:SASL_PLAINTEXT")
+          .withEnv("KAFKA_SASL_ENABLED_MECHANISMS", "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512")
+          .withEnv(
+              "KAFKA_LISTENER_NAME_PLAINTEXT_SASL_ENABLED_MECHANISMS",
+              "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512")
+          .withEnv("KAFKA_LISTENER_NAME_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG", BROKER_JAAS)
+          .withEnv(
+              "KAFKA_LISTENER_NAME_PLAINTEXT_SCRAM___SHA___512_SASL_JAAS_CONFIG",
+              "org.apache.kafka.common.security.scram.ScramLoginModule required;")
+          .withEnv(
+              "KAFKA_LISTENER_NAME_PLAINTEXT_SCRAM___SHA___256_SASL_JAAS_CONFIG",
+              "org.apache.kafka.common.security.scram.ScramLoginModule required;");
+
+  @BeforeAll
+  static void setup() throws Exception {
+    Properties props = new Properties();
+    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
+    props.putAll(clientSaslProps(USERNAME, PASSWORD));
+    try (AdminClient admin = AdminClient.create(props)) {
+      admin
+          .createTopics(
+              List.of(
+                  new NewTopic(TOPIC, 1, (short) 1),
+                  new NewTopic(TOPIC_NEG, 1, (short) 1),
+                  new NewTopic(TOPIC_SCRAM_512, 1, (short) 1),
+                  new NewTopic(TOPIC_SCRAM_256, 1, (short) 1)))
+          .all()
+          .get(30, TimeUnit.SECONDS);
+      admin
+          .alterUserScramCredentials(
+              List.of(
+                  new UserScramCredentialUpsertion(
+                      USERNAME,
+                      new ScramCredentialInfo(ScramMechanism.SCRAM_SHA_512, 4096),
+                      PASSWORD)))
+          .all()
+          .get(30, TimeUnit.SECONDS);
+      admin
+          .alterUserScramCredentials(
+              List.of(
+                  new UserScramCredentialUpsertion(
+                      USERNAME,
+                      new ScramCredentialInfo(ScramMechanism.SCRAM_SHA_256, 4096),
+                      PASSWORD)))
+          .all()
+          .get(30, TimeUnit.SECONDS);
+    }
+  }
+
+  @AfterAll
+  static void stop() {
+    if (KAFKA.isRunning()) {
+      KAFKA.stop();
+    }
+  }
+
+  @Test
+  void writeToSink_authenticatesAndDelivers() throws Exception {
+    KafkaSinkCommand sink =
+        (KafkaSinkCommand)
+            new KafkaSinkCommandFactory().createCommand("sasl-node", jobContext(PASSWORD));
+    KafkaSinkDto.Config config =
+        KafkaSinkDto.Config.builder()
+            .topic(TOPIC)
+            .broker(KAFKA.getBootstrapServers())
+            .encodingType(EncodingType.JSON_OBJECT.toString())
+            .securityProtocol("SASL_PLAINTEXT")
+            .saslMechanism("PLAIN")
+            .credentialId(CREDENTIAL_ID)
+            .build();
+    sink.parseAndValidateArg(OBJECT_MAPPER.convertValue(config, new TypeReference<>() {}));
+    sink.initialize(new MetricClientProvider.NoopMetricClientProvider());
+
+    var ctx = sink.getExecutionContext();
+    sink.writeToSink(records(1, 10), "user", ctx);
+
+    List<Integer> ids =
+        drain(TOPIC, "sasl-consumer-" + System.nanoTime(), Duration.ofSeconds(20), 10);
+    assertEquals(10, new HashSet<>(ids).size(), "all SASL-authenticated records delivered");
+
+    sink.terminate();
+  }
+
+  @Test
+  void wrongPassword_failsAuthentication() throws Exception {
+    KafkaSinkCommand sink =
+        (KafkaSinkCommand)
+            new KafkaSinkCommandFactory().createCommand("sasl-bad-node", jobContext("wrong-pass"));
+    KafkaSinkDto.Config config =
+        KafkaSinkDto.Config.builder()
+            .topic(TOPIC_NEG)
+            .broker(KAFKA.getBootstrapServers())
+            .encodingType(EncodingType.JSON_OBJECT.toString())
+            .securityProtocol("SASL_PLAINTEXT")
+            .saslMechanism("PLAIN")
+            .credentialId(CREDENTIAL_ID)
+            .build();
+    sink.parseAndValidateArg(OBJECT_MAPPER.convertValue(config, new TypeReference<>() {}));
+    sink.initialize(new MetricClientProvider.NoopMetricClientProvider());
+
+    var ctx = sink.getExecutionContext();
+    sink.writeToSink(records(100, 105), "user", ctx);
+
+    List<Integer> ids =
+        drain(TOPIC_NEG, "sasl-bad-consumer-" + System.nanoTime(), Duration.ofSeconds(10), 1);
+    assertTrue(ids.isEmpty(), "no records should be delivered with a wrong password");
+
+    sink.terminate();
+  }
+
+  @Test
+  void writeToSink_scramSha512_authenticatesAndDelivers() throws Exception {
+    assertScramDelivers("SCRAM-SHA-512", TOPIC_SCRAM_512);
+  }
+
+  @Test
+  void writeToSink_scramSha256_authenticatesAndDelivers() throws Exception {
+    assertScramDelivers("SCRAM-SHA-256", TOPIC_SCRAM_256);
+  }
+
+  // ===== helpers =====
+
+  private void assertScramDelivers(String mechanism, String topic) throws Exception {
+    KafkaSinkCommand sink =
+        (KafkaSinkCommand)
+            new KafkaSinkCommandFactory().createCommand("scram-node", jobContext(PASSWORD));
+    KafkaSinkDto.Config config =
+        KafkaSinkDto.Config.builder()
+            .topic(topic)
+            .broker(KAFKA.getBootstrapServers())
+            .encodingType(EncodingType.JSON_OBJECT.toString())
+            .securityProtocol("SASL_PLAINTEXT")
+            .saslMechanism(mechanism)
+            .credentialId(CREDENTIAL_ID)
+            .build();
+    sink.parseAndValidateArg(OBJECT_MAPPER.convertValue(config, new TypeReference<>() {}));
+    sink.initialize(new MetricClientProvider.NoopMetricClientProvider());
+
+    var ctx = sink.getExecutionContext();
+    sink.writeToSink(records(1, 10), "user", ctx);
+
+    List<Integer> ids =
+        drain(topic, "scram-consumer-" + System.nanoTime(), Duration.ofSeconds(20), 10);
+    assertEquals(10, new HashSet<>(ids).size(), mechanism + "-authenticated records delivered");
+
+    sink.terminate();
+  }
+
+  private static Map<String, Object> clientSaslProps(String username, String password) {
+    Map<String, Object> props = new HashMap<>();
+    props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
+    props.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+    props.put(
+        SaslConfigs.SASL_JAAS_CONFIG,
+        "org.apache.kafka.common.security.plain.PlainLoginModule required username=\""
+            + username
+            + "\" password=\""
+            + password
+            + "\";");
+    return props;
+  }
+
+  private static List<RecordFleakData> records(int fromInclusive, int toInclusive) {
+    List<RecordFleakData> out = new ArrayList<>();
+    for (int id = fromInclusive; id <= toInclusive; id++) {
+      out.add((RecordFleakData) FleakData.wrap(Map.of("id", id)));
+    }
+    return out;
+  }
+
+  private List<Integer> drain(String topic, String group, Duration overall, int expected) {
+    Properties props = new Properties();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, group);
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+    props.put(
+        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+    props.putAll(clientSaslProps(USERNAME, PASSWORD));
+    List<Integer> ids = new ArrayList<>();
+    try (KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(props)) {
+      consumer.subscribe(Collections.singletonList(topic));
+      long deadline = System.nanoTime() + overall.toNanos();
+      while (System.nanoTime() < deadline && new HashSet<>(ids).size() < expected) {
+        ConsumerRecords<byte[], byte[]> polled = consumer.poll(Duration.ofMillis(500));
+        StreamSupport.stream(polled.spliterator(), false)
+            .map(
+                r -> fromJsonString(new String(r.value()), new TypeReference<RecordFleakData>() {}))
+            .map(rec -> ((Number) rec.unwrap().get("id")).intValue())
+            .forEach(ids::add);
+      }
+    }
+    return ids;
+  }
+
+  private static JobContext jobContext(String password) {
+    Map<String, Serializable> other = new HashMap<>();
+    other.put(
+        CREDENTIAL_ID,
+        OBJECT_MAPPER.convertValue(
+            new UsernamePasswordCredential(USERNAME, password), new TypeReference<>() {}));
+    return JobContext.builder()
+        .metricTags(Map.of(METRIC_TAG_SERVICE, "test_service", METRIC_TAG_ENV, "test_env"))
+        .otherProperties(other)
+        .build();
+  }
+}


### PR DESCRIPTION
https://linear.app/fleak/issue/FLE-2236/destination-node-add-credential-support-for-kafkamsk-sink