### PR TITLE
FLE-2241: Reclaim drained store-and-forward buffer directories

### DIFF
--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkCommand.java
@@ -26,6 +26,7 @@ import io.fleak.zephflow.lib.commands.sink.PassThroughMessagePreProcessor;
 import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
 import io.fleak.zephflow.lib.commands.sink.SinkExecutionContext;
 import io.fleak.zephflow.lib.commands.sink.SinkStoreForward;
+import io.fleak.zephflow.lib.commands.sink.StoreForwardCleaner;
 import io.fleak.zephflow.lib.commands.sink.StoreForwardPaths;
 import io.fleak.zephflow.lib.pathselect.PathExpression;
 import io.fleak.zephflow.lib.serdes.EncodingType;
@@ -182,6 +183,7 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
     }
 
     Path storePath = StoreForwardPaths.resolve(config.getLocalStorePath(), jobContext, nodeId);
+    StoreForwardCleaner.sweepOnce(config.getLocalStorePath(), jobContext, storePath);
 
     Map<String, String> metricTags =
         basicCommandMetricTags(jobContext.getMetricTags(), commandName(), nodeId);

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/ChronicleStoreForward.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/ChronicleStoreForward.java
@@ -24,6 +24,7 @@ import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
@@ -65,9 +66,9 @@ public class ChronicleStoreForward implements SinkStoreForward {
       Path storePath, long maxBytes, long retryIntervalMs, int drainChunkSize, String nodeId) {}
 
   private static final String PAYLOAD_KEY = "r";
-  private static final String ACK_FILE_NAME = "sf-ack.idx";
+  static final String ACK_FILE_NAME = "sf-ack.idx";
   private static final String ACK_CAUGHT_UP = "END";
-  private static final String LOCK_FILE_NAME = "sf.lock";
+  static final String LOCK_FILE_NAME = "sf.lock";
 
   private final long maxBytes;
   private final long retryIntervalMs;
@@ -402,6 +403,69 @@ public class ChronicleStoreForward implements SinkStoreForward {
       Files.writeString(ackFile, token, StandardCharsets.UTF_8);
     } catch (Exception e) {
       log.warn("store-and-forward [{}] could not persist ack watermark", nodeId, e);
+    }
+  }
+
+  /**
+   * Under the buffer directory's exclusive ownership lock, reports whether it is safe for {@link
+   * StoreForwardCleaner} to delete: {@code true} only when no live process owns the directory
+   * <em>and</em> it holds no records past the delivered watermark. Returns {@code false} if the
+   * lock is held by another owner, or on any doubt (unreadable ack, unopenable queue), so we never
+   * delete a directory that a live replica uses or that might still contain undelivered data.
+   */
+  static boolean isReclaimable(Path dir) {
+    try (FileChannel ch = FileChannel.open(dir.resolve(LOCK_FILE_NAME), StandardOpenOption.WRITE)) {
+      FileLock lock;
+      try {
+        lock = ch.tryLock();
+      } catch (OverlappingFileLockException e) {
+        return false; // held by a live instance in this JVM
+      }
+      if (lock == null) {
+        return false; // held by another process
+      }
+      try {
+        return !hasUndeliveredRecords(dir);
+      } finally {
+        lock.release();
+      }
+    } catch (NoSuchFileException e) {
+      return false; // directory vanished concurrently
+    } catch (IOException e) {
+      log.warn("store-and-forward cleaner: cannot lock {}; keeping", dir, e);
+      return false;
+    }
+  }
+
+  private static boolean hasUndeliveredRecords(Path dir) {
+    String token;
+    try {
+      Path ack = dir.resolve(ACK_FILE_NAME);
+      token = Files.exists(ack) ? Files.readString(ack, StandardCharsets.UTF_8).trim() : null;
+    } catch (IOException e) {
+      log.warn("store-and-forward cleaner: cannot read ack in {}; keeping", dir, e);
+      return true;
+    }
+    if (ACK_CAUGHT_UP.equals(token)) {
+      return false; // watermark confirms everything was delivered
+    }
+    try (ChronicleQueue queue = SingleChronicleQueueBuilder.single(dir.toFile()).build()) {
+      ExcerptTailer tailer = queue.createTailer();
+      ((SingleThreadedChecked) tailer).singleThreadedCheckDisabled(true);
+      if (token != null) {
+        try {
+          tailer.moveToIndex(Long.parseLong(token));
+        } catch (NumberFormatException e) {
+          log.warn("store-and-forward cleaner: malformed ack {} in {}; keeping", token, dir);
+          return true;
+        }
+      }
+      try (DocumentContext dc = tailer.readingDocument()) {
+        return dc.isPresent();
+      }
+    } catch (Exception e) {
+      log.warn("store-and-forward cleaner: cannot inspect queue in {}; keeping", dir, e);
+      return true;
     }
   }
 

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/StoreForwardCleaner.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/StoreForwardCleaner.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sink;
+
+import io.fleak.zephflow.api.JobContext;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Reclaims store-and-forward buffer directories left behind by replicas that no longer run on this
+ * worker (scaled down, rescheduled, or belonging to deleted jobs). Grid deletes each task's working
+ * directory on exit, but store-and-forward buffers deliberately live outside it to survive
+ * restarts, so nothing else ever cleans them up and they accumulate forever (FLE-2241, problem 2).
+ *
+ * <p>A directory is reclaimed only when all three hold, so we never delete data that could still be
+ * delivered:
+ *
+ * <ul>
+ *   <li><b>unowned</b> — its {@code sf.lock} can be acquired exclusively, i.e. no live process is
+ *       using it (this is the authoritative liveness check);
+ *   <li><b>stale</b> — untouched for at least {@link #DEFAULT_MIN_AGE}, so a replica that is merely
+ *       mid-restart is not swept out from under itself;
+ *   <li><b>drained</b> — under that lock, {@link ChronicleStoreForward#isReclaimable} confirms no
+ *       records remain past the delivered watermark.
+ * </ul>
+ *
+ * <p>A directory that is unowned and stale but still holds undelivered records is kept, not deleted
+ * — recovering those records is a separate concern (FLE-2241, problem 1).
+ */
+@Slf4j
+public final class StoreForwardCleaner {
+
+  static final Duration DEFAULT_MIN_AGE = Duration.ofMinutes(15);
+
+  // One sweep per base directory per process: a DAG with several store-and-forward sinks shares a
+  // single worker buffer tree, so the first sink to start sweeps it and the rest are no-ops.
+  private static final Set<Path> SWEPT = ConcurrentHashMap.newKeySet();
+
+  private StoreForwardCleaner() {}
+
+  /**
+   * Kicks off a background sweep of the store-and-forward base directory for this job, at most once
+   * per process. {@code ownDir} is the caller's own buffer directory and is always skipped.
+   */
+  public static void sweepOnce(String localStorePath, JobContext jobContext, Path ownDir) {
+    sweepOnce(StoreForwardPaths.baseDir(localStorePath, jobContext), ownDir);
+  }
+
+  static void sweepOnce(Path baseDir, Path ownDir) {
+    if (baseDir == null || !SWEPT.add(baseDir.toAbsolutePath().normalize())) {
+      return;
+    }
+    Thread t =
+        new Thread(() -> sweep(baseDir, ownDir, DEFAULT_MIN_AGE), "sink-store-forward-cleaner");
+    t.setDaemon(true);
+    t.start();
+  }
+
+  static void sweep(Path baseDir, Path ownDir, Duration minAge) {
+    Path base = baseDir.toAbsolutePath().normalize();
+    Path own = ownDir == null ? null : ownDir.toAbsolutePath().normalize();
+    if (!Files.isDirectory(base)) {
+      return;
+    }
+    List<Path> bufferDirs = new ArrayList<>();
+    try (Stream<Path> walk = Files.walk(base)) {
+      walk.filter(
+              p ->
+                  Files.isRegularFile(p)
+                      && ChronicleStoreForward.LOCK_FILE_NAME.equals(p.getFileName().toString()))
+          .map(Path::getParent)
+          .forEach(bufferDirs::add);
+    } catch (IOException e) {
+      log.warn("store-and-forward cleaner: cannot scan {}", base, e);
+      return;
+    }
+    for (Path dir : bufferDirs) {
+      try {
+        maybeReclaim(base, dir, own, minAge);
+      } catch (Exception e) {
+        log.warn("store-and-forward cleaner: error handling {}", dir, e);
+      }
+    }
+  }
+
+  private static void maybeReclaim(Path base, Path dir, Path ownDir, Duration minAge)
+      throws IOException {
+    if (dir.equals(ownDir) || !isStale(dir, minAge)) {
+      return;
+    }
+    if (ChronicleStoreForward.isReclaimable(dir)) {
+      deleteRecursively(dir);
+      pruneEmptyParents(base, dir.getParent());
+      log.info("store-and-forward cleaner: reclaimed drained buffer {}", dir);
+    } else {
+      log.info("store-and-forward cleaner: keeping in-use or undrained buffer {}", dir);
+    }
+  }
+
+  private static boolean isStale(Path dir, Duration minAge) throws IOException {
+    long cutoff = System.currentTimeMillis() - minAge.toMillis();
+    long newest = Files.getLastModifiedTime(dir).toMillis();
+    try (Stream<Path> files = Files.list(dir)) {
+      for (Path f : (Iterable<Path>) files::iterator) {
+        newest = Math.max(newest, Files.getLastModifiedTime(f).toMillis());
+      }
+    }
+    return newest <= cutoff;
+  }
+
+  private static void deleteRecursively(Path dir) throws IOException {
+    try (Stream<Path> walk = Files.walk(dir)) {
+      walk.sorted(Comparator.reverseOrder())
+          .forEach(
+              p -> {
+                try {
+                  Files.deleteIfExists(p);
+                } catch (IOException e) {
+                  log.warn("store-and-forward cleaner: could not delete {}", p, e);
+                }
+              });
+    }
+  }
+
+  /** Removes now-empty node/job directories up to (but not including) the base directory. */
+  private static void pruneEmptyParents(Path base, Path start) {
+    for (Path p = start; p != null && !p.equals(base) && p.startsWith(base); p = p.getParent()) {
+      try (Stream<Path> entries = Files.list(p)) {
+        if (entries.findAny().isPresent()) {
+          return;
+        }
+      } catch (IOException e) {
+        return;
+      }
+      try {
+        Files.deleteIfExists(p);
+      } catch (IOException e) {
+        return;
+      }
+    }
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/StoreForwardPaths.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/StoreForwardPaths.java
@@ -46,7 +46,7 @@ public final class StoreForwardPaths {
         .resolve(REPLICA_DIR_PREFIX + replicaIndex(jobContext));
   }
 
-  private static Path baseDir(String localStorePath, JobContext jobContext) {
+  static Path baseDir(String localStorePath, JobContext jobContext) {
     if (localStorePath != null && !localStorePath.isBlank()) {
       return Path.of(localStorePath);
     }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/zerobussink/ZerobusSinkCommand.java
@@ -22,6 +22,7 @@ import io.fleak.zephflow.lib.commands.sink.ChronicleStoreForward;
 import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
 import io.fleak.zephflow.lib.commands.sink.SinkExecutionContext;
 import io.fleak.zephflow.lib.commands.sink.SinkStoreForward;
+import io.fleak.zephflow.lib.commands.sink.StoreForwardCleaner;
 import io.fleak.zephflow.lib.commands.sink.StoreForwardPaths;
 import io.fleak.zephflow.lib.credentials.DatabricksCredential;
 import java.nio.file.Path;
@@ -81,6 +82,7 @@ public class ZerobusSinkCommand extends SimpleSinkCommand<Map<String, Object>> {
     }
 
     Path storePath = StoreForwardPaths.resolve(config.getLocalStorePath(), jobContext, nodeId);
+    StoreForwardCleaner.sweepOnce(config.getLocalStorePath(), jobContext, storePath);
 
     Map<String, String> metricTags =
         basicCommandMetricTags(jobContext.getMetricTags(), commandName(), nodeId);

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/StoreForwardCleanerTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/StoreForwardCleanerTest.java
@@ -1,0 +1,306 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sink;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class StoreForwardCleanerTest {
+
+  private static final ConnectionFailureClassifier IO_IS_CONNECTION =
+      t -> {
+        for (Throwable c = t; c != null && c != c.getCause(); c = c.getCause()) {
+          if (c instanceof IOException) {
+            return true;
+          }
+        }
+        return false;
+      };
+
+  private static final Duration MIN_AGE = Duration.ofMinutes(1);
+  private static final Duration OLD = Duration.ofMinutes(10);
+
+  @Test
+  void reclaimsDrainedStaleUnownedDir(@TempDir Path base) throws Exception {
+    Path dir = drainedDir(base);
+    age(dir, OLD);
+
+    StoreForwardCleaner.sweep(base, null, MIN_AGE);
+
+    assertFalse(Files.exists(dir));
+  }
+
+  @Test
+  void reclaimsNeverBufferedDir(@TempDir Path base) throws Exception {
+    Path dir = makeNeverBuffered(base.resolve("empty"));
+    age(dir, OLD);
+
+    StoreForwardCleaner.sweep(base, null, MIN_AGE);
+
+    assertFalse(Files.exists(dir));
+  }
+
+  @Test
+  void keepsDirWithUndeliveredRecords(@TempDir Path base) throws Exception {
+    Path dir = undeliveredDir(base);
+    age(dir, OLD);
+
+    StoreForwardCleaner.sweep(base, null, MIN_AGE);
+
+    assertTrue(Files.exists(dir));
+  }
+
+  @Test
+  void keepsDirStillOwnedByLiveProcess(@TempDir Path base) throws Exception {
+    Path dir = base.resolve("live");
+    ChronicleStoreForward sf = open(dir); // holds the lock, not closed
+    age(dir, OLD);
+
+    StoreForwardCleaner.sweep(base, null, MIN_AGE);
+
+    assertTrue(Files.exists(dir));
+    sf.close();
+  }
+
+  @Test
+  void keepsOwnDir(@TempDir Path base) throws Exception {
+    Path dir = drainedDir(base);
+    age(dir, OLD);
+
+    StoreForwardCleaner.sweep(base, dir, MIN_AGE);
+
+    assertTrue(Files.exists(dir));
+  }
+
+  @Test
+  void keepsFreshDirWithinGracePeriod(@TempDir Path base) throws Exception {
+    Path dir = drainedDir(base);
+    // not aged: newest mtime is now, inside the grace window
+
+    StoreForwardCleaner.sweep(base, null, MIN_AGE);
+
+    assertTrue(Files.exists(dir));
+  }
+
+  @Test
+  void prunesEmptiedNodeAndJobDirsButKeepsBase(@TempDir Path base) throws Exception {
+    Path leaf = base.resolve("job-1").resolve("node-1").resolve("replica-0");
+    ChronicleStoreForward sf = open(leaf);
+    sf.start(records -> {});
+    sf.close();
+    age(leaf, OLD);
+
+    StoreForwardCleaner.sweep(base, null, MIN_AGE);
+
+    assertFalse(Files.exists(base.resolve("job-1")));
+    assertTrue(Files.exists(base));
+  }
+
+  @Test
+  void reclaimsOnlyEligibleDirsInASingleSweep(@TempDir Path base) throws Exception {
+    Path drained = makeDrained(base.resolve("drained"));
+    Path undelivered = makeUndelivered(base.resolve("undelivered"));
+    Path live = base.resolve("live");
+    ChronicleStoreForward alive = open(live); // still owns its lock
+    age(drained, OLD);
+    age(undelivered, OLD);
+    age(live, OLD);
+
+    StoreForwardCleaner.sweep(base, null, MIN_AGE);
+
+    assertFalse(Files.exists(drained), "drained dir reclaimed");
+    assertTrue(Files.exists(undelivered), "undelivered dir kept");
+    assertTrue(Files.exists(live), "live dir kept");
+    alive.close();
+  }
+
+  @Test
+  void keepsJobDirWhenASiblingReplicaStillHasData(@TempDir Path base) throws Exception {
+    Path node = base.resolve("job-1").resolve("node-1");
+    Path replica0 = makeDrained(node.resolve("replica-0"));
+    Path replica1 = makeUndelivered(node.resolve("replica-1"));
+    age(replica0, OLD);
+    age(replica1, OLD);
+
+    StoreForwardCleaner.sweep(base, null, MIN_AGE);
+
+    assertFalse(Files.exists(replica0), "drained replica reclaimed");
+    assertTrue(Files.exists(replica1), "replica with data kept");
+    assertTrue(Files.exists(node), "node dir kept because a replica remains");
+    assertTrue(Files.exists(base.resolve("job-1")), "job dir kept because a replica remains");
+  }
+
+  @Test
+  void keepsPartiallyDrainedDir(@TempDir Path base) throws Exception {
+    Path dir = makePartiallyDrained(base.resolve("partial"));
+    age(dir, OLD);
+
+    StoreForwardCleaner.sweep(base, null, MIN_AGE);
+
+    assertTrue(Files.exists(dir));
+  }
+
+  @Test
+  void keepsDirWithUnparseableAck(@TempDir Path base) throws Exception {
+    Path dir = makeNeverBuffered(base.resolve("bad-ack"));
+    writeRawAck(dir, "not-an-index");
+    age(dir, OLD);
+
+    StoreForwardCleaner.sweep(base, null, MIN_AGE);
+
+    assertTrue(Files.exists(dir));
+  }
+
+  /**
+   * The production entry point: resolves the base dir from {@code localStorePath}/{@link
+   * JobContext} and reclaims on a background thread using the real {@link
+   * StoreForwardCleaner#DEFAULT_MIN_AGE}.
+   */
+  @Test
+  void sweepOnceResolvesBaseFromJobContextAndReclaimsAsync(@TempDir Path base) throws Exception {
+    Path dir = makeDrained(base.resolve("drained"));
+    age(dir, StoreForwardCleaner.DEFAULT_MIN_AGE.plusMinutes(5)); // exceed the real grace period
+
+    StoreForwardCleaner.sweepOnce(
+        base.toString(), JobContext.builder().build(), base.resolve("me"));
+
+    await(() -> !Files.exists(dir));
+  }
+
+  // ===== helpers =====
+
+  private static ChronicleStoreForward open(Path dir) {
+    return new ChronicleStoreForward(
+        new ChronicleStoreForward.Config(dir, 1_000_000, 50, 10, "node-1"),
+        IO_IS_CONNECTION,
+        null,
+        null,
+        null);
+  }
+
+  /** A directory whose records were all delivered (ack watermark == END), then closed. */
+  private static Path drainedDir(Path base) throws Exception {
+    return makeDrained(base.resolve("drained"));
+  }
+
+  private static Path makeDrained(Path dir) throws Exception {
+    ChronicleStoreForward sf = open(dir);
+    List<RecordFleakData> delivered = new CopyOnWriteArrayList<>();
+    sf.start(delivered::addAll);
+    sf.offer(List.of(record("a")));
+    await(() -> !sf.isBuffering());
+    sf.close();
+    return dir;
+  }
+
+  private static Path makeNeverBuffered(Path dir) throws Exception {
+    ChronicleStoreForward sf = open(dir);
+    sf.start(records -> {});
+    sf.close();
+    return dir;
+  }
+
+  /** A directory whose delivery never succeeded, so records stay on disk undelivered. */
+  private static Path undeliveredDir(Path base) throws Exception {
+    return makeUndelivered(base.resolve("undelivered"));
+  }
+
+  private static Path makeUndelivered(Path dir) throws Exception {
+    ChronicleStoreForward sf = open(dir);
+    sf.start(
+        records -> {
+          throw new IOException("down");
+        });
+    sf.offer(List.of(record("x")));
+    await(sf::isBuffering);
+    sf.close();
+    return dir;
+  }
+
+  /**
+   * A directory where the first record was delivered (advancing the ack watermark to a concrete
+   * index) but the second is stuck undelivered — exercises the numeric-watermark branch of {@link
+   * ChronicleStoreForward#hasUndeliveredRecords}.
+   */
+  private static Path makePartiallyDrained(Path dir) throws Exception {
+    List<RecordFleakData> delivered = new CopyOnWriteArrayList<>();
+    AtomicInteger attempts = new AtomicInteger();
+    // drainChunkSize 1 so each record is its own chunk/ack step.
+    ChronicleStoreForward sf =
+        new ChronicleStoreForward(
+            new ChronicleStoreForward.Config(dir, 1_000_000, 50, 1, "node-1"),
+            IO_IS_CONNECTION,
+            null,
+            null,
+            null);
+    sf.start(
+        records -> {
+          if (attempts.getAndIncrement() == 0) {
+            delivered.addAll(records); // first chunk delivered -> ack advances to a numeric index
+          } else {
+            throw new IOException("down"); // everything after stays undelivered
+          }
+        });
+    sf.offer(List.of(record("x"), record("y")));
+    await(() -> delivered.size() == 1 && attempts.get() >= 2);
+    sf.close();
+    return dir;
+  }
+
+  private static void writeRawAck(Path dir, String token) throws IOException {
+    Files.writeString(dir.resolve(ChronicleStoreForward.ACK_FILE_NAME), token);
+  }
+
+  private static RecordFleakData record(String value) {
+    return (RecordFleakData) FleakData.wrap(Map.of("v", value));
+  }
+
+  private static void age(Path dir, Duration back) throws IOException {
+    FileTime t = FileTime.fromMillis(System.currentTimeMillis() - back.toMillis());
+    Files.setLastModifiedTime(dir, t);
+    try (Stream<Path> files = Files.list(dir)) {
+      for (Path f : (Iterable<Path>) files::iterator) {
+        Files.setLastModifiedTime(f, t);
+      }
+    }
+  }
+
+  private static void await(BooleanSupplier condition) throws InterruptedException {
+    long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      TimeUnit.MILLISECONDS.sleep(20);
+    }
+    fail("condition not met within timeout");
+  }
+}


### PR DESCRIPTION
Add StoreForwardCleaner: a once-per-process background sweep that deletes stale, unowned, fully-drained sink buffer directories. Directories still holding undelivered records are kept (FLE-2272).