### PR TITLE
Fix InfluxDB v2 counters losing buffered increments

### DIFF
--- a/api/src/main/java/io/fleak/zephflow/api/metric/InfluxDBV2FleakCounter.java
+++ b/api/src/main/java/io/fleak/zephflow/api/metric/InfluxDBV2FleakCounter.java
@@ -15,11 +15,25 @@ package io.fleak.zephflow.api.metric;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class InfluxDBV2FleakCounter implements FleakCounter {
+
+  // Shared daemon flusher: without it, pending increments are only flushed from inside a
+  // later increase() call, so a bursty counter that goes quiet (e.g. a one-off batch of
+  // error counts) is never written out at all.
+  private static final ScheduledExecutorService FLUSH_SCHEDULER =
+      Executors.newSingleThreadScheduledExecutor(
+          r -> {
+            Thread t = new Thread(r, "influxdb-counter-flusher");
+            t.setDaemon(true);
+            return t;
+          });
 
   private final String name;
   private final Map<String, String> tags;
@@ -46,6 +60,16 @@ public class InfluxDBV2FleakCounter implements FleakCounter {
     this.metricSender = metricSender;
     this.flushThreshold = flushThreshold;
     this.flushIntervalMs = flushIntervalMs;
+    FLUSH_SCHEDULER.scheduleAtFixedRate(
+        this::flushQuietly, flushIntervalMs, flushIntervalMs, TimeUnit.MILLISECONDS);
+  }
+
+  private void flushQuietly() {
+    try {
+      flush();
+    } catch (Exception e) {
+      log.warn("Periodic flush failed for counter {}", name, e);
+    }
   }
 
   @Override


### PR DESCRIPTION
InfluxDBV2FleakCounter only flushed pending increments from inside a subsequent increase() call (>=1000 accumulated or >1s since last flush), with no background flusher. A bursty counter that goes quiet afterwards (the typical profile of error/fault counters) accumulated locally and was never written to InfluxDB at all; the field never appeared in the bucket.

Add a shared single-thread daemon scheduler that flushes each counter every flushIntervalMs, so buffered counts are written out even when no further increments arrive. Batching behavior is otherwise unchanged.

## Validation (real broker-outage scenario, EMQX + sparkplugb_source)

Same test run twice — 10 nodes at 30 msg/s for 300s, broker stopped for 15s at T+60 — before and after the patch (patched class loaded via classpath shadowing over the released commands-all.jar):

| counter | before | after | ground truth |
|---|---|---|---|
| sparkplug_rebirth_requested_count | field never written | 60 | connector logged the rebirth activity |
| sparkplug_seq_gap_count | field never written | 60 | consistent with per-message gap counting |
| sparkplug_death_count | field never written | 10 | simulator sent exactly 10 DEATHs |
| sparkplug_birth_count | 31 (= first burst of 30 stranded, then 30+1 flushed together) | 60 across 3 points | sink received exactly 60 BIRTHs |

Trade-off: the scheduled task holds a reference to each counter, so counters are never GC'd — acceptable since counters are process-lifetime objects created once per pipeline.