### PR TITLE
Add array-aware EVAL functions for Sigma detection

### DIFF
--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/CidrMatchFunction.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/CidrMatchFunction.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import com.google.common.base.Preconditions;
+import com.google.common.net.InetAddresses;
+import io.fleak.zephflow.api.structure.*;
+import io.fleak.zephflow.lib.antlr.EvalExpressionParser;
+import io.fleak.zephflow.lib.commands.eval.compiled.EvalContext;
+import java.net.InetAddress;
+import java.util.List;
+
+/*
+cidrMatchFunction:
+Tests whether an IP address falls inside a CIDR network range (IPv4 or IPv6).
+
+Syntax:
+cidr_match($.path.to.ip.field, "10.0.0.0/8")
+
+Parameters:
+- First argument: the IP address to test (string)
+- Second argument: the CIDR range (string, "address/prefixLength")
+
+Returns: true if the IP is within the range, false otherwise. Returns false when either
+argument is not a parseable IP / CIDR, or the IP and range are different families (v4 vs v6).
+*/
+class CidrMatchFunction implements FeelFunction {
+
+  @Override
+  public FunctionSignature getSignature() {
+    return FunctionSignature.required("cidr_match", 2, "ip address and cidr range");
+  }
+
+  @Override
+  public FleakData evaluateCompiledEager(
+      EvalContext ctx,
+      List<FleakData> evaluatedArgs,
+      EvalExpressionParser.GenericFunctionCallContext originalCtx) {
+    FleakData ipFd = evaluatedArgs.getFirst();
+    FleakData cidrFd = evaluatedArgs.get(1);
+    Preconditions.checkArgument(
+        cidrFd instanceof StringPrimitiveFleakData,
+        "cidr_match: cidr must be a string: %s",
+        cidrFd);
+
+    return new BooleanPrimitiveFleakData(matchesAny(ipFd, cidrFd.getStringValue()));
+  }
+
+  // Accepts a scalar or an array (matching any element), so multi-valued IP fields work.
+  private static boolean matchesAny(FleakData value, String cidr) {
+    if (value == null) {
+      return false;
+    }
+    if (value instanceof ArrayFleakData array) {
+      for (FleakData element : array.getArrayPayload()) {
+        if (matchesAny(element, cidr)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if (value instanceof RecordFleakData) {
+      return false;
+    }
+    Object raw = value.unwrap();
+    return raw != null && matches(String.valueOf(raw), cidr);
+  }
+
+  private static boolean matches(String ipStr, String cidr) {
+    int slash = cidr.indexOf('/');
+    if (slash < 0) {
+      return false;
+    }
+    try {
+      InetAddress ip = InetAddresses.forString(ipStr.trim());
+      InetAddress network = InetAddresses.forString(cidr.substring(0, slash).trim());
+      int prefix = Integer.parseInt(cidr.substring(slash + 1).trim());
+
+      byte[] ipBytes = ip.getAddress();
+      byte[] networkBytes = network.getAddress();
+      if (ipBytes.length != networkBytes.length) {
+        return false;
+      }
+      if (prefix < 0 || prefix > ipBytes.length * 8) {
+        return false;
+      }
+
+      int fullBytes = prefix / 8;
+      for (int i = 0; i < fullBytes; i++) {
+        if (ipBytes[i] != networkBytes[i]) {
+          return false;
+        }
+      }
+      int remainingBits = prefix % 8;
+      if (remainingBits > 0) {
+        int mask = (0xFF << (8 - remainingBits)) & 0xFF;
+        return (ipBytes[fullBytes] & mask) == (networkBytes[fullBytes] & mask);
+      }
+      return true;
+    } catch (RuntimeException e) {
+      return false;
+    }
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/DateComponentEqAnyFunction.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/DateComponentEqAnyFunction.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import com.google.common.base.Preconditions;
+import io.fleak.zephflow.api.structure.*;
+import io.fleak.zephflow.lib.antlr.EvalExpressionParser;
+import io.fleak.zephflow.lib.commands.eval.compiled.EvalContext;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.IsoFields;
+import java.util.List;
+
+/*
+dateComponentEqAnyFunction:
+True if the calendar component (minute/hour/day/week/month/year, UTC) of the value equals the given
+number. The value may be an epoch-millisecond number or an ISO-8601 string, and may be a scalar OR
+an array, in which case any element satisfying it returns true.
+
+Syntax:
+date_component_eq_any($.path.to.timestamp, "hour", 14)
+*/
+class DateComponentEqAnyFunction implements FeelFunction {
+
+  @Override
+  public FunctionSignature getSignature() {
+    return FunctionSignature.required("date_component_eq_any", 3, "timestamp, unit, number");
+  }
+
+  @Override
+  public FleakData evaluateCompiledEager(
+      EvalContext ctx,
+      List<FleakData> evaluatedArgs,
+      EvalExpressionParser.GenericFunctionCallContext originalCtx) {
+    FleakData unitFd = evaluatedArgs.get(1);
+    Preconditions.checkArgument(
+        unitFd instanceof StringPrimitiveFleakData,
+        "date_component_eq_any: unit must be a string: %s",
+        unitFd);
+    FleakData numberFd = evaluatedArgs.get(2);
+    Preconditions.checkArgument(
+        numberFd instanceof NumberPrimitiveFleakData,
+        "date_component_eq_any: number must be a number: %s",
+        numberFd);
+
+    return new BooleanPrimitiveFleakData(
+        matchesAny(
+            evaluatedArgs.getFirst(), unitFd.getStringValue(), (int) numberFd.getNumberValue()));
+  }
+
+  private static boolean matchesAny(FleakData value, String unit, int expected) {
+    if (value == null) {
+      return false;
+    }
+    if (value instanceof ArrayFleakData array) {
+      for (FleakData element : array.getArrayPayload()) {
+        if (matchesAny(element, unit, expected)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    ZonedDateTime dateTime = toUtcDateTime(value);
+    if (dateTime == null) {
+      return false;
+    }
+    Integer component = extract(dateTime, unit);
+    return component != null && component == expected;
+  }
+
+  private static ZonedDateTime toUtcDateTime(FleakData valueFd) {
+    if (valueFd instanceof NumberPrimitiveFleakData) {
+      return Instant.ofEpochMilli((long) valueFd.getNumberValue()).atZone(ZoneOffset.UTC);
+    }
+    if (valueFd instanceof StringPrimitiveFleakData) {
+      String str = valueFd.getStringValue().trim();
+      try {
+        return OffsetDateTime.parse(str, DateTimeFormatter.ISO_DATE_TIME)
+            .atZoneSameInstant(ZoneOffset.UTC);
+      } catch (RuntimeException ignored) {
+        // fall through
+      }
+      try {
+        return Instant.parse(str).atZone(ZoneOffset.UTC);
+      } catch (RuntimeException ignored) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  private static Integer extract(ZonedDateTime dateTime, String unit) {
+    return switch (unit.toLowerCase()) {
+      case "minute" -> dateTime.getMinute();
+      case "hour" -> dateTime.getHour();
+      case "day" -> dateTime.getDayOfMonth();
+      case "week" -> dateTime.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+      case "month" -> dateTime.getMonthValue();
+      case "year" -> dateTime.getYear();
+      default -> null;
+    };
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/DeepContainsFunction.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/DeepContainsFunction.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import com.google.common.base.Preconditions;
+import io.fleak.zephflow.api.structure.*;
+import io.fleak.zephflow.lib.antlr.EvalExpressionParser;
+import io.fleak.zephflow.lib.commands.eval.compiled.EvalContext;
+import java.util.List;
+
+/*
+deepContainsFunction:
+Recursively searches a value (record, array, or primitive) for a needle substring, matching
+case-insensitively against the string form of every primitive found within.
+
+Syntax:
+deep_contains($, "powershell")
+
+Parameters:
+- First argument: the haystack — any value; typically the whole event root ($)
+- Second argument: the needle (string)
+
+Returns: true if the needle appears anywhere inside the haystack, false otherwise. A null
+haystack yields false.
+*/
+class DeepContainsFunction implements FeelFunction {
+
+  @Override
+  public FunctionSignature getSignature() {
+    return FunctionSignature.required("deep_contains", 2, "haystack value and needle string");
+  }
+
+  @Override
+  public FleakData evaluateCompiledEager(
+      EvalContext ctx,
+      List<FleakData> evaluatedArgs,
+      EvalExpressionParser.GenericFunctionCallContext originalCtx) {
+    FleakData haystack = evaluatedArgs.getFirst();
+    if (haystack == null) {
+      return new BooleanPrimitiveFleakData(false);
+    }
+    FleakData needleFd = evaluatedArgs.get(1);
+    Preconditions.checkArgument(
+        needleFd instanceof StringPrimitiveFleakData,
+        "deep_contains: needle must be a string: %s",
+        needleFd);
+
+    String needle = needleFd.getStringValue().toLowerCase();
+    return new BooleanPrimitiveFleakData(search(haystack, needle));
+  }
+
+  private static boolean search(FleakData node, String needle) {
+    switch (node) {
+      case RecordFleakData record -> {
+        for (FleakData child : record.getPayload().values()) {
+          if (child != null && search(child, needle)) {
+            return true;
+          }
+        }
+        return false;
+      }
+      case ArrayFleakData array -> {
+        for (FleakData child : array.getArrayPayload()) {
+          if (child != null && search(child, needle)) {
+            return true;
+          }
+        }
+        return false;
+      }
+      default -> {
+        Object raw = node.unwrap();
+        return raw != null && String.valueOf(raw).toLowerCase().contains(needle);
+      }
+    }
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/FeelFunction.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/FeelFunction.java
@@ -56,6 +56,10 @@ public interface FeelFunction {
             .put("epoch_to_ts_str", new EpochToTsStrFunction())
             .put("str_contains", new StrContainsFunction())
             .put("regex_match", new RegexMatchFunction())
+            .put("regex_match_any", new RegexMatchAnyFunction())
+            .put("regex_search_any", new RegexSearchAnyFunction())
+            .put("num_compare_any", new NumCompareAnyFunction())
+            .put("date_component_eq_any", new DateComponentEqAnyFunction())
             .put("to_str", new ToStringFunction())
             .put("upper", new UpperFunction())
             .put("lower", new LowerFunction())
@@ -82,7 +86,9 @@ public interface FeelFunction {
             .put("ceil", new CeilFunction())
             .put("now", new NowFunction())
             .put("random_long", new RandomLongFunction())
-            .put("in", new InFunction());
+            .put("in", new InFunction())
+            .put("cidr_match", new CidrMatchFunction())
+            .put("deep_contains", new DeepContainsFunction());
 
     if (pythonExecutor != null) {
       builder.put("python", new PythonFunction(pythonExecutor));

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/NumCompareAnyFunction.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/NumCompareAnyFunction.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import com.google.common.base.Preconditions;
+import io.fleak.zephflow.api.structure.*;
+import io.fleak.zephflow.lib.antlr.EvalExpressionParser;
+import io.fleak.zephflow.lib.commands.eval.compiled.EvalContext;
+import java.util.List;
+
+/*
+numCompareAnyFunction:
+Compares a value against a number using one of lt/lte/gt/gte, coercing the value from a string when
+needed. The value may be a scalar OR an array, in which case it returns true if any element
+satisfies the comparison. Non-numeric / null values simply do not satisfy the comparison.
+
+Syntax:
+num_compare_any($.path.to.field, "lt", 1024)
+*/
+class NumCompareAnyFunction implements FeelFunction {
+
+  @Override
+  public FunctionSignature getSignature() {
+    return FunctionSignature.required(
+        "num_compare_any", 3, "value, operator (lt/lte/gt/gte), number");
+  }
+
+  @Override
+  public FleakData evaluateCompiledEager(
+      EvalContext ctx,
+      List<FleakData> evaluatedArgs,
+      EvalExpressionParser.GenericFunctionCallContext originalCtx) {
+    FleakData opFd = evaluatedArgs.get(1);
+    Preconditions.checkArgument(
+        opFd instanceof StringPrimitiveFleakData,
+        "num_compare_any: operator must be a string: %s",
+        opFd);
+    FleakData operandFd = evaluatedArgs.get(2);
+    Preconditions.checkArgument(
+        operandFd instanceof NumberPrimitiveFleakData,
+        "num_compare_any: operand must be a number: %s",
+        operandFd);
+
+    return new BooleanPrimitiveFleakData(
+        satisfiesAny(evaluatedArgs.getFirst(), opFd.getStringValue(), operandFd.getNumberValue()));
+  }
+
+  private static boolean satisfiesAny(FleakData value, String op, double operand) {
+    if (value == null) {
+      return false;
+    }
+    if (value instanceof ArrayFleakData array) {
+      for (FleakData element : array.getArrayPayload()) {
+        if (satisfiesAny(element, op, operand)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    Double number = toNumber(value);
+    if (number == null) {
+      return false;
+    }
+    return switch (op) {
+      case "lt" -> number < operand;
+      case "lte" -> number <= operand;
+      case "gt" -> number > operand;
+      case "gte" -> number >= operand;
+      default -> throw new IllegalArgumentException("num_compare_any: unknown operator: " + op);
+    };
+  }
+
+  private static Double toNumber(FleakData value) {
+    if (value instanceof NumberPrimitiveFleakData n) {
+      return n.getNumberValue();
+    }
+    if (value instanceof StringPrimitiveFleakData s) {
+      try {
+        return Double.parseDouble(s.getStringValue().trim());
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/RegexMatchAnyFunction.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/RegexMatchAnyFunction.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import com.google.common.base.Preconditions;
+import io.fleak.zephflow.api.structure.*;
+import io.fleak.zephflow.lib.antlr.EvalExpressionParser;
+import io.fleak.zephflow.lib.commands.eval.compiled.EvalContext;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+/*
+regexMatchAnyFunction:
+Full-match a regular expression against a value that may be a scalar OR an array. For an array it
+returns true if any element (by its string form) fully matches. Non-string scalars are matched by
+their string form; records and nulls never match.
+
+Syntax:
+regex_match_any($.path.to.field, "<regex_pattern>")
+*/
+class RegexMatchAnyFunction implements FeelFunction {
+  private final Map<String, Pattern> patternCache = new ConcurrentHashMap<>();
+
+  @Override
+  public FunctionSignature getSignature() {
+    return FunctionSignature.required(
+        "regex_match_any", 2, "value (scalar or array) and regex pattern");
+  }
+
+  @Override
+  public FleakData evaluateCompiledEager(
+      EvalContext ctx,
+      List<FleakData> evaluatedArgs,
+      EvalExpressionParser.GenericFunctionCallContext originalCtx) {
+    FleakData patternFd = evaluatedArgs.get(1);
+    Preconditions.checkArgument(
+        patternFd instanceof StringPrimitiveFleakData,
+        "regex_match_any: pattern must be a string: %s",
+        patternFd);
+    Pattern pattern = patternCache.computeIfAbsent(patternFd.getStringValue(), Pattern::compile);
+    return new BooleanPrimitiveFleakData(matches(evaluatedArgs.getFirst(), pattern, true));
+  }
+
+  /**
+   * Cap on character accesses per match. A pathological (catastrophic-backtracking) pattern blows
+   * past this quickly; we then treat it as "no match" rather than letting it hang the pipeline.
+   */
+  static final long MATCH_BUDGET = 5_000_000L;
+
+  /** True if {@code value} (or any element, if it is an array) matches the pattern. */
+  static boolean matches(FleakData value, Pattern pattern, boolean fullMatch) {
+    if (value == null) {
+      return false;
+    }
+    if (value instanceof ArrayFleakData array) {
+      for (FleakData element : array.getArrayPayload()) {
+        if (matches(element, pattern, fullMatch)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if (value instanceof RecordFleakData) {
+      return false;
+    }
+    Object raw = value.unwrap();
+    if (raw == null) {
+      return false;
+    }
+    BudgetedCharSequence input = new BudgetedCharSequence(String.valueOf(raw), MATCH_BUDGET);
+    try {
+      return fullMatch ? pattern.matcher(input).matches() : pattern.matcher(input).find();
+    } catch (BudgetExceededException e) {
+      return false; // over the match budget -> treat as no match, per the design
+    }
+  }
+
+  private static final class BudgetExceededException extends RuntimeException {
+    BudgetExceededException() {
+      super(null, null, false, false);
+    }
+  }
+
+  /**
+   * A CharSequence that aborts the regex engine once it has read more than {@code budget} chars.
+   */
+  private static final class BudgetedCharSequence implements CharSequence {
+    private final CharSequence delegate;
+    private long remaining;
+
+    BudgetedCharSequence(CharSequence delegate, long budget) {
+      this.delegate = delegate;
+      this.remaining = budget;
+    }
+
+    @Override
+    public char charAt(int index) {
+      if (--remaining < 0) {
+        throw new BudgetExceededException();
+      }
+      return delegate.charAt(index);
+    }
+
+    @Override
+    public int length() {
+      return delegate.length();
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+      return delegate.subSequence(start, end);
+    }
+
+    @Override
+    public String toString() {
+      return delegate.toString();
+    }
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/RegexSearchAnyFunction.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/RegexSearchAnyFunction.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import com.google.common.base.Preconditions;
+import io.fleak.zephflow.api.structure.*;
+import io.fleak.zephflow.lib.antlr.EvalExpressionParser;
+import io.fleak.zephflow.lib.commands.eval.compiled.EvalContext;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+/*
+regexSearchAnyFunction:
+Unanchored regex search against a value that may be a scalar OR an array. For an array it returns
+true if the pattern is found anywhere within any element's string form.
+
+Syntax:
+regex_search_any($.path.to.field, "<regex_pattern>")
+*/
+class RegexSearchAnyFunction implements FeelFunction {
+  private final Map<String, Pattern> patternCache = new ConcurrentHashMap<>();
+
+  @Override
+  public FunctionSignature getSignature() {
+    return FunctionSignature.required(
+        "regex_search_any", 2, "value (scalar or array) and regex pattern");
+  }
+
+  @Override
+  public FleakData evaluateCompiledEager(
+      EvalContext ctx,
+      List<FleakData> evaluatedArgs,
+      EvalExpressionParser.GenericFunctionCallContext originalCtx) {
+    FleakData patternFd = evaluatedArgs.get(1);
+    Preconditions.checkArgument(
+        patternFd instanceof StringPrimitiveFleakData,
+        "regex_search_any: pattern must be a string: %s",
+        patternFd);
+    Pattern pattern = patternCache.computeIfAbsent(patternFd.getStringValue(), Pattern::compile);
+    return new BooleanPrimitiveFleakData(
+        RegexMatchAnyFunction.matches(evaluatedArgs.getFirst(), pattern, false));
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/CidrMatchFunctionTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/CidrMatchFunctionTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import io.fleak.zephflow.api.structure.*;
+import io.fleak.zephflow.lib.utils.JsonUtils;
+import org.junit.jupiter.api.Test;
+
+class CidrMatchFunctionTest extends FeelFunctionTestBase {
+
+  private static final FleakData DUMMY = new StringPrimitiveFleakData("x");
+
+  @Test
+  public void testIpv4() {
+    testFunctionExecution(DUMMY, "cidr_match(\"10.1.2.3\", \"10.0.0.0/8\")", true);
+    testFunctionExecution(DUMMY, "cidr_match(\"11.1.2.3\", \"10.0.0.0/8\")", false);
+    testFunctionExecution(DUMMY, "cidr_match(\"192.168.1.5\", \"192.168.1.0/24\")", true);
+    testFunctionExecution(DUMMY, "cidr_match(\"192.168.2.5\", \"192.168.1.0/24\")", false);
+    testFunctionExecution(DUMMY, "cidr_match(\"10.0.0.1\", \"10.0.0.1/32\")", true);
+  }
+
+  @Test
+  public void testIpv6() {
+    testFunctionExecution(DUMMY, "cidr_match(\"2001:db8::1\", \"2001:db8::/32\")", true);
+    testFunctionExecution(DUMMY, "cidr_match(\"2001:dead::1\", \"2001:db8::/32\")", false);
+  }
+
+  @Test
+  public void testMalformedOrMixedFamily() {
+    testFunctionExecution(DUMMY, "cidr_match(\"10.1.2.3\", \"2001:db8::/32\")", false);
+    testFunctionExecution(DUMMY, "cidr_match(\"not-an-ip\", \"10.0.0.0/8\")", false);
+    testFunctionExecution(DUMMY, "cidr_match(\"10.1.2.3\", \"10.0.0.0\")", false);
+  }
+
+  @Test
+  public void testArrayMatchesAnyElement() {
+    FleakData hit = JsonUtils.loadFleakDataFromJsonString("{\"ips\":[\"8.8.8.8\",\"10.1.2.3\"]}");
+    testFunctionExecution(hit, "cidr_match($.ips, \"10.0.0.0/8\")", true);
+    FleakData miss = JsonUtils.loadFleakDataFromJsonString("{\"ips\":[\"8.8.8.8\",\"1.2.3.4\"]}");
+    testFunctionExecution(miss, "cidr_match($.ips, \"10.0.0.0/8\")", false);
+  }
+
+  @Test
+  public void testPrefixBoundaries() {
+    // /0 matches any address of the same family
+    testFunctionExecution(DUMMY, "cidr_match(\"203.0.113.9\", \"0.0.0.0/0\")", true);
+    // an out-of-range prefix is rejected (not treated as a wider mask)
+    testFunctionExecution(DUMMY, "cidr_match(\"10.1.2.3\", \"10.0.0.0/33\")", false);
+  }
+
+  @Test
+  public void testMissingOrNonStringValueIsFalse() {
+    testFunctionExecution(
+        JsonUtils.loadFleakDataFromJsonString("{\"g\":1}"),
+        "cidr_match($.ip, \"10.0.0.0/8\")",
+        false);
+    testFunctionExecution(
+        JsonUtils.loadFleakDataFromJsonString("{\"ip\":{\"n\":1}}"),
+        "cidr_match($.ip, \"10.0.0.0/8\")",
+        false);
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/DateComponentEqAnyFunctionTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/DateComponentEqAnyFunctionTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import io.fleak.zephflow.api.structure.*;
+import io.fleak.zephflow.lib.utils.JsonUtils;
+import org.junit.jupiter.api.Test;
+
+class DateComponentEqAnyFunctionTest extends FeelFunctionTestBase {
+
+  private static final FleakData DUMMY = new StringPrimitiveFleakData("x");
+  private static final String TS = "\"2023-03-15T14:30:00Z\""; // Wed 2023-03-15 14:30 UTC, week 11
+
+  private static FleakData ev(String json) {
+    return JsonUtils.loadFleakDataFromJsonString(json);
+  }
+
+  @Test
+  public void extractsEveryUnitFromIsoString() {
+    testFunctionExecution(DUMMY, "date_component_eq_any(" + TS + ", \"minute\", 30)", true);
+    testFunctionExecution(DUMMY, "date_component_eq_any(" + TS + ", \"hour\", 14)", true);
+    testFunctionExecution(DUMMY, "date_component_eq_any(" + TS + ", \"day\", 15)", true);
+    testFunctionExecution(DUMMY, "date_component_eq_any(" + TS + ", \"week\", 11)", true);
+    testFunctionExecution(DUMMY, "date_component_eq_any(" + TS + ", \"month\", 3)", true);
+    testFunctionExecution(DUMMY, "date_component_eq_any(" + TS + ", \"year\", 2023)", true);
+  }
+
+  @Test
+  public void nonMatchingComponentIsFalse() {
+    testFunctionExecution(DUMMY, "date_component_eq_any(" + TS + ", \"hour\", 9)", false);
+    testFunctionExecution(DUMMY, "date_component_eq_any(" + TS + ", \"month\", 12)", false);
+  }
+
+  @Test
+  public void unitIsCaseInsensitive() {
+    testFunctionExecution(DUMMY, "date_component_eq_any(" + TS + ", \"HOUR\", 14)", true);
+  }
+
+  @Test
+  public void extractsFromEpochMillis() {
+    // 1678890600000 == 2023-03-15T14:30:00Z
+    testFunctionExecution(DUMMY, "date_component_eq_any(1678890600000, \"hour\", 14)", true);
+    testFunctionExecution(DUMMY, "date_component_eq_any(1678890600000, \"minute\", 30)", true);
+  }
+
+  @Test
+  public void unknownUnitOrUnparseableValueOrMissingIsFalse() {
+    testFunctionExecution(DUMMY, "date_component_eq_any(" + TS + ", \"fortnight\", 1)", false);
+    testFunctionExecution(DUMMY, "date_component_eq_any(\"not-a-date\", \"hour\", 14)", false);
+    testFunctionExecution(ev("{\"g\":1}"), "date_component_eq_any($.ts, \"hour\", 14)", false);
+  }
+
+  @Test
+  public void arrayMatchesAnyElement() {
+    FleakData hit = ev("{\"ts\":[\"2023-03-15T09:00:00Z\",\"2023-03-15T14:00:00Z\"]}");
+    testFunctionExecution(hit, "date_component_eq_any($.ts, \"hour\", 14)", true);
+    FleakData miss = ev("{\"ts\":[\"2023-03-15T09:00:00Z\"]}");
+    testFunctionExecution(miss, "date_component_eq_any($.ts, \"hour\", 14)", false);
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/DeepContainsFunctionTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/DeepContainsFunctionTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import io.fleak.zephflow.api.structure.*;
+import io.fleak.zephflow.lib.utils.JsonUtils;
+import org.junit.jupiter.api.Test;
+
+class DeepContainsFunctionTest extends FeelFunctionTestBase {
+
+  private static FleakData event(String json) {
+    return JsonUtils.loadFleakDataFromJsonString(json);
+  }
+
+  @Test
+  public void testFindsNestedSubstringCaseInsensitively() {
+    FleakData event =
+        event(
+            "{ \"process\": { \"cmd_line\": \"C:\\\\Windows\\\\System32\\\\PowerShell.exe -enc\" },"
+                + " \"tags\": [\"a\", \"b\"] }");
+    testFunctionExecution(event, "deep_contains($, \"powershell\")", true);
+    testFunctionExecution(event, "deep_contains($, \"-enc\")", true);
+    testFunctionExecution(event, "deep_contains($, \"b\")", true);
+  }
+
+  @Test
+  public void testMissingNeedleReturnsFalse() {
+    FleakData event = event("{ \"a\": { \"b\": \"hello\" } }");
+    testFunctionExecution(event, "deep_contains($, \"world\")", false);
+  }
+
+  @Test
+  public void testMatchesNumericValues() {
+    FleakData event = event("{ \"port\": 4444 }");
+    testFunctionExecution(event, "deep_contains($, \"4444\")", true);
+  }
+
+  @Test
+  public void testMatchesBooleanValues() {
+    FleakData event = event("{ \"admin\": true }");
+    testFunctionExecution(event, "deep_contains($, \"true\")", true);
+  }
+
+  @Test
+  public void testNullHaystackIsFalse() {
+    FleakData event = event("{ \"a\": 1 }");
+    testFunctionExecution(event, "deep_contains($.missing, \"x\")", false);
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/NumCompareAnyFunctionTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/NumCompareAnyFunctionTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.fleak.zephflow.api.structure.*;
+import io.fleak.zephflow.lib.utils.JsonUtils;
+import org.junit.jupiter.api.Test;
+
+class NumCompareAnyFunctionTest extends FeelFunctionTestBase {
+
+  private static final FleakData DUMMY = new StringPrimitiveFleakData("x");
+
+  @Test
+  public void allFourOperators() {
+    testFunctionExecution(DUMMY, "num_compare_any(4444, \"gt\", 1024)", true);
+    testFunctionExecution(DUMMY, "num_compare_any(80, \"gt\", 1024)", false);
+    testFunctionExecution(DUMMY, "num_compare_any(1024, \"gte\", 1024)", true);
+    testFunctionExecution(DUMMY, "num_compare_any(1023, \"gte\", 1024)", false);
+    testFunctionExecution(DUMMY, "num_compare_any(80, \"lt\", 1024)", true);
+    testFunctionExecution(DUMMY, "num_compare_any(1024, \"lt\", 1024)", false);
+    testFunctionExecution(DUMMY, "num_compare_any(1024, \"lte\", 1024)", true);
+    testFunctionExecution(DUMMY, "num_compare_any(1025, \"lte\", 1024)", false);
+  }
+
+  @Test
+  public void handlesDoublesAndNegatives() {
+    testFunctionExecution(DUMMY, "num_compare_any(3.5, \"lt\", 4)", true);
+    testFunctionExecution(DUMMY, "num_compare_any(\"-5\", \"lt\", 0)", true);
+    testFunctionExecution(DUMMY, "num_compare_any(-5, \"gt\", 0)", false);
+  }
+
+  @Test
+  public void nonNumericValuesDoNotSatisfy() {
+    // missing field, a record, and a non-numeric string all yield false rather than throwing
+    testFunctionExecution(ev("{\"g\":1}"), "num_compare_any($.port, \"gt\", 10)", false);
+    testFunctionExecution(ev("{\"port\":{\"n\":1}}"), "num_compare_any($.port, \"gt\", 10)", false);
+    testFunctionExecution(DUMMY, "num_compare_any(\"abc\", \"gt\", 10)", false);
+  }
+
+  @Test
+  public void unknownOperatorThrows() {
+    assertThrows(
+        Exception.class, () -> evaluateExpression("num_compare_any(5, \"between\", 10)", DUMMY));
+  }
+
+  private static FleakData ev(String json) {
+    return JsonUtils.loadFleakDataFromJsonString(json);
+  }
+
+  @Test
+  public void stringValueIsCoerced() {
+    testFunctionExecution(DUMMY, "num_compare_any(\"5000\", \"gt\", 1024)", true);
+    testFunctionExecution(DUMMY, "num_compare_any(\"50\", \"gt\", 1024)", false);
+    testFunctionExecution(DUMMY, "num_compare_any(\"not-a-number\", \"lt\", 10)", false);
+  }
+
+  @Test
+  public void arrayMatchesAnyElement() {
+    FleakData ev = JsonUtils.loadFleakDataFromJsonString("{\"ports\":[80,443,4444]}");
+    testFunctionExecution(ev, "num_compare_any($.ports, \"gt\", 1024)", true);
+    FleakData low = JsonUtils.loadFleakDataFromJsonString("{\"ports\":[80,443]}");
+    testFunctionExecution(low, "num_compare_any($.ports, \"gt\", 1024)", false);
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/RegexMatchAnyFunctionTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/RegexMatchAnyFunctionTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.lib.utils.JsonUtils;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class RegexMatchAnyFunctionTest extends FeelFunctionTestBase {
+
+  private static FleakData ev(String json) {
+    return JsonUtils.loadFleakDataFromJsonString(json);
+  }
+
+  @Test
+  public void scalarFullMatch() {
+    testFunctionExecution(ev("{\"f\":\"cmd.exe\"}"), "regex_match_any($.f, \"cmd\\\\.exe\")", true);
+    testFunctionExecution(
+        ev("{\"f\":\"xcmd.exe\"}"), "regex_match_any($.f, \"cmd\\\\.exe\")", false);
+  }
+
+  @Test
+  public void arrayMatchesAnyElement() {
+    testFunctionExecution(
+        ev("{\"f\":[\"a\",\"cmd.exe\"]}"), "regex_match_any($.f, \"cmd\\\\.exe\")", true);
+    testFunctionExecution(
+        ev("{\"f\":[\"a\",\"b\"]}"), "regex_match_any($.f, \"cmd\\\\.exe\")", false);
+  }
+
+  @Test
+  public void missingFieldAndNumbers() {
+    testFunctionExecution(ev("{\"g\":1}"), "regex_match_any($.f, \".*\")", false);
+    testFunctionExecution(ev("{\"f\":4444}"), "regex_match_any($.f, \"4444\")", true);
+  }
+
+  @Test
+  public void recordValueIsNeverMatched() {
+    // a nested object is not string-matched, even by ".*"
+    testFunctionExecution(ev("{\"f\":{\"n\":1}}"), "regex_match_any($.f, \".*\")", false);
+  }
+
+  @Test
+  public void catastrophicRegexIsBudgetedNotHung() {
+    // (a+)+$ on many a's + trailing X is exponential backtracking; the match budget must abort it
+    // quickly and return false instead of hanging.
+    String evil = "{\"f\":\"" + "a".repeat(40) + "X\"}";
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(5),
+        () -> testFunctionExecution(ev(evil), "regex_match_any($.f, \"(a+)+$\")", false));
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/RegexSearchAnyFunctionTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/RegexSearchAnyFunctionTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.lib.utils.JsonUtils;
+import org.junit.jupiter.api.Test;
+
+class RegexSearchAnyFunctionTest extends FeelFunctionTestBase {
+
+  private static FleakData ev(String json) {
+    return JsonUtils.loadFleakDataFromJsonString(json);
+  }
+
+  @Test
+  public void findsUnanchoredUnlikeFullMatch() {
+    // regex_match_any is a full match and would be false here; regex_search_any (find) is true
+    testFunctionExecution(
+        ev("{\"f\":\"prefix net view suffix\"}"), "regex_match_any($.f, \"net view\")", false);
+    testFunctionExecution(
+        ev("{\"f\":\"prefix net view suffix\"}"), "regex_search_any($.f, \"net view\")", true);
+  }
+
+  @Test
+  public void searchesAnyArrayElement() {
+    testFunctionExecution(
+        ev("{\"f\":[\"x\",\"has net view here\"]}"), "regex_search_any($.f, \"net view\")", true);
+    testFunctionExecution(
+        ev("{\"f\":[\"x\",\"y\"]}"), "regex_search_any($.f, \"net view\")", false);
+  }
+
+  @Test
+  public void missingFieldIsFalse() {
+    testFunctionExecution(ev("{\"g\":1}"), "regex_search_any($.f, \".*\")", false);
+  }
+
+  @Test
+  public void coercesNonStringScalar() {
+    testFunctionExecution(ev("{\"f\":4444}"), "regex_search_any($.f, \"44\")", true);
+  }
+
+  @Test
+  public void recordValueIsNeverMatched() {
+    testFunctionExecution(ev("{\"f\":{\"n\":1}}"), "regex_search_any($.f, \".*\")", false);
+  }
+}


### PR DESCRIPTION
New FeelFunctions: cidr_match, deep_contains, num_compare_any, date_component_eq_any, regex_match_any, regex_search_any. Each matches a scalar or any array element; regex_*_any carry a per-match char budget that aborts catastrophic backtracking.