### PR TITLE
Fix sinks that report wrong or no output_event_size

### DIFF
--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/databrickssink/BatchDatabricksFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/databrickssink/BatchDatabricksFlusher.java
@@ -513,7 +513,7 @@ public class BatchDatabricksFlusher extends AbstractBufferedFlusher<Map<String, 
 
     if (snapshot != null) {
       log.info("Flushing {} remaining records during close", snapshot.size());
-      SimpleSinkCommand.FlushResult result = executeFlush(snapshot, Map.of());
+      SimpleSinkCommand.FlushResult result = executeFlushOutOfBand(snapshot, Map.of());
       if (!result.errorOutputList().isEmpty()) {
         reportErrorMetrics(result.errorOutputList().size(), Map.of());
         handleScheduledFlushErrors(result.errorOutputList());

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/deltalakesink/DeltaLakeWriter.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/deltalakesink/DeltaLakeWriter.java
@@ -530,7 +530,7 @@ public class DeltaLakeWriter extends AbstractBufferedFlusher<Map<String, Object>
           "Flushing {} remaining buffered events before closing writer for path: {}",
           snapshot.size(),
           config.getTablePath());
-      SimpleSinkCommand.FlushResult result = executeFlush(snapshot, Map.of());
+      SimpleSinkCommand.FlushResult result = executeFlushOutOfBand(snapshot, Map.of());
       if (!result.errorOutputList().isEmpty()) {
         reportErrorMetrics(result.errorOutputList().size(), Map.of());
         if (dlqWriter == null) {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/elasticsearchsink/ElasticsearchSinkFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/elasticsearchsink/ElasticsearchSinkFlusher.java
@@ -76,10 +76,16 @@ public class ElasticsearchSinkFlusher
     var metaNode = OBJECT_MAPPER.createObjectNode();
     metaNode.putObject("index").put("_index", index);
     String actionMeta = OBJECT_MAPPER.writeValueAsString(metaNode);
+    int actionMetaBytes = actionMeta.getBytes(StandardCharsets.UTF_8).length;
+    // Per-doc NDJSON byte sizes, so a partial failure can report only what actually got indexed.
+    long[] docBytes = new long[docs.size()];
     StringBuilder ndjson = new StringBuilder();
-    for (ElasticsearchOutboundDoc doc : docs) {
+    for (int i = 0; i < docs.size(); i++) {
+      String jsonPayload = docs.get(i).jsonPayload();
       ndjson.append(actionMeta).append("\n");
-      ndjson.append(doc.jsonPayload()).append("\n");
+      ndjson.append(jsonPayload).append("\n");
+      // action-meta line + its newline + payload line + its newline
+      docBytes[i] = actionMetaBytes + 1L + jsonPayload.getBytes(StandardCharsets.UTF_8).length + 1L;
     }
 
     byte[] bodyBytes = ndjson.toString().getBytes(StandardCharsets.UTF_8);
@@ -127,6 +133,7 @@ public class ElasticsearchSinkFlusher
 
     List<ErrorOutput> errors = new ArrayList<>();
     int successCount = 0;
+    long flushedDataSize = 0;
     JsonNode items = bulkResponse.path("items");
     var rawAndPrepared = preparedInputEvents.rawAndPreparedList();
     for (int i = 0; i < items.size(); i++) {
@@ -135,6 +142,9 @@ public class ElasticsearchSinkFlusher
       int status = indexResult.path("status").asInt(200);
       if (status >= 200 && status < 300) {
         successCount++;
+        if (i < docBytes.length) {
+          flushedDataSize += docBytes[i];
+        }
       } else {
         String errorReason = indexResult.path("error").path("reason").asText("unknown error");
         if (i < rawAndPrepared.size()) {
@@ -144,7 +154,7 @@ public class ElasticsearchSinkFlusher
     }
 
     log.debug("Elasticsearch bulk: {} succeeded, {} failed", successCount, errors.size());
-    return new SimpleSinkCommand.FlushResult(successCount, bodyBytes.length, errors);
+    return new SimpleSinkCommand.FlushResult(successCount, flushedDataSize, errors);
   }
 
   @Override

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/jdbcsink/JdbcSinkFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/jdbcsink/JdbcSinkFlusher.java
@@ -15,6 +15,7 @@ package io.fleak.zephflow.lib.commands.jdbcsink;
 
 import io.fleak.zephflow.lib.commands.jdbcsource.JdbcDriverLoader;
 import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
+import io.fleak.zephflow.lib.commands.sink.SinkDataSizeEstimator;
 import java.io.IOException;
 import java.sql.*;
 import java.util.*;
@@ -68,11 +69,13 @@ public class JdbcSinkFlusher implements SimpleSinkCommand.Flusher<Map<String, Ob
       List<String> columns = new ArrayList<>(data.getFirst().keySet());
       String sql = buildSql(columns);
 
+      long flushedDataSize = 0;
       try (PreparedStatement stmt = connection.prepareStatement(sql)) {
         for (Map<String, Object> row : data) {
           for (int i = 0; i < columns.size(); i++) {
             Object value = row.get(columns.get(i));
             stmt.setObject(i + 1, value);
+            flushedDataSize += SinkDataSizeEstimator.estimateValueBytes(value);
           }
           stmt.addBatch();
         }
@@ -80,8 +83,8 @@ public class JdbcSinkFlusher implements SimpleSinkCommand.Flusher<Map<String, Ob
       }
 
       connection.commit();
-      log.debug("Flushed {} rows to JDBC sink", data.size());
-      return new SimpleSinkCommand.FlushResult(data.size(), 0, List.of());
+      log.debug("Flushed {} rows ({} bytes) to JDBC sink", data.size(), flushedDataSize);
+      return new SimpleSinkCommand.FlushResult(data.size(), flushedDataSize, List.of());
     } catch (Exception e) {
       try {
         connection.rollback();

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3/BatchS3Flusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3/BatchS3Flusher.java
@@ -16,6 +16,7 @@ package io.fleak.zephflow.lib.commands.s3;
 import static io.fleak.zephflow.lib.utils.MiscUtils.threadSleep;
 
 import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.api.metric.FleakCounter;
 import io.fleak.zephflow.api.structure.RecordFleakData;
 import io.fleak.zephflow.lib.aws.AwsClientFactory;
 import io.fleak.zephflow.lib.commands.sink.AbstractBufferedFlusher;
@@ -29,6 +30,7 @@ import java.nio.file.Path;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
@@ -52,6 +54,8 @@ public class BatchS3Flusher extends AbstractBufferedFlusher<RecordFleakData> {
   private final BlobFileWriter<RecordFleakData> fileWriter;
   private final int batchSize;
   private final long flushIntervalMs;
+  private final FleakCounter sinkOutputCounter;
+  private final FleakCounter outputSizeCounter;
   private Path tempDirectory;
 
   public BatchS3Flusher(
@@ -63,7 +67,9 @@ public class BatchS3Flusher extends AbstractBufferedFlusher<RecordFleakData> {
       long flushIntervalMs,
       DlqWriter dlqWriter,
       JobContext jobContext,
-      String nodeId) {
+      String nodeId,
+      FleakCounter sinkOutputCounter,
+      FleakCounter outputSizeCounter) {
     super(dlqWriter, jobContext, nodeId);
     this.s3TransferResources = s3TransferResources;
     this.bucketName = bucketName;
@@ -71,6 +77,20 @@ public class BatchS3Flusher extends AbstractBufferedFlusher<RecordFleakData> {
     this.fileWriter = fileWriter;
     this.batchSize = batchSize;
     this.flushIntervalMs = flushIntervalMs;
+    this.sinkOutputCounter = sinkOutputCounter;
+    this.outputSizeCounter = outputSizeCounter;
+  }
+
+  /**
+   * Only reached for timer-driven and close-time flushes (see {@link
+   * AbstractBufferedFlusher#executeFlushOutOfBand}). Batch-size-triggered flushes return their
+   * result to {@code SimpleSinkCommand}, which counts them.
+   */
+  @Override
+  protected void reportMetrics(
+      SimpleSinkCommand.FlushResult result, Map<String, String> metricTags) {
+    sinkOutputCounter.increase(result.successCount(), metricTags);
+    outputSizeCounter.increase(result.flushedDataSize(), metricTags);
   }
 
   @Override
@@ -193,7 +213,7 @@ public class BatchS3Flusher extends AbstractBufferedFlusher<RecordFleakData> {
     List<Pair<RecordFleakData, RecordFleakData>> remaining = swapBufferIfNotEmpty();
     if (!remaining.isEmpty()) {
       log.info("Flushing {} remaining records on close", remaining.size());
-      executeFlush(remaining, java.util.Map.of());
+      executeFlushOutOfBand(remaining, Map.of());
     }
     s3TransferResources.close();
     if (dlqWriter != null) {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/s3/S3SinkCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/s3/S3SinkCommand.java
@@ -60,7 +60,8 @@ public class S3SinkCommand extends SimpleSinkCommand<RecordFleakData> {
         createSinkCounters(metricClientProvider, jobContext, commandName(), nodeId);
 
     S3SinkDto.Config config = (S3SinkDto.Config) commandConfig;
-    SimpleSinkCommand.Flusher<RecordFleakData> flusher = createS3Flusher(config, jobContext);
+    SimpleSinkCommand.Flusher<RecordFleakData> flusher =
+        createS3Flusher(config, jobContext, counters);
     SimpleSinkCommand.SinkMessagePreProcessor<RecordFleakData> messagePreProcessor =
         new PassThroughMessagePreProcessor();
 
@@ -75,7 +76,7 @@ public class S3SinkCommand extends SimpleSinkCommand<RecordFleakData> {
   }
 
   private SimpleSinkCommand.Flusher<RecordFleakData> createS3Flusher(
-      S3SinkDto.Config config, JobContext jobContext) {
+      S3SinkDto.Config config, JobContext jobContext, SinkCounters counters) {
     Optional<UsernamePasswordCredential> usernamePasswordCredentialOpt =
         lookupUsernamePasswordCredentialOpt(jobContext, config.getCredentialId());
 
@@ -104,7 +105,9 @@ public class S3SinkCommand extends SimpleSinkCommand<RecordFleakData> {
               config.getFlushIntervalMillis(),
               dlqWriter,
               jobContext,
-              nodeId);
+              nodeId,
+              counters.sinkOutputCounter(),
+              counters.outputSizeCounter());
       flusher.initialize();
       return flusher;
     } else {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/AbstractBufferedFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/AbstractBufferedFlusher.java
@@ -169,7 +169,7 @@ public abstract class AbstractBufferedFlusher<T> implements SimpleSinkCommand.Fl
 
   private void executeScheduledFlushInternal(List<Pair<RecordFleakData, T>> batch) {
     try {
-      SimpleSinkCommand.FlushResult result = executeFlush(batch, Map.of());
+      SimpleSinkCommand.FlushResult result = executeFlushOutOfBand(batch, Map.of());
       if (!result.errorOutputList().isEmpty()) {
         reportErrorMetrics(result.errorOutputList().size(), Map.of());
         handleScheduledFlushErrors(result.errorOutputList());
@@ -252,7 +252,10 @@ public abstract class AbstractBufferedFlusher<T> implements SimpleSinkCommand.Fl
   }
 
   /**
-   * Executes a flush with proper lock handling and metrics reporting.
+   * Executes a flush with proper lock handling, for flushes triggered from {@link #flush}. Does
+   * <b>not</b> call {@link #reportMetrics}: the returned {@link SimpleSinkCommand.FlushResult}
+   * travels back to {@link SimpleSinkCommand#writeToSink}, which already counts it. Reporting here
+   * too would double-count both {@code sink_output_count} and {@code output_event_size}.
    *
    * @param batch The batch to flush
    * @param metricTags Tags for metrics
@@ -268,12 +271,28 @@ public abstract class AbstractBufferedFlusher<T> implements SimpleSinkCommand.Fl
 
     beforeWrite();
     try {
-      SimpleSinkCommand.FlushResult result = doFlushWithRecovery(batch);
-      reportMetrics(result, metricTags);
-      return result;
+      return doFlushWithRecovery(batch);
     } finally {
       afterWrite();
     }
+  }
+
+  /**
+   * Executes a flush whose result never reaches {@link SimpleSinkCommand} — timer-driven and
+   * close-time flushes. Because nothing downstream will count the result, this is the only place
+   * those flushes can be reported, so it calls {@link #reportMetrics}. Subclasses that buffer must
+   * use this (not {@link #executeFlush}) from their own close path, or the final partial batch is
+   * written but never counted.
+   *
+   * @param batch The batch to flush
+   * @param metricTags Tags for metrics
+   * @return The flush result
+   */
+  protected final SimpleSinkCommand.FlushResult executeFlushOutOfBand(
+      List<Pair<RecordFleakData, T>> batch, Map<String, String> metricTags) {
+    SimpleSinkCommand.FlushResult result = executeFlush(batch, metricTags);
+    reportMetrics(result, metricTags);
+    return result;
   }
 
   /**

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SinkDataSizeEstimator.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SinkDataSizeEstimator.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sink;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Estimates the number of bytes a sink wrote, for sinks whose transport does not report a wire
+ * size.
+ *
+ * <p>JDBC drivers send batches over a driver-specific protocol and expose no byte count, so {@code
+ * output_event_size} for the JDBC-family sinks is necessarily an estimate. It measures the bound
+ * <em>values</em> only: column names travel once in the prepared SQL, not per row, so counting them
+ * per row would inflate the metric in proportion to batch size.
+ */
+public final class SinkDataSizeEstimator {
+
+  private SinkDataSizeEstimator() {}
+
+  /** Estimated bytes of the values bound for one row. */
+  public static long estimateRowBytes(Map<String, Object> row) {
+    if (row == null) {
+      return 0;
+    }
+    long size = 0;
+    for (Object value : row.values()) {
+      size += estimateValueBytes(value);
+    }
+    return size;
+  }
+
+  /**
+   * Estimated bytes of a single bound value. Numeric and boolean types use their binary widths;
+   * anything without a known width falls back to the UTF-8 length of its string form.
+   */
+  public static long estimateValueBytes(Object value) {
+    return switch (value) {
+      case null -> 0L;
+      case String s -> s.getBytes(StandardCharsets.UTF_8).length;
+      case byte[] b -> b.length;
+      case Boolean ignored -> 1L;
+      case Byte ignored -> 1L;
+      case Short ignored -> 2L;
+      case Integer ignored -> 4L;
+      case Float ignored -> 4L;
+      case Long ignored -> 8L;
+      case Double ignored -> 8L;
+      default -> String.valueOf(value).getBytes(StandardCharsets.UTF_8).length;
+    };
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkFlusher.java
@@ -21,6 +21,7 @@ import jakarta.mail.Session;
 import jakarta.mail.Transport;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -70,7 +71,7 @@ public class SmtpSinkFlusher implements SimpleSinkCommand.Flusher<PreparedEmail>
         MimeMessage message = createMimeMessage(email);
         Transport.send(message, username, password);
         sentCount++;
-        totalSize += email.body() != null ? email.body().length() : 0;
+        totalSize += messageSizeBytes(email);
       } catch (Exception e) {
         log.error("Failed to send email to {}", email.to(), e);
         errorOutputs.add(new ErrorOutput(rawEvent, e.getMessage()));
@@ -79,6 +80,19 @@ public class SmtpSinkFlusher implements SimpleSinkCommand.Flusher<PreparedEmail>
 
     log.debug("SMTP flush completed: {} sent, {} errors", sentCount, errorOutputs.size());
     return new SimpleSinkCommand.FlushResult(sentCount, totalSize, errorOutputs);
+  }
+
+  /**
+   * Bytes of the message content we generated: subject plus body, measured as UTF-8 rather than as
+   * Java chars so non-ASCII mail is not under-reported. Excludes MIME headers and transfer
+   * encoding, which the mail library adds.
+   */
+  static long messageSizeBytes(PreparedEmail email) {
+    return utf8Length(email.subject()) + utf8Length(email.body());
+  }
+
+  private static long utf8Length(String s) {
+    return s == null ? 0L : s.getBytes(StandardCharsets.UTF_8).length;
   }
 
   MimeMessage createMimeMessage(PreparedEmail email) throws Exception {

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/elasticsearchsink/ElasticsearchSinkFlusherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/elasticsearchsink/ElasticsearchSinkFlusherTest.java
@@ -15,8 +15,17 @@ package io.fleak.zephflow.lib.commands.elasticsearchsink;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.sun.net.httpserver.HttpServer;
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.commands.sink.SimpleSinkCommand;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 class ElasticsearchSinkFlusherTest {
@@ -49,5 +58,90 @@ class ElasticsearchSinkFlusherTest {
     assertTrue(result.contains("foo=bar"), "Should contain foo=bar");
     assertTrue(result.contains("baz=qux"), "Should contain baz=qux");
     assertTrue(result.contains("&"), "Should contain '&' separator");
+  }
+
+  private static final String DOC_A = "{\"a\":1}";
+  private static final String DOC_B = "{\"b\":2}";
+
+  /** Serves one canned _bulk response and records the request body it received. */
+  private record FakeEs(HttpServer server, AtomicReference<byte[]> lastBody)
+      implements AutoCloseable {
+    static FakeEs serving(String bulkResponseJson) throws IOException {
+      HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+      AtomicReference<byte[]> lastBody = new AtomicReference<>();
+      server.createContext(
+          "/_bulk",
+          exchange -> {
+            lastBody.set(exchange.getRequestBody().readAllBytes());
+            byte[] out = bulkResponseJson.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, out.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+              os.write(out);
+            }
+          });
+      server.start();
+      return new FakeEs(server, lastBody);
+    }
+
+    String host() {
+      return "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @Override
+    public void close() {
+      server.stop(0);
+    }
+  }
+
+  private static SimpleSinkCommand.PreparedInputEvents<ElasticsearchOutboundDoc> twoDocs() {
+    RecordFleakData raw = (RecordFleakData) FleakData.wrap(Map.of("k", "v"));
+    SimpleSinkCommand.PreparedInputEvents<ElasticsearchOutboundDoc> events =
+        new SimpleSinkCommand.PreparedInputEvents<>();
+    events.add(raw, new ElasticsearchOutboundDoc(DOC_A));
+    events.add(raw, new ElasticsearchOutboundDoc(DOC_B));
+    return events;
+  }
+
+  @Test
+  void flushAllIndexed_reportsFullBodySize() throws Exception {
+    try (FakeEs es = FakeEs.serving("{\"errors\":false,\"items\":[]}")) {
+      ElasticsearchSinkFlusher flusher =
+          new ElasticsearchSinkFlusher(es.host(), "idx", null, null, Map.of());
+
+      SimpleSinkCommand.FlushResult result = flusher.flush(twoDocs(), Map.of());
+
+      assertEquals(2, result.successCount());
+      assertEquals(es.lastBody().get().length, result.flushedDataSize());
+    }
+  }
+
+  /**
+   * On a partial failure the flusher used to report the entire request body, crediting bytes for
+   * documents Elasticsearch rejected. It must report only the NDJSON of the indexed ones.
+   */
+  @Test
+  void flushPartialFailure_reportsOnlyIndexedDocBytes() throws Exception {
+    String bulkResponse =
+        "{\"errors\":true,\"items\":["
+            + "{\"index\":{\"status\":201}},"
+            + "{\"index\":{\"status\":400,\"error\":{\"reason\":\"mapper_parsing_exception\"}}}"
+            + "]}";
+    try (FakeEs es = FakeEs.serving(bulkResponse)) {
+      ElasticsearchSinkFlusher flusher =
+          new ElasticsearchSinkFlusher(es.host(), "idx", null, null, Map.of());
+
+      SimpleSinkCommand.FlushResult result = flusher.flush(twoDocs(), Map.of());
+
+      assertEquals(1, result.successCount());
+      assertEquals(1, result.errorOutputList().size());
+
+      int fullBody = es.lastBody().get().length;
+      // action-meta line + newline + the one accepted doc + newline.
+      int actionMeta = "{\"index\":{\"_index\":\"idx\"}}".getBytes(StandardCharsets.UTF_8).length;
+      long expected = actionMeta + 1 + DOC_A.getBytes(StandardCharsets.UTF_8).length + 1;
+      assertEquals(expected, result.flushedDataSize());
+      assertTrue(
+          result.flushedDataSize() < fullBody, "must not credit bytes for the rejected document");
+    }
   }
 }

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/jdbcsink/JdbcSinkFlusherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/jdbcsink/JdbcSinkFlusherTest.java
@@ -239,6 +239,47 @@ class JdbcSinkFlusherTest {
     flusher.close();
   }
 
+  /**
+   * jdbcsink (and timescaledbsink, which reuses this flusher) used to hard-code a 0 data size, so
+   * {@code output_event_size} was always 0 for both.
+   */
+  @Test
+  void flushReportsEstimatedRowBytes() throws Exception {
+    JdbcSinkFlusher flusher =
+        new JdbcSinkFlusher(
+            JDBC_URL, null, null, "test_sink", null, JdbcSinkDto.WriteMode.INSERT, List.of());
+
+    SimpleSinkCommand.PreparedInputEvents<Map<String, Object>> events =
+        new SimpleSinkCommand.PreparedInputEvents<>();
+    RecordFleakData record = (RecordFleakData) FleakData.wrap(Map.of("id", 1));
+    events.add(record, buildRow(1.0, "alpha", 10.5));
+    events.add(record, buildRow(2.0, "beta", 20.0));
+
+    SimpleSinkCommand.FlushResult result = flusher.flush(events, Map.of());
+
+    assertEquals(2, result.successCount());
+    // Two rows of (Double id = 8, String name, Double amount = 8).
+    long expected = (8 + 5 + 8) + (8 + 4 + 8);
+    assertEquals(expected, result.flushedDataSize());
+  }
+
+  @Test
+  void flushOfNonAsciiValueCountsUtf8Bytes() throws Exception {
+    JdbcSinkFlusher flusher =
+        new JdbcSinkFlusher(
+            JDBC_URL, null, null, "test_sink", null, JdbcSinkDto.WriteMode.INSERT, List.of());
+
+    SimpleSinkCommand.PreparedInputEvents<Map<String, Object>> events =
+        new SimpleSinkCommand.PreparedInputEvents<>();
+    RecordFleakData record = (RecordFleakData) FleakData.wrap(Map.of("id", 1));
+    // "日本" is 2 chars but 6 UTF-8 bytes.
+    events.add(record, buildRow(1.0, "日本", 10.5));
+
+    SimpleSinkCommand.FlushResult result = flusher.flush(events, Map.of());
+
+    assertEquals(8 + 6 + 8, result.flushedDataSize());
+  }
+
   private static Map<String, Object> buildRow(double id, String name, double amount) {
     LinkedHashMap<String, Object> row = new LinkedHashMap<>();
     row.put("id", id);

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/s3/BatchS3FlusherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/s3/BatchS3FlusherTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import io.fleak.zephflow.api.metric.FleakCounter;
 import io.fleak.zephflow.api.structure.FleakData;
 import io.fleak.zephflow.api.structure.RecordFleakData;
 import io.fleak.zephflow.lib.aws.AwsClientFactory;
@@ -49,6 +50,8 @@ class BatchS3FlusherTest {
   private S3Client testS3Client;
   private BatchS3Flusher flusher;
   private AwsClientFactory awsClientFactory;
+  private FleakCounter sinkOutputCounter;
+  private FleakCounter outputSizeCounter;
 
   @Container
   protected static MinIOContainer minioContainer =
@@ -57,6 +60,8 @@ class BatchS3FlusherTest {
   @BeforeEach
   void setUp() {
     awsClientFactory = new AwsClientFactory();
+    sinkOutputCounter = mock(FleakCounter.class);
+    outputSizeCounter = mock(FleakCounter.class);
     testS3Client = createS3Client();
     testS3Client.createBucket(b -> b.bucket(BUCKET_NAME));
   }
@@ -111,7 +116,9 @@ class BatchS3FlusherTest {
         flushIntervalMs,
         null,
         null,
-        null);
+        null,
+        sinkOutputCounter,
+        outputSizeCounter);
   }
 
   @Test
@@ -159,6 +166,61 @@ class BatchS3FlusherTest {
 
     List<String> objectKeys = listS3Objects();
     assertEquals(1, objectKeys.size());
+  }
+
+  /**
+   * A timer-driven flush never returns its FlushResult to SimpleSinkCommand, so reportMetrics is
+   * the only thing that can count it. Before reportMetrics was implemented here, these flushes
+   * uploaded to S3 and reported nothing.
+   */
+  @Test
+  void timerFlushReportsOutputSizeAndCount() throws Exception {
+    flusher = createFlusher(100, 60000);
+    flusher.initialize();
+
+    for (int i = 0; i < 3; i++) {
+      Map<String, Object> data = new HashMap<>();
+      data.put("id", i);
+      data.put("name", "test" + i);
+      RecordFleakData record = (RecordFleakData) FleakData.wrap(data);
+      SimpleSinkCommand.PreparedInputEvents<RecordFleakData> events =
+          new SimpleSinkCommand.PreparedInputEvents<>();
+      events.add(record, record);
+      flusher.flush(events, Map.of());
+    }
+
+    // Buffer is below the batch size, so nothing has been reported yet.
+    verify(outputSizeCounter, never()).increase(anyLong(), anyMap());
+
+    flusher.executeScheduledFlush();
+
+    verify(sinkOutputCounter).increase(eq(3L), anyMap());
+    verify(outputSizeCounter).increase(longThat(size -> size > 0), anyMap());
+  }
+
+  /**
+   * A batch-size-triggered flush returns its FlushResult to SimpleSinkCommand, which counts it. The
+   * flusher must not also report it, or every inline flush is counted twice.
+   */
+  @Test
+  void inlineFlushDoesNotDoubleReport() throws Exception {
+    flusher = createFlusher(1, 60000);
+    flusher.initialize();
+
+    Map<String, Object> data = Map.of("id", 1, "name", "test");
+    RecordFleakData record = (RecordFleakData) FleakData.wrap(data);
+    SimpleSinkCommand.PreparedInputEvents<RecordFleakData> events =
+        new SimpleSinkCommand.PreparedInputEvents<>();
+    events.add(record, record);
+
+    SimpleSinkCommand.FlushResult result = flusher.flush(events, Map.of());
+
+    // The size comes back on the result for SimpleSinkCommand to count...
+    assertEquals(1, result.successCount());
+    assertTrue(result.flushedDataSize() > 0);
+    // ...and must not be reported a second time by the flusher itself.
+    verify(outputSizeCounter, never()).increase(anyLong(), anyMap());
+    verify(sinkOutputCounter, never()).increase(anyLong(), anyMap());
   }
 
   @Test
@@ -227,7 +289,17 @@ class BatchS3FlusherTest {
 
     flusher =
         new BatchS3Flusher(
-            s3TransferResources, BUCKET_NAME, KEY_NAME, parquetWriter, 5, 60000, null, null, null);
+            s3TransferResources,
+            BUCKET_NAME,
+            KEY_NAME,
+            parquetWriter,
+            5,
+            60000,
+            null,
+            null,
+            null,
+            sinkOutputCounter,
+            outputSizeCounter);
     flusher.initialize();
 
     for (int i = 0; i < 5; i++) {
@@ -289,7 +361,9 @@ class BatchS3FlusherTest {
             60000,
             mockDlqWriter,
             null,
-            "s3-test-node");
+            "s3-test-node",
+            sinkOutputCounter,
+            outputSizeCounter);
     dlqFlusher.initialize();
 
     Map<String, Object> data = Map.of("id", 1, "name", "test");

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/AbstractBufferedFlusherMetricsTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/AbstractBufferedFlusherMetricsTest.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sink;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins which flush paths call {@link AbstractBufferedFlusher#reportMetrics}. There are two ways a
+ * buffered flush gets counted and they are mutually exclusive:
+ *
+ * <ul>
+ *   <li>Batch-size-triggered ("inline"): the {@code FlushResult} is returned to {@link
+ *       SimpleSinkCommand}, which counts it. {@code reportMetrics} must NOT fire, or the sink
+ *       double-counts {@code output_event_size} and {@code sink_output_count}.
+ *   <li>Timer-driven and close-time ("out of band"): the result goes nowhere, so {@code
+ *       reportMetrics} is the only thing that can count it and it MUST fire.
+ * </ul>
+ */
+class AbstractBufferedFlusherMetricsTest {
+
+  private static final long BYTES_PER_RECORD = 11L;
+
+  /** Records every reportMetrics call so we can assert on how many happened, and from where. */
+  private static class RecordingFlusher extends AbstractBufferedFlusher<RecordFleakData> {
+    final List<SimpleSinkCommand.FlushResult> reported = new ArrayList<>();
+    private final int batchSize;
+
+    RecordingFlusher(int batchSize) {
+      super(null, null, "test-node");
+      this.batchSize = batchSize;
+    }
+
+    @Override
+    protected int getBatchSize() {
+      return batchSize;
+    }
+
+    /**
+     * Long enough that the timer never fires on its own; tests drive it via executeScheduledFlush.
+     */
+    @Override
+    protected long getFlushIntervalMs() {
+      return 600_000;
+    }
+
+    @Override
+    protected SimpleSinkCommand.FlushResult doFlush(
+        List<Pair<RecordFleakData, RecordFleakData>> batch) {
+      return new SimpleSinkCommand.FlushResult(
+          batch.size(), batch.size() * BYTES_PER_RECORD, List.of());
+    }
+
+    @Override
+    protected void ensureCanWriteRecord(RecordFleakData record) {}
+
+    @Override
+    protected void reportMetrics(
+        SimpleSinkCommand.FlushResult result, Map<String, String> metricTags) {
+      reported.add(result);
+    }
+
+    @Override
+    public void close() {
+      stopFlushTimer();
+    }
+  }
+
+  private static SimpleSinkCommand.PreparedInputEvents<RecordFleakData> oneEvent() {
+    RecordFleakData record = (RecordFleakData) FleakData.wrap(Map.of("id", 1));
+    SimpleSinkCommand.PreparedInputEvents<RecordFleakData> events =
+        new SimpleSinkCommand.PreparedInputEvents<>();
+    events.add(record, record);
+    return events;
+  }
+
+  @Test
+  void inlineFlush_returnsSizeAndDoesNotReport() throws Exception {
+    try (RecordingFlusher flusher = new RecordingFlusher(1)) {
+      flusher.initialize();
+
+      SimpleSinkCommand.FlushResult result = flusher.flush(oneEvent(), Map.of());
+
+      // The caller (SimpleSinkCommand) gets the size and counts it...
+      assertEquals(1, result.successCount());
+      assertEquals(BYTES_PER_RECORD, result.flushedDataSize());
+      // ...so reporting here too would double-count.
+      assertTrue(
+          flusher.reported.isEmpty(),
+          "inline flush must not call reportMetrics; SimpleSinkCommand already counts the result");
+    }
+  }
+
+  @Test
+  void bufferedBelowBatchSize_reportsNothingAndReturnsZero() throws Exception {
+    try (RecordingFlusher flusher = new RecordingFlusher(10)) {
+      flusher.initialize();
+
+      SimpleSinkCommand.FlushResult result = flusher.flush(oneEvent(), Map.of());
+
+      assertEquals(0, result.successCount());
+      assertEquals(0, result.flushedDataSize());
+      assertTrue(flusher.reported.isEmpty());
+    }
+  }
+
+  @Test
+  void timerFlush_reportsExactlyOnce() throws Exception {
+    try (RecordingFlusher flusher = new RecordingFlusher(10)) {
+      flusher.initialize();
+      flusher.flush(oneEvent(), Map.of());
+      flusher.flush(oneEvent(), Map.of());
+      assertTrue(flusher.reported.isEmpty(), "still buffered, nothing flushed yet");
+
+      flusher.executeScheduledFlush();
+
+      assertEquals(1, flusher.reported.size(), "timer flush must be reported exactly once");
+      assertEquals(2, flusher.reported.getFirst().successCount());
+      assertEquals(2 * BYTES_PER_RECORD, flusher.reported.getFirst().flushedDataSize());
+    }
+  }
+
+  /**
+   * A batch that flushes inline and a later batch that flushes on the timer must produce exactly
+   * one count each — this is the combination that used to double-count the inline half.
+   */
+  @Test
+  void mixedInlineAndTimerFlushes_eachCountedOnce() throws Exception {
+    try (RecordingFlusher flusher = new RecordingFlusher(2)) {
+      flusher.initialize();
+
+      // Two events reach batchSize=2 -> inline flush, counted by SimpleSinkCommand via the result.
+      flusher.flush(oneEvent(), Map.of());
+      SimpleSinkCommand.FlushResult inline = flusher.flush(oneEvent(), Map.of());
+      assertEquals(2 * BYTES_PER_RECORD, inline.flushedDataSize());
+      assertTrue(flusher.reported.isEmpty());
+
+      // A third event stays buffered until the timer fires.
+      flusher.flush(oneEvent(), Map.of());
+      flusher.executeScheduledFlush();
+
+      assertEquals(1, flusher.reported.size());
+      assertEquals(BYTES_PER_RECORD, flusher.reported.getFirst().flushedDataSize());
+    }
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/SinkDataSizeEstimatorTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/SinkDataSizeEstimatorTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.sink;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SinkDataSizeEstimatorTest {
+
+  @Test
+  void nullIsZero() {
+    assertEquals(0, SinkDataSizeEstimator.estimateValueBytes(null));
+  }
+
+  @Test
+  void stringUsesUtf8Length() {
+    assertEquals(5, SinkDataSizeEstimator.estimateValueBytes("hello"));
+    // 2 chars, 6 UTF-8 bytes.
+    assertEquals(6, SinkDataSizeEstimator.estimateValueBytes("日本"));
+  }
+
+  @Test
+  void fixedWidthTypesUseBinaryWidths() {
+    assertEquals(1, SinkDataSizeEstimator.estimateValueBytes(true));
+    assertEquals(1, SinkDataSizeEstimator.estimateValueBytes((byte) 7));
+    assertEquals(2, SinkDataSizeEstimator.estimateValueBytes((short) 7));
+    assertEquals(4, SinkDataSizeEstimator.estimateValueBytes(7));
+    assertEquals(4, SinkDataSizeEstimator.estimateValueBytes(7.0f));
+    assertEquals(8, SinkDataSizeEstimator.estimateValueBytes(7L));
+    assertEquals(8, SinkDataSizeEstimator.estimateValueBytes(7.0d));
+  }
+
+  @Test
+  void byteArrayUsesItsLength() {
+    assertEquals(3, SinkDataSizeEstimator.estimateValueBytes(new byte[] {1, 2, 3}));
+  }
+
+  @Test
+  void unknownTypeFallsBackToStringForm() {
+    // No binary width known, so measure "12.50".
+    assertEquals(5, SinkDataSizeEstimator.estimateValueBytes(new BigDecimal("12.50")));
+  }
+
+  @Test
+  void rowSumsValuesAndIgnoresColumnNames() {
+    Map<String, Object> row = new LinkedHashMap<>();
+    row.put("a_very_long_column_name", "ab"); // name must not be counted
+    row.put("n", 1L);
+    row.put("missing", null);
+
+    assertEquals(2 + 8, SinkDataSizeEstimator.estimateRowBytes(row));
+  }
+
+  @Test
+  void nullRowIsZero() {
+    assertEquals(0, SinkDataSizeEstimator.estimateRowBytes(null));
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkFlusherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/smtpsink/SmtpSinkFlusherTest.java
@@ -110,6 +110,29 @@ class SmtpSinkFlusherTest {
     assertNull(message.getRecipients(Message.RecipientType.CC));
   }
 
+  /**
+   * The size used to be {@code body().length()} — a Java char count, which under-reports non-ASCII
+   * mail and ignored the subject entirely.
+   */
+  @Test
+  void messageSizeCountsUtf8BytesOfSubjectAndBody() {
+    // "Grüße" is 5 chars / 7 UTF-8 bytes; "日本語" is 3 chars / 9 UTF-8 bytes.
+    PreparedEmail email =
+        new PreparedEmail(
+            "from@test.com", List.of("to@test.com"), List.of(), "Grüße", "日本語", "text/plain");
+
+    assertEquals(7 + 9, SmtpSinkFlusher.messageSizeBytes(email));
+  }
+
+  @Test
+  void messageSizeToleratesNullSubjectAndBody() {
+    PreparedEmail email =
+        new PreparedEmail(
+            "from@test.com", List.of("to@test.com"), List.of(), null, null, "text/plain");
+
+    assertEquals(0, SmtpSinkFlusher.messageSizeBytes(email));
+  }
+
   @Test
   void testFlushEmptyEvents() throws Exception {
     SimpleSinkCommand.PreparedInputEvents<PreparedEmail> emptyEvents =

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/timescaledbsink/TimescaleDbSinkCommandIntegrationTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/timescaledbsink/TimescaleDbSinkCommandIntegrationTest.java
@@ -14,10 +14,14 @@
 package io.fleak.zephflow.lib.commands.timescaledbsink;
 
 import static io.fleak.zephflow.lib.utils.JsonUtils.OBJECT_MAPPER;
+import static io.fleak.zephflow.lib.utils.MiscUtils.METRIC_NAME_OUTPUT_EVENT_SIZE_COUNT;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.fleak.zephflow.api.JobContext;
+import io.fleak.zephflow.api.metric.FleakCounter;
 import io.fleak.zephflow.api.metric.MetricClientProvider;
 import io.fleak.zephflow.api.structure.FleakData;
 import io.fleak.zephflow.api.structure.RecordFleakData;
@@ -94,13 +98,24 @@ class TimescaleDbSinkCommandIntegrationTest {
             .build();
 
     command.parseAndValidateArg(OBJECT_MAPPER.convertValue(config, new TypeReference<>() {}));
-    command.initialize(new MetricClientProvider.NoopMetricClientProvider());
+
+    // timescaledbsink reuses JdbcSinkFlusher, which used to report a hard-coded 0 data size, so
+    // output_event_size was always 0 for this node. Capture the counter to prove it now reports.
+    FleakCounter outputSizeCounter = mock(FleakCounter.class);
+    MetricClientProvider metricClientProvider = mock(MetricClientProvider.class);
+    when(metricClientProvider.counter(anyString(), anyMap()))
+        .thenReturn(new MetricClientProvider.NoopMetricClientProvider.NoopFleakCounter());
+    when(metricClientProvider.counter(eq(METRIC_NAME_OUTPUT_EVENT_SIZE_COUNT), anyMap()))
+        .thenReturn(outputSizeCounter);
+
+    command.initialize(metricClientProvider);
     var result = command.writeToSink(events, "user", command.getExecutionContext());
 
     assertEquals(2, result.getSuccessCount());
     assertEquals(0, result.getFailureEvents().size());
     assertTrue(isHypertable("metrics"));
     assertEquals(2, rowCount());
+    verify(outputSizeCounter).increase(longThat(size -> size > 0), anyMap());
   }
 
   @SneakyThrows


### PR DESCRIPTION
## Context

Audited **all 24 sink nodes** (21 in zephflow-core, 3 in zephflow-plus) for output data size reporting.

The good news: `output_event_size` is already fully plumbed and **no sink is missing metric wiring**. Counters are created centrally in `SimpleSinkCommand.createSinkCounters()` and emitted in one place, `SimpleSinkCommand.writeOneBatch():157`, from `FlushResult.flushedDataSize`. The contract is that each `Flusher.flush()` returns a correct size — and that's where several sinks broke it.

This PR covers the zephflow-core half. The zephflow-plus sinks (`snowflakejdbcsink`, `pineconesink`) have the same class of bug and will follow once a core version containing `SinkDataSizeEstimator` is published.

## Reported 0 bytes

| Node | Cause |
|---|---|
| `jdbcsink` | `JdbcSinkFlusher.java:84` hard-coded `0` |
| `timescaledbsink` | reuses `JdbcSinkFlusher`, inherited the `0` |

New `SinkDataSizeEstimator` sums the bound values. JDBC drivers expose no wire byte count, so this is an explicitly documented estimate, measuring **values only** — column names travel once in the prepared SQL, not per row, so counting them per row would inflate the metric in proportion to batch size.

## Mis-reported

- **`databrickssink`** and **`deltalakesink`** were **double-counting**. `AbstractBufferedFlusher` called `reportMetrics` from `executeFlush`, which is also the inline (batch-size-triggered) path whose `FlushResult` is *then* counted again by `SimpleSinkCommand`. `executeFlush` no longer reports; the new `executeFlushOutOfBand` does, and is used only by the timer and close paths whose results never reach `SimpleSinkCommand`.
- **`s3sink` in batching mode** computed `totalSize` correctly but never overrode `reportMetrics`, so timer- and close-driven flushes uploaded to S3 and reported **nothing** — neither bytes nor `sink_output_count`. `BatchS3Flusher` now takes the two counters and reports out-of-band flushes.

`kafkasink` was already the correct reference pattern here: it passes `NoopFleakCounter` into the context and reports from the producer callback.

## Accuracy fixes

- **`smtpsink`** measured `body().length()` — a Java *char* count, which under-reports non-ASCII mail and ignored the subject entirely. Now UTF-8 bytes of subject + body.
- **`elasticsearchsink`** credited the whole request body on partial failure, including documents ES rejected. Now sums only the NDJSON of the accepted documents.

## Verified correct, unchanged (16)

`s3sink` non-batching, `kinesissink`, `kafkasink`, `stdout`, `clickhousesink`, `zerobussink`, `sqssink`, `azuremonitorsink`, `splunkhecsink`, `gcssink`, `azureblobsink`, `pubsubsink`, `azureeventhubsink`, `influxdbsink` — plus `elasticsearchsink`'s happy path and `xsiamsink` in plus.

## Testing

`./gradlew build` green. Each new test was checked to **fail without its fix**, not just pass with it:

- Reverting the `AbstractBufferedFlusher` change → 3 of 4 `AbstractBufferedFlusherMetricsTest` cases fail (the 4th correctly still passes, as nothing flushes below batch size).
- Reverting the JDBC size to `0` → `flushReportsEstimatedRowBytes`, `flushOfNonAsciiValueCountsUtf8Bytes`, and the TimescaleDB integration assertion all fail.

New/updated tests:
- `SinkDataSizeEstimatorTest` — per-type widths, UTF-8 handling, column names excluded.
- `AbstractBufferedFlusherMetricsTest` — pins which flush paths report, covering all three buffered sinks at the source.
- `BatchS3FlusherTest` — timer flush reports size and count; inline flush does not double-report.
- `ElasticsearchSinkFlusherTest` — partial-failure and all-indexed cases against a JDK `HttpServer` fake ES endpoint.
- `SmtpSinkFlusherTest` — UTF-8 subject/body, null tolerance.
- `TimescaleDbSinkCommandIntegrationTest` — used `NoopMetricClientProvider`, so swapped in a mock to actually observe `output_event_size`.

## Reviewer notes

- ⚠️ **`BatchS3Flusher`'s public constructor gains two `FleakCounter` parameters.** All callers in both repos are updated; flagging as it is a public class.
- Sizes remain intentionally heterogeneous across sinks (wire bytes vs. full HTTP body vs. compressed file bytes vs. server-reported bytes vs. estimate). Making these units uniform would be a behaviour change to existing dashboards and is out of scope.
- There is still no `pipeline_output_size_bytes` at the DAG level (`runner/Constants.java` has input and total only), so there's no pipeline-wide egress figure to cross-check sink counters against. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)