### PR TITLE
Add coalesce and concat EVAL functions

### DIFF
--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/CoalesceFunction.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/CoalesceFunction.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import io.fleak.zephflow.api.structure.*;
+import io.fleak.zephflow.lib.antlr.EvalExpressionParser;
+import io.fleak.zephflow.lib.commands.eval.compiled.EvalContext;
+import java.util.*;
+
+/*
+coalesceFunction:
+Return the first argument whose value is non-null, or null if every argument is null. The chosen
+argument keeps its original type (string, number, ...). Useful when the same logical value may live
+under one of several paths, e.g.:
+```
+coalesce($.process.file.path, $.actor.process.file.path)
+```
+*/
+class CoalesceFunction implements FeelFunction {
+  @Override
+  public FunctionSignature getSignature() {
+    return FunctionSignature.variable(
+        "coalesce", 1, "one or more values; returns the first non-null");
+  }
+
+  @Override
+  public FleakData evaluateCompiledEager(
+      EvalContext ctx,
+      List<FleakData> evaluatedArgs,
+      EvalExpressionParser.GenericFunctionCallContext originalCtx) {
+    for (FleakData arg : evaluatedArgs) {
+      if (arg != null) {
+        return arg;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/ConcatFunction.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/ConcatFunction.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import io.fleak.zephflow.api.structure.*;
+import io.fleak.zephflow.lib.antlr.EvalExpressionParser;
+import io.fleak.zephflow.lib.commands.eval.compiled.EvalContext;
+import java.util.*;
+
+/*
+concatFunction:
+Join all arguments into a single string. Each argument is converted to string the same way as
+to_str, and a null argument is treated as an empty string (never throws, unlike the `+` operator).
+If every argument is null, returns null. Useful for rebuilding a value split across fields, e.g.:
+```
+concat($.file.parent_folder, "\\", $.file.name)
+```
+*/
+class ConcatFunction implements FeelFunction {
+  @Override
+  public FunctionSignature getSignature() {
+    return FunctionSignature.variable("concat", 1, "one or more values joined into a string");
+  }
+
+  @Override
+  public FleakData evaluateCompiledEager(
+      EvalContext ctx,
+      List<FleakData> evaluatedArgs,
+      EvalExpressionParser.GenericFunctionCallContext originalCtx) {
+    StringBuilder sb = new StringBuilder();
+    boolean anyNonNull = false;
+    for (FleakData arg : evaluatedArgs) {
+      if (arg == null) {
+        continue;
+      }
+      anyNonNull = true;
+      sb.append(Objects.toString(arg.unwrap()));
+    }
+    return anyNonNull ? FleakData.wrap(sb.toString()) : null;
+  }
+}

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/FeelFunction.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/eval/FeelFunction.java
@@ -88,7 +88,9 @@ public interface FeelFunction {
             .put("random_long", new RandomLongFunction())
             .put("in", new InFunction())
             .put("cidr_match", new CidrMatchFunction())
-            .put("deep_contains", new DeepContainsFunction());
+            .put("deep_contains", new DeepContainsFunction())
+            .put("coalesce", new CoalesceFunction())
+            .put("concat", new ConcatFunction());
 
     if (pythonExecutor != null) {
       builder.put("python", new PythonFunction(pythonExecutor));

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/CoalesceFunctionTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/CoalesceFunctionTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.StringPrimitiveFleakData;
+import io.fleak.zephflow.lib.utils.JsonUtils;
+import org.junit.jupiter.api.Test;
+
+class CoalesceFunctionTest extends FeelFunctionTestBase {
+
+  private static final FleakData DUMMY = new StringPrimitiveFleakData("x");
+
+  private static FleakData ev(String json) {
+    return JsonUtils.loadFleakDataFromJsonString(json);
+  }
+
+  @Test
+  public void returnsFirstNonNull() {
+    testFunctionExecution(ev("{\"a\":\"first\",\"b\":\"second\"}"), "coalesce($.a, $.b)", "first");
+  }
+
+  @Test
+  public void skipsMissingToLaterArg() {
+    testFunctionExecution(ev("{\"b\":\"second\"}"), "coalesce($.a, $.b)", "second");
+  }
+
+  @Test
+  public void allNullYieldsNull() {
+    testFunctionExecution(ev("{\"g\":1}"), "coalesce($.a, $.b)", null);
+  }
+
+  @Test
+  public void explicitNullLiteralIsSkipped() {
+    testFunctionExecution(DUMMY, "coalesce(null, \"fallback\")", "fallback");
+  }
+
+  @Test
+  public void preservesNonStringType() {
+    // the chosen argument keeps its type; it is not stringified
+    testFunctionExecution(ev("{\"flag\":true}"), "coalesce($.missing, $.flag)", true);
+    testFunctionExecution(ev("{\"n\":42}"), "coalesce($.missing, $.n)", 42L);
+  }
+
+  @Test
+  public void nonNullButFalsyValuesAreReturnedNotSkipped() {
+    // "first non-null", not "first truthy": empty string / 0 / false are values and must be
+    // returned
+    testFunctionExecution(ev("{\"a\":\"\",\"b\":\"fallback\"}"), "coalesce($.a, $.b)", "");
+    testFunctionExecution(ev("{\"a\":0,\"b\":\"fallback\"}"), "coalesce($.a, $.b)", 0L);
+    testFunctionExecution(ev("{\"a\":false,\"b\":\"fallback\"}"), "coalesce($.a, $.b)", false);
+  }
+
+  @Test
+  public void explicitJsonNullValueIsSkipped() {
+    // a present-but-null field is skipped just like an absent one
+    testFunctionExecution(ev("{\"a\":null,\"b\":\"present\"}"), "coalesce($.a, $.b)", "present");
+  }
+
+  @Test
+  public void skipsMultipleNullsToFirstPresent() {
+    testFunctionExecution(ev("{\"c\":\"third\"}"), "coalesce($.a, $.b, $.c)", "third");
+  }
+
+  @Test
+  public void singleArgumentReturnsItself() {
+    testFunctionExecution(ev("{\"a\":\"only\"}"), "coalesce($.a)", "only");
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/ConcatFunctionTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/eval/ConcatFunctionTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.eval;
+
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.StringPrimitiveFleakData;
+import io.fleak.zephflow.lib.utils.JsonUtils;
+import org.junit.jupiter.api.Test;
+
+class ConcatFunctionTest extends FeelFunctionTestBase {
+
+  private static final FleakData DUMMY = new StringPrimitiveFleakData("x");
+
+  private static FleakData ev(String json) {
+    return JsonUtils.loadFleakDataFromJsonString(json);
+  }
+
+  @Test
+  public void joinsStringParts() {
+    // rebuild a full path from a directory and a name, separated by a backslash
+    testFunctionExecution(
+        ev("{\"dir\":\"C:\\\\Win\",\"name\":\"cmd.exe\"}"),
+        "concat($.dir, \"\\\\\", $.name)",
+        "C:\\Win\\cmd.exe");
+  }
+
+  @Test
+  public void nullArgumentIsTreatedAsEmpty() {
+    // dir is missing -> treated as "" instead of throwing like the + operator would
+    testFunctionExecution(
+        ev("{\"name\":\"cmd.exe\"}"), "concat($.dir, \"\\\\\", $.name)", "\\cmd.exe");
+  }
+
+  @Test
+  public void coercesNonStringArgument() {
+    testFunctionExecution(DUMMY, "concat(\"port-\", 4444)", "port-4444");
+  }
+
+  @Test
+  public void integerFieldConcatenatesWithoutDecimalPoint() {
+    // a whole-number field must join as "4444", not "4444.0"
+    testFunctionExecution(ev("{\"n\":4444}"), "concat(\"port-\", $.n)", "port-4444");
+  }
+
+  @Test
+  public void allNullYieldsNull() {
+    testFunctionExecution(ev("{\"g\":1}"), "concat($.a, $.b)", null);
+  }
+
+  @Test
+  public void presentEmptyStringsYieldEmptyNotNull() {
+    // present-but-empty is different from all-null: result is "" (non-null)
+    testFunctionExecution(ev("{\"a\":\"\",\"b\":\"\"}"), "concat($.a, $.b)", "");
+  }
+
+  @Test
+  public void explicitJsonNullValueIsTreatedAsEmpty() {
+    testFunctionExecution(ev("{\"a\":null,\"b\":\"x\"}"), "concat($.a, $.b)", "x");
+  }
+
+  @Test
+  public void singleArgumentIsStringified() {
+    testFunctionExecution(ev("{\"a\":\"x\"}"), "concat($.a)", "x");
+  }
+}


### PR DESCRIPTION
coalesce(a, b, ...) returns the first non-null argument. concat(a, b, ...) joins arguments into a string, coercing each like to_str and treating null as empty (unlike +, which throws on null/mixed types).