### PR TITLE
Isolate per-node failures in DAG runner

### DIFF
--- a/api/src/main/java/io/fleak/zephflow/api/ScalarCommand.java
+++ b/api/src/main/java/io/fleak/zephflow/api/ScalarCommand.java
@@ -35,6 +35,12 @@ public abstract class ScalarCommand extends OperatorCommand {
   /**
    * Process events with explicit execution context.
    *
+   * <p><b>Contract:</b> must NOT mutate the input {@code events} (or the records they contain) in
+   * place. Return new records or pass inputs through unchanged. The DAG runner shares the same
+   * event objects across fan-out branches without copying, so an in-place mutation would corrupt
+   * what sibling branches see. This applies to overrides of both this method and {@link
+   * #processOneEvent}.
+   *
    * @param events The events to process
    * @param callingUser The calling user ID
    * @param context The execution context (must be initialized via initialize())
@@ -58,6 +64,11 @@ public abstract class ScalarCommand extends OperatorCommand {
 
   /**
    * Process a single event. Subclasses should implement this method.
+   *
+   * <p><b>Contract:</b> must NOT mutate the input {@code event} in place. Either return a new
+   * {@link RecordFleakData} or pass the input through unchanged. The DAG runner shares the same
+   * event objects across fan-out branches without copying, so an in-place mutation here would
+   * corrupt what sibling branches see.
    *
    * @param event The event to process
    * @param callingUser The calling user ID

--- a/api/src/main/java/io/fleak/zephflow/api/ScalarSinkCommand.java
+++ b/api/src/main/java/io/fleak/zephflow/api/ScalarSinkCommand.java
@@ -34,6 +34,10 @@ public abstract class ScalarSinkCommand extends OperatorCommand {
   /**
    * Write events to sink with explicit execution context.
    *
+   * <p><b>Contract:</b> must NOT mutate the input {@code events} (or the records they contain) in
+   * place. The DAG runner shares the same event objects across fan-out branches without copying, so
+   * an in-place mutation here would corrupt what sibling branches see.
+   *
    * @param events The events to write
    * @param callingUser The calling user ID
    * @param context The execution context (must be initialized via initialize())

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SimpleSinkCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/SimpleSinkCommand.java
@@ -139,11 +139,6 @@ public abstract class SimpleSinkCommand<T> extends ScalarSinkCommand {
         return bufferFailedBatch(
             batch, preparedInputEvents, errorOutputs, callingUserTag, sinkContext);
       }
-      if (e instanceof UnknownSinkCommitStateException unknownState) {
-        // Records may already be committed; we cannot honestly report them as failed (in the
-        // non-DLQ path failed records are silently dropped). Let it propagate as a fatal job error.
-        throw unknownState;
-      }
       log.debug("failed to write to sink", e);
       // if error is thrown, it's a complete failure
       List<ErrorOutput> error =

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/UnknownSinkCommitStateException.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/UnknownSinkCommitStateException.java
@@ -17,12 +17,12 @@ package io.fleak.zephflow.lib.commands.sink;
  * Thrown by a {@link SimpleSinkCommand.Flusher} when records have already been handed to the target
  * system but the durability confirmation failed, leaving the commit state unknown.
  *
- * <p>This must NOT be treated as a normal per-record failure. {@link SimpleSinkCommand} converts an
- * ordinary thrown exception into one {@code ErrorOutput} per record (see {@code writeOneBatch}); in
- * the runner's non-DLQ path those are merely counted and then discarded, which would silently lose
- * records that may in fact have been written. Reporting a clean "complete failure" when the truth
- * is "we don't know" is worse than failing the node. So {@code writeOneBatch} rethrows this
- * exception instead, letting it propagate as a fatal node/job error.
+ * <p>It is handled like any other flush failure by {@link SimpleSinkCommand}: with
+ * store-and-forward enrolled the batch is buffered to local storage (the classifier walks the cause
+ * chain and treats the underlying network signal as transient), giving at-least-once via replay;
+ * otherwise it is converted to per-record {@code ErrorOutput}s that go to the DLQ (at-least-once)
+ * or are dropped in the plain non-DLQ path (at-most-once). It no longer fails the whole job — that
+ * would couple unrelated sink branches, breaking per-node fault isolation.
  */
 public class UnknownSinkCommitStateException extends RuntimeException {
   public UnknownSinkCommitStateException(String message, Throwable cause) {

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/SimpleSinkCommandTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/sink/SimpleSinkCommandTest.java
@@ -196,9 +196,106 @@ class SimpleSinkCommandTest {
     verify(sinkErrorCounter, never()).increase(any());
   }
 
+  @Test
+  public void testWriteToSink_unknownCommitStateBecomesPerRecordErrorsWithoutStoreForward()
+      throws Exception {
+    FakeUnknownStateSinkCommand sinkCommand =
+        (FakeUnknownStateSinkCommand)
+            new FakeUnknownStateSinkCommandFactory().createCommand(currentNodeId, jobContext);
+    sinkCommand.parseAndValidateArg(null);
+    sinkCommand.initialize(metricClientProvider);
+    var context = sinkCommand.getExecutionContext();
+
+    List<RecordFleakData> input = List.of(event(0), event(3));
+    // Must NOT throw: with no store-and-forward, an unknown-commit-state failure is downgraded to
+    // per-record errors so it stays a node-local failure instead of aborting the whole job.
+    ScalarSinkCommand.SinkResult result = sinkCommand.writeToSink(input, callingUser, context);
+
+    ScalarSinkCommand.SinkResult expected =
+        new ScalarSinkCommand.SinkResult(
+            2,
+            0,
+            List.of(
+                new ErrorOutput(event(0), "commit state unknown"),
+                new ErrorOutput(event(3), "commit state unknown")));
+    assertEquals(expected, result);
+  }
+
   private static RecordFleakData event(int val) {
     return new RecordFleakData(
         Map.of("val", new NumberPrimitiveFleakData(val, NumberPrimitiveFleakData.NumberType.LONG)));
+  }
+
+  private static class FakeUnknownStateSinkCommandFactory extends CommandFactory {
+
+    @Override
+    public OperatorCommand createCommand(String nodeId, JobContext jobContext) {
+      return new FakeUnknownStateSinkCommand(
+          nodeId,
+          jobContext,
+          (ConfigParser) configStr -> new CommandConfig() {},
+          (ConfigValidator) (commandConfig, nodeId1, jobContext1) -> {});
+    }
+
+    @Override
+    public CommandType commandType() {
+      return CommandType.SINK;
+    }
+  }
+
+  private static class FakeUnknownStateSinkCommand extends SimpleSinkCommand<Integer> {
+
+    protected FakeUnknownStateSinkCommand(
+        String nodeId,
+        JobContext jobContext,
+        ConfigParser configParser,
+        ConfigValidator configValidator) {
+      super(nodeId, jobContext, configParser, configValidator);
+    }
+
+    @Override
+    protected int batchSize() {
+      return 100;
+    }
+
+    @Override
+    public String commandName() {
+      return "fake_unknown_state_sink";
+    }
+
+    @Override
+    protected SinkExecutionContext<Integer> createExecutionContext(
+        MetricClientProvider metricClientProvider,
+        JobContext jobContext,
+        CommandConfig commandConfig,
+        String nodeId) {
+      SimpleSinkCommand.SinkMessagePreProcessor<Integer> preprocessor =
+          (event, ts) -> (int) event.getPayload().get("val").getNumberValue();
+
+      SimpleSinkCommand.Flusher<Integer> flusher =
+          new SimpleSinkCommand.Flusher<>() {
+            @Override
+            public SimpleSinkCommand.FlushResult flush(
+                SimpleSinkCommand.PreparedInputEvents<Integer> preparedInputEvents,
+                Map<String, String> metricTags) {
+              throw new UnknownSinkCommitStateException(
+                  "commit state unknown", new RuntimeException("io"));
+            }
+
+            @Override
+            public void close() {}
+          };
+
+      return new SinkExecutionContext<>(
+          flusher,
+          preprocessor,
+          metricClientProvider.counter(METRIC_NAME_INPUT_EVENT_COUNT, jobContext.getMetricTags()),
+          metricClientProvider.counter(METRIC_NAME_ERROR_EVENT_COUNT, jobContext.getMetricTags()),
+          metricClientProvider.counter(METRIC_NAME_SINK_OUTPUT_COUNT, jobContext.getMetricTags()),
+          metricClientProvider.counter(
+              METRIC_NAME_OUTPUT_EVENT_SIZE_COUNT, jobContext.getMetricTags()),
+          metricClientProvider.counter(METRIC_NAME_SINK_ERROR_COUNT, jobContext.getMetricTags()));
+    }
   }
 
   private static class FakeBufferingSinkCommandFactory extends CommandFactory {

--- a/runner/src/main/java/io/fleak/zephflow/runner/DagResult.java
+++ b/runner/src/main/java/io/fleak/zephflow/runner/DagResult.java
@@ -38,6 +38,10 @@ public class DagResult {
 
   @JsonIgnore Map<String, ScalarSinkCommand.SinkResult> sinkResultMap = new HashMap<>();
 
+  // First node failure seen during the run, tracked independently of the debug-only errorByStep so
+  // the DLQ path can reliably fire regardless of runConfig. Null when the run had no failures.
+  @JsonIgnore NodeFailure firstFailure;
+
   void consolidateSinkResult() {
     sinkResultMap.forEach(
         (s, sinkResult) -> {
@@ -54,12 +58,9 @@ public class DagResult {
       NoSourceDagRunner.DagRunConfig runConfig,
       List<RecordFleakData> output,
       List<ErrorOutput> failureEvents,
-      DagRunCounters pipelineCounters,
-      boolean useDlq) {
+      DagRunCounters pipelineCounters) {
     if (CollectionUtils.isNotEmpty(failureEvents)) {
-      if (useDlq) {
-        throw new IllegalArgumentException(failureEvents.getFirst().errorMessage());
-      }
+      recordFailure(nodeId, commandName, failureEvents.getFirst().errorMessage());
       Map<String, String> tags = new HashMap<>(callingUserTag);
       tags.put(METRIC_TAG_NODE_ID, nodeId);
       tags.put(METRIC_TAG_COMMAND_NAME, commandName);
@@ -76,6 +77,19 @@ public class DagResult {
       recordDebugInfo(nodeId, upstreamNodeId, copies, outputByStep, true);
     }
   }
+
+  /** Remembers the first node failure of the run; later failures don't overwrite it. */
+  void recordFailure(String nodeId, String commandName, String errorMessage) {
+    if (firstFailure == null) {
+      firstFailure = new NodeFailure(nodeId, commandName, errorMessage);
+    }
+  }
+
+  boolean hasFailure() {
+    return firstFailure != null;
+  }
+
+  record NodeFailure(String nodeId, String commandName, String errorMessage) {}
 
   private <T> void recordDebugInfo(
       String currentNodeId,

--- a/runner/src/main/java/io/fleak/zephflow/runner/NoSourceDagRunner.java
+++ b/runner/src/main/java/io/fleak/zephflow/runner/NoSourceDagRunner.java
@@ -84,6 +84,17 @@ public record NoSourceDagRunner(
     if (log.isDebugEnabled() && MapUtils.isNotEmpty(dagResult.getErrorByStep())) {
       log.debug("failed to process events: {}", toJsonString(dagResult.errorByStep));
     }
+    // Per-node failures are isolated during the traversal (siblings still run). When DLQ is enabled
+    // we surface them here, after every branch has run, so the source persists the whole raw record
+    // to the DLQ (at-least-once). Without DLQ the failures are counted and dropped (at-most-once).
+    if (useDlq && dagResult.hasFailure()) {
+      DagResult.NodeFailure failure = dagResult.getFirstFailure();
+      throw new NodeExecutionException(
+          failure.nodeId(),
+          failure.commandName(),
+          failure.errorMessage(),
+          new IllegalArgumentException(failure.errorMessage()));
+    }
     return dagResult;
   }
 
@@ -104,7 +115,20 @@ public record NoSourceDagRunner(
       return;
     }
     for (var e : outgoingEdges) {
-      processEvent(e.getTo(), currentNodeId, events, runContext);
+      // Failure isolation: a node failure aborts only its own subtree; sibling branches still run.
+      // Recorded failures may trigger the DLQ once the whole run finishes (see run()).
+      // Data isolation relies on the command contract (no in-place mutation of input records), so
+      // fan-out branches safely share the same event objects with no per-branch copy.
+      try {
+        processEvent(e.getTo(), currentNodeId, events, runContext);
+      } catch (NodeExecutionException nee) {
+        runContext.dagResult.recordFailure(nee.getNodeId(), nee.getCommandName(), nee.getMessage());
+        Map<String, String> tags = new HashMap<>(runContext.callingUserTag);
+        tags.put(METRIC_TAG_NODE_ID, nee.getNodeId());
+        tags.put(METRIC_TAG_COMMAND_NAME, nee.getCommandName());
+        counters.increaseErrorEventCounter(events.size(), tags);
+        log.debug("node {} failed; isolating branch", nee.getNodeId(), nee);
+      }
     }
   }
 
@@ -133,8 +157,7 @@ public record NoSourceDagRunner(
             runContext.runConfig,
             result.getOutput(),
             result.getFailureEvents(),
-            counters,
-            useDlq);
+            counters);
 
         routeToDownstream(
             currentNodeId, command.commandName(), result.getOutput(), downstreamEdges, runContext);
@@ -153,8 +176,7 @@ public record NoSourceDagRunner(
             runContext.runConfig,
             List.of(sinkOutputEvent),
             result.getFailureEvents(),
-            counters,
-            useDlq);
+            counters);
         Map<String, String> tags = new HashMap<>(runContext.callingUserTag);
         tags.put(METRIC_TAG_NODE_ID, currentNodeId);
         tags.put(METRIC_TAG_COMMAND_NAME, command.commandName());

--- a/runner/src/test/java/io/fleak/zephflow/runner/NoSourceDagRunnerTest.java
+++ b/runner/src/test/java/io/fleak/zephflow/runner/NoSourceDagRunnerTest.java
@@ -616,7 +616,8 @@ class NoSourceDagRunnerTest {
       assertEquals(NODE_ID_1, exception.getNodeId(), "NodeId mismatch");
       assertEquals(CMD_NAME_1, exception.getCommandName(), "CommandName mismatch");
       assertInstanceOf(IllegalArgumentException.class, exception.getCause());
-      verify(mockCounters, never()).increaseErrorEventCounter(anyLong(), anyMap());
+      // Failures are now counted during the isolated traversal; the DLQ throw fires at end of run.
+      verify(mockCounters).increaseErrorEventCounter(eq((long) errors.size()), anyMap());
       verify(mockScalarCmd2, never()).process(anyList(), anyString(), any());
       verify(mockCounters).increaseInputEventCounter(anyLong(), anyMap());
       verify(mockCounters).startStopWatch();
@@ -711,7 +712,8 @@ class NoSourceDagRunnerTest {
       assertEquals(SINK_ID, exception.getNodeId(), "NodeId mismatch");
       assertEquals(SINK_CMD_NAME, exception.getCommandName(), "CommandName mismatch");
       assertInstanceOf(IllegalArgumentException.class, exception.getCause());
-      verify(mockCounters, never()).increaseErrorEventCounter(anyLong(), anyMap());
+      // Failures are now counted during the isolated traversal; the DLQ throw fires at end of run.
+      verify(mockCounters).increaseErrorEventCounter(eq((long) errors.size()), anyMap());
       verify(mockCounters).increaseInputEventCounter(anyLong(), anyMap());
       verify(mockCounters).startStopWatch();
     }
@@ -745,6 +747,303 @@ class NoSourceDagRunnerTest {
       assertTrue(
           result.errorByStep.isEmpty(),
           "errorByStep map should be empty when includeErrorByStep=false");
+    }
+
+    private ScalarSinkCommand throwingSink(String commandName, RuntimeException toThrow) {
+      ScalarSinkCommand sink = mock(ScalarSinkCommand.class);
+      lenient().when(sink.commandName()).thenReturn(commandName);
+      lenient().when(sink.getExecutionContext()).thenReturn(mock(ExecutionContext.class));
+      lenient().doNothing().when(sink).initialize(any());
+      lenient()
+          .when(sink.writeToSink(anyList(), eq(CALLING_USER), any(ExecutionContext.class)))
+          .thenThrow(toThrow);
+      return sink;
+    }
+
+    @Test
+    @DisplayName("should isolate a failing branch so sibling branches still process (useDlq=false)")
+    void run_shouldIsolateFailingBranch_whenDlqFalse() {
+      String sinkAId = "sinkA";
+      String sinkBId = "sinkB";
+      ScalarSinkCommand failingSink =
+          throwingSink("failingSink", new RuntimeException("sink A blew up"));
+
+      edgesFromSource =
+          List.of(
+              Edge.builder().from(SOURCE_NODE_ID).to(sinkAId).build(),
+              Edge.builder().from(SOURCE_NODE_ID).to(sinkBId).build());
+      List<Node<OperatorCommand>> nodes =
+          List.of(
+              Node.<OperatorCommand>builder().id(sinkAId).nodeContent(failingSink).build(),
+              Node.<OperatorCommand>builder().id(sinkBId).nodeContent(mockSinkCmd).build());
+      Dag<OperatorCommand> compiledDag = new Dag<>(nodes, List.of());
+
+      noSourceDagRunner =
+          new NoSourceDagRunner(
+              edgesFromSource, compiledDag, mockMetricProvider, mockCounters, false);
+
+      DagResult result = noSourceDagRunner.run(inputEvents, CALLING_USER, runConfigIncludeAll);
+
+      verify(mockSinkCmd).writeToSink(anyList(), eq(CALLING_USER), any(ExecutionContext.class));
+      assertTrue(result.outputEvents.containsKey(sinkBId), "sibling sink B should have output");
+      assertFalse(
+          result.outputEvents.containsKey(sinkAId), "failing sink A should produce no output");
+      verify(mockCounters).increaseErrorEventCounter(eq((long) inputEvents.size()), anyMap());
+    }
+
+    @Test
+    @DisplayName("should isolate a deep branch failure without affecting sibling downstream")
+    void run_shouldIsolateDeepBranchFailure() {
+      String sinkFailId = "sinkFail";
+      String sinkGoodId = "sinkGood";
+      ScalarSinkCommand failingSink =
+          throwingSink("failingSink", new RuntimeException("deep sink blew up"));
+
+      Node<OperatorCommand> node1 =
+          Node.<OperatorCommand>builder().id(NODE_ID_1).nodeContent(mockScalarCmd1).build();
+      List<Node<OperatorCommand>> nodes =
+          List.of(
+              node1,
+              Node.<OperatorCommand>builder().id(sinkFailId).nodeContent(failingSink).build(),
+              Node.<OperatorCommand>builder().id(sinkGoodId).nodeContent(mockSinkCmd).build());
+      List<Edge> edges =
+          List.of(
+              Edge.builder().from(NODE_ID_1).to(sinkFailId).build(),
+              Edge.builder().from(NODE_ID_1).to(sinkGoodId).build());
+      Dag<OperatorCommand> compiledDag = new Dag<>(nodes, edges);
+
+      noSourceDagRunner =
+          new NoSourceDagRunner(
+              edgesFromSource, compiledDag, mockMetricProvider, mockCounters, false);
+
+      DagResult result = noSourceDagRunner.run(inputEvents, CALLING_USER, runConfigIncludeAll);
+
+      verify(mockSinkCmd).writeToSink(anyList(), eq(CALLING_USER), any(ExecutionContext.class));
+      assertTrue(result.outputEvents.containsKey(sinkGoodId), "sibling sink should have output");
+      assertFalse(
+          result.outputEvents.containsKey(sinkFailId), "failing sink should produce no output");
+    }
+
+    @Test
+    @DisplayName("should share event objects across fan-out branches without copying")
+    void run_shouldShareEventsAcrossBranches_noCopy() {
+      // Data isolation across branches is guaranteed by the command contract (no in-place
+      // mutation),
+      // not by copying. This locks the zero-copy fan-out so a copy is never silently reintroduced.
+      edgesFromSource =
+          List.of(
+              Edge.builder().from(SOURCE_NODE_ID).to(NODE_ID_1).build(),
+              Edge.builder().from(SOURCE_NODE_ID).to(NODE_ID_2).build());
+      List<Node<OperatorCommand>> nodes =
+          List.of(
+              Node.<OperatorCommand>builder().id(NODE_ID_1).nodeContent(mockScalarCmd1).build(),
+              Node.<OperatorCommand>builder().id(NODE_ID_2).nodeContent(mockScalarCmd2).build());
+      Dag<OperatorCommand> compiledDag = new Dag<>(nodes, List.of());
+
+      noSourceDagRunner =
+          new NoSourceDagRunner(
+              edgesFromSource, compiledDag, mockMetricProvider, mockCounters, false);
+
+      noSourceDagRunner.run(inputEvents, CALLING_USER, runConfigIncludeAll);
+
+      ArgumentCaptor<List<RecordFleakData>> cap1 = ArgumentCaptor.forClass(List.class);
+      ArgumentCaptor<List<RecordFleakData>> cap2 = ArgumentCaptor.forClass(List.class);
+      verify(mockScalarCmd1).process(cap1.capture(), eq(CALLING_USER), any(ExecutionContext.class));
+      verify(mockScalarCmd2).process(cap2.capture(), eq(CALLING_USER), any(ExecutionContext.class));
+
+      assertSame(
+          inputEvents.get(0),
+          cap1.getValue().get(0),
+          "fan-out must pass the original record instances (no copy)");
+      assertSame(
+          cap1.getValue().get(0),
+          cap2.getValue().get(0),
+          "both branches must share the same record instance");
+    }
+
+    @Test
+    @DisplayName("should run all branches then throw for DLQ when one branch fails (useDlq=true)")
+    void run_shouldRunAllBranchesThenThrow_whenDlqTrue() {
+      String sinkFailId = "sinkFail";
+      String sinkGoodId = "sinkGood";
+      ScalarSinkCommand failingSink =
+          throwingSink("failingSink", new RuntimeException("sink blew up"));
+
+      edgesFromSource =
+          List.of(
+              Edge.builder().from(SOURCE_NODE_ID).to(sinkFailId).build(),
+              Edge.builder().from(SOURCE_NODE_ID).to(sinkGoodId).build());
+      List<Node<OperatorCommand>> nodes =
+          List.of(
+              Node.<OperatorCommand>builder().id(sinkFailId).nodeContent(failingSink).build(),
+              Node.<OperatorCommand>builder().id(sinkGoodId).nodeContent(mockSinkCmd).build());
+      Dag<OperatorCommand> compiledDag = new Dag<>(nodes, List.of());
+
+      noSourceDagRunner =
+          new NoSourceDagRunner(
+              edgesFromSource, compiledDag, mockMetricProvider, mockCounters, true); // useDlq=true
+
+      NodeExecutionException exception =
+          assertThrows(
+              NodeExecutionException.class,
+              () -> noSourceDagRunner.run(inputEvents, CALLING_USER, runConfigIncludeAll));
+
+      // the sibling good sink still ran before the end-of-run DLQ throw
+      verify(mockSinkCmd).writeToSink(anyList(), eq(CALLING_USER), any(ExecutionContext.class));
+      assertEquals(sinkFailId, exception.getNodeId(), "throw should carry the failing node id");
+    }
+
+    @Test
+    @DisplayName("should not visit the downstream of a node that threw")
+    void run_shouldSkipDownstreamOfFailingNode() {
+      when(mockScalarCmd1.process(anyList(), eq(CALLING_USER), any(ExecutionContext.class)))
+          .thenThrow(new RuntimeException("node1 blew up"));
+
+      Node<OperatorCommand> node1 =
+          Node.<OperatorCommand>builder().id(NODE_ID_1).nodeContent(mockScalarCmd1).build();
+      Node<OperatorCommand> sinkNode =
+          Node.<OperatorCommand>builder().id(SINK_ID).nodeContent(mockSinkCmd).build();
+      Dag<OperatorCommand> compiledDag =
+          new Dag<>(
+              List.of(node1, sinkNode),
+              List.of(Edge.builder().from(NODE_ID_1).to(SINK_ID).build()));
+
+      noSourceDagRunner =
+          new NoSourceDagRunner(
+              edgesFromSource, compiledDag, mockMetricProvider, mockCounters, false);
+
+      DagResult result = noSourceDagRunner.run(inputEvents, CALLING_USER, runConfigIncludeAll);
+
+      verify(mockSinkCmd, never()).writeToSink(anyList(), any(), any(ExecutionContext.class));
+      assertFalse(
+          result.outputEvents.containsKey(SINK_ID), "downstream of a failing node must be skipped");
+      verify(mockCounters).increaseErrorEventCounter(eq((long) inputEvents.size()), anyMap());
+    }
+
+    @Test
+    @DisplayName("should route only successful records downstream on a partial node failure")
+    void run_shouldRouteSuccessfulRecordsDownstreamOnPartialFailure() {
+      RecordFleakData good = createEvent("good");
+      RecordFleakData bad = createEvent("bad");
+      List<RecordFleakData> in = List.of(good, bad);
+      when(mockScalarCmd1.process(eq(in), eq(CALLING_USER), any(ExecutionContext.class)))
+          .thenReturn(
+              new ScalarCommand.ProcessResult(
+                  new ArrayList<>(List.of(good)), List.of(createError(bad, "boom"))));
+
+      Node<OperatorCommand> node1 =
+          Node.<OperatorCommand>builder().id(NODE_ID_1).nodeContent(mockScalarCmd1).build();
+      Node<OperatorCommand> sinkNode =
+          Node.<OperatorCommand>builder().id(SINK_ID).nodeContent(mockSinkCmd).build();
+      Dag<OperatorCommand> compiledDag =
+          new Dag<>(
+              List.of(node1, sinkNode),
+              List.of(Edge.builder().from(NODE_ID_1).to(SINK_ID).build()));
+
+      noSourceDagRunner =
+          new NoSourceDagRunner(
+              edgesFromSource, compiledDag, mockMetricProvider, mockCounters, false);
+
+      noSourceDagRunner.run(in, CALLING_USER, runConfigIncludeAll);
+
+      ArgumentCaptor<List<RecordFleakData>> sinkInput = ArgumentCaptor.forClass(List.class);
+      verify(mockSinkCmd)
+          .writeToSink(sinkInput.capture(), eq(CALLING_USER), any(ExecutionContext.class));
+      assertEquals(
+          List.of(good), sinkInput.getValue(), "only successful records should reach downstream");
+      verify(mockCounters).increaseErrorEventCounter(eq(1L), anyMap());
+    }
+
+    @Test
+    @DisplayName("should not throw for DLQ when the run has no failures (useDlq=true)")
+    void run_shouldNotThrowWhenNoFailure_whenDlqTrue() {
+      Node<OperatorCommand> node1 =
+          Node.<OperatorCommand>builder().id(NODE_ID_1).nodeContent(mockScalarCmd1).build();
+      Node<OperatorCommand> sinkNode =
+          Node.<OperatorCommand>builder().id(SINK_ID).nodeContent(mockSinkCmd).build();
+      Dag<OperatorCommand> compiledDag =
+          new Dag<>(
+              List.of(node1, sinkNode),
+              List.of(Edge.builder().from(NODE_ID_1).to(SINK_ID).build()));
+
+      noSourceDagRunner =
+          new NoSourceDagRunner(
+              edgesFromSource, compiledDag, mockMetricProvider, mockCounters, true); // useDlq=true
+
+      DagResult result = noSourceDagRunner.run(inputEvents, CALLING_USER, runConfigIncludeAll);
+
+      assertTrue(result.outputEvents.containsKey(SINK_ID), "sink output should be present");
+      verify(mockCounters, never()).increaseErrorEventCounter(anyLong(), anyMap());
+    }
+
+    @Test
+    @DisplayName("should attempt every failing branch and report the first failure (useDlq=true)")
+    void run_shouldReportFirstFailure_whenMultipleBranchesFail_whenDlqTrue() {
+      String sinkAId = "sinkA";
+      String sinkBId = "sinkB";
+      ScalarSinkCommand failA = throwingSink("failA", new RuntimeException("A blew up"));
+      ScalarSinkCommand failB = throwingSink("failB", new RuntimeException("B blew up"));
+
+      edgesFromSource =
+          List.of(
+              Edge.builder().from(SOURCE_NODE_ID).to(sinkAId).build(),
+              Edge.builder().from(SOURCE_NODE_ID).to(sinkBId).build());
+      List<Node<OperatorCommand>> nodes =
+          List.of(
+              Node.<OperatorCommand>builder().id(sinkAId).nodeContent(failA).build(),
+              Node.<OperatorCommand>builder().id(sinkBId).nodeContent(failB).build());
+      Dag<OperatorCommand> compiledDag = new Dag<>(nodes, List.of());
+
+      noSourceDagRunner =
+          new NoSourceDagRunner(
+              edgesFromSource, compiledDag, mockMetricProvider, mockCounters, true); // useDlq=true
+
+      NodeExecutionException exception =
+          assertThrows(
+              NodeExecutionException.class,
+              () -> noSourceDagRunner.run(inputEvents, CALLING_USER, runConfigIncludeAll));
+
+      assertEquals(sinkAId, exception.getNodeId(), "first branch's failure should be reported");
+      assertEquals("A blew up", exception.getMessage(), "first failure message should be reported");
+      // the second failing branch was still attempted despite the first failing
+      verify(failB).writeToSink(anyList(), eq(CALLING_USER), any(ExecutionContext.class));
+    }
+
+    @Test
+    @DisplayName("downstream in-place mutation must not corrupt an upstream node's recorded output")
+    void run_shouldSnapshotStepOutputBeforeDownstreamMutation() {
+      // A passes its records straight through; B mutates them in place. On a single-branch chain
+      // the
+      // runner does not copy between A and B, so the per-step output recording is what protects A's
+      // recorded output from B's mutation.
+      when(mockScalarCmd2.process(anyList(), eq(CALLING_USER), any(ExecutionContext.class)))
+          .thenAnswer(
+              invocation -> {
+                List<RecordFleakData> events = invocation.getArgument(0);
+                events.forEach(e -> e.getPayload().put("mutated", FleakData.wrap("yes")));
+                return new ScalarCommand.ProcessResult(new ArrayList<>(events), List.of());
+              });
+
+      Node<OperatorCommand> nodeA =
+          Node.<OperatorCommand>builder().id(NODE_ID_1).nodeContent(mockScalarCmd1).build();
+      Node<OperatorCommand> nodeB =
+          Node.<OperatorCommand>builder().id(NODE_ID_2).nodeContent(mockScalarCmd2).build();
+      Dag<OperatorCommand> compiledDag =
+          new Dag<>(
+              List.of(nodeA, nodeB), List.of(Edge.builder().from(NODE_ID_1).to(NODE_ID_2).build()));
+
+      noSourceDagRunner =
+          new NoSourceDagRunner(
+              edgesFromSource, compiledDag, mockMetricProvider, mockCounters, false);
+
+      DagResult result = noSourceDagRunner.run(inputEvents, CALLING_USER, runConfigIncludeAll);
+
+      List<RecordFleakData> recordedA = result.outputByStep.get(NODE_ID_1).get(SOURCE_NODE_ID);
+      recordedA.forEach(
+          r ->
+              assertFalse(
+                  r.getPayload().containsKey("mutated"),
+                  "upstream node's recorded output must not reflect a downstream mutation"));
     }
   }
 


### PR DESCRIPTION
- A node error aborts only its own subtree; sibling branches still run
- DLQ fires once at end of run (at-least-once); without DLQ, failures are dropped and counted (at-most-once)
- UnknownSinkCommitStateException downgraded from fatal-abort to a normal node-local failure
- Document the no-in-place-mutation command contract (runner shares events across fan-out branches without copying)