### PR TITLE
FLE-2569: Emit an end-of-run summary of counter totals from clistarter

### DIFF
--- a/clistarter/src/main/java/io/fleak/zephflow/clistarter/Main.java
+++ b/clistarter/src/main/java/io/fleak/zephflow/clistarter/Main.java
@@ -23,8 +23,16 @@ import io.fleak.zephflow.api.metric.InfluxDBV2MetricSender;
 import io.fleak.zephflow.api.metric.MetricClientProvider;
 import io.fleak.zephflow.api.metric.SplunkMetricClientProvider;
 import io.fleak.zephflow.api.metric.SplunkMetricSender;
+import io.fleak.zephflow.lib.utils.JsonUtils;
 import io.fleak.zephflow.runner.DagExecutor;
 import io.fleak.zephflow.runner.JobConfig;
+import io.fleak.zephflow.runner.RunSummary;
+import io.fleak.zephflow.runner.RunSummaryMetricClientProvider;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.cli.ParseException;
 import org.influxdb.InfluxDB;
@@ -35,16 +43,49 @@ import org.influxdb.dto.Query;
 @Slf4j
 public class Main {
 
+  public static final String RUN_SUMMARY_FILE_ENV_VAR = "ZEPHFLOW_RUN_SUMMARY_FILE";
+
+  public static final String RUN_SUMMARY_FILE_SYS_PROP = "zephflow.run.summary.file";
+
   public static void main(String[] args) throws Exception {
     try {
       JobConfig jobConfig = JobCliParser.parseArgs(args);
-      try (MetricClientProvider metricClientProvider = createMetricClientProvider(args)) {
-        DagExecutor dagExecutor = DagExecutor.createDagExecutor(jobConfig, metricClientProvider);
-        dagExecutor.executeDag();
+      try (MetricClientProvider innerProvider = createMetricClientProvider(args)) {
+        RunSummaryMetricClientProvider metricClientProvider =
+            new RunSummaryMetricClientProvider(innerProvider);
+        try {
+          DagExecutor dagExecutor = DagExecutor.createDagExecutor(jobConfig, metricClientProvider);
+          dagExecutor.executeDag();
+        } finally {
+          writeRunSummary(metricClientProvider.summarize(), resolveRunSummaryPath());
+        }
       }
     } catch (ParseException cliParseException) {
       JobCliParser.printUsage("pipelinejob");
       System.exit(1);
+    }
+  }
+
+  private static String resolveRunSummaryPath() {
+    String path = System.getenv(RUN_SUMMARY_FILE_ENV_VAR);
+    if (path == null || path.isBlank()) {
+      path = System.getProperty(RUN_SUMMARY_FILE_SYS_PROP);
+    }
+    return path;
+  }
+
+  static void writeRunSummary(RunSummary runSummary, String path) {
+    if (path == null || path.isBlank()) {
+      return;
+    }
+    try {
+      Map<String, Object> payload = new LinkedHashMap<>();
+      payload.put("counters", new TreeMap<>(runSummary.counters()));
+      payload.put("summary", runSummary.summaryText());
+      Files.writeString(Path.of(path), JsonUtils.toJsonString(payload));
+      log.info("Wrote run summary to {}: {}", path, runSummary.summaryText());
+    } catch (Exception e) {
+      log.error("Failed to write run summary to {}", path, e);
     }
   }
 

--- a/clistarter/src/test/java/io/fleak/zephflow/clistarter/MainTest.java
+++ b/clistarter/src/test/java/io/fleak/zephflow/clistarter/MainTest.java
@@ -22,14 +22,60 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /** Created by bolei on 3/1/25 */
 class MainTest {
+
+  @Test
+  public void testMainWritesRunSummaryFile(@TempDir Path tempDir) throws Exception {
+    Path summaryFile = tempDir.resolve("run-summary.json");
+
+    System.setProperty(Main.RUN_SUMMARY_FILE_SYS_PROP, summaryFile.toString());
+    try {
+      runMainWithStdioDag();
+    } finally {
+      System.clearProperty(Main.RUN_SUMMARY_FILE_SYS_PROP);
+    }
+
+    assertTrue(Files.exists(summaryFile), "run summary file should be written");
+    Map<String, Object> payload =
+        fromJsonString(Files.readString(summaryFile), new TypeReference<Map<String, Object>>() {});
+    @SuppressWarnings("unchecked")
+    Map<String, Object> counters = (Map<String, Object>) payload.get("counters");
+    assertEquals(10, ((Number) counters.get("pipeline_input_event_count")).intValue());
+    assertEquals(20, ((Number) counters.get("sink_output_count")).intValue());
+    String summary = (String) payload.get("summary");
+    assertTrue(summary.contains("input events: 10"), summary);
+    assertTrue(summary.contains("output events: 20"), summary);
+  }
+
   @Test
   public void testMain() throws Exception {
+    String output = runMainWithStdioDag();
+
+    List<String> lines = output.lines().toList();
+    var objects =
+        lines.stream()
+            .filter(l -> l.startsWith("{\""))
+            .map(l -> fromJsonString(l, new TypeReference<Map<String, Object>>() {}))
+            .collect(Collectors.toSet());
+    //noinspection unchecked
+    Set<Map<String, Object>> expected =
+        new HashSet<>(
+            (List<Map<String, Object>>)
+                ((Map<String, Object>)
+                        fromJsonResource("/expected_output_stdio.json", new TypeReference<>() {}))
+                    .get("d"));
+    assertEquals(expected, objects);
+  }
+
+  private static String runMainWithStdioDag() throws Exception {
     String dagDefStr = MiscUtils.loadStringFromResource("/test_dag_stdio.yml");
     String dagDefBase64Str = MiscUtils.toBase64String(dagDefStr.getBytes());
     String[] args = {"-d", dagDefBase64Str, "-id", "test_job", "-s", "my_service", "-e", "my_env"};
@@ -44,26 +90,10 @@ class MainTest {
                 Objects.requireNonNull(toJsonString(sourceEvents)).getBytes());
         ByteArrayOutputStream testOut = new ByteArrayOutputStream();
         PrintStream psOut = new PrintStream(testOut)) {
-
       System.setIn(in);
       System.setOut(psOut);
-
       Main.main(args);
-      String output = testOut.toString();
-      List<String> lines = output.lines().toList();
-      var objects =
-          lines.stream()
-              .filter(l -> l.startsWith("{\""))
-              .map(l -> fromJsonString(l, new TypeReference<Map<String, Object>>() {}))
-              .collect(Collectors.toSet());
-      //noinspection unchecked
-      Set<Map<String, Object>> expected =
-          new HashSet<>(
-              (List<Map<String, Object>>)
-                  ((Map<String, Object>)
-                          fromJsonResource("/expected_output_stdio.json", new TypeReference<>() {}))
-                      .get("d"));
-      assertEquals(expected, objects);
+      return testOut.toString();
     }
   }
 }

--- a/runner/src/main/java/io/fleak/zephflow/runner/RunSummary.java
+++ b/runner/src/main/java/io/fleak/zephflow/runner/RunSummary.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.runner;
+
+import static io.fleak.zephflow.lib.utils.MiscUtils.*;
+import static io.fleak.zephflow.runner.Constants.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public record RunSummary(Map<String, Long> counters) {
+
+  public long counterTotal(String counterName) {
+    Long total = counters.get(counterName);
+    return total == null ? 0 : total;
+  }
+
+  public String summaryText() {
+    List<String> parts = new ArrayList<>();
+    parts.add("input events: " + counterTotal(METRIC_NAME_PIPELINE_INPUT_EVENT));
+    parts.add("deserialize failures: " + counterTotal(METRIC_NAME_INPUT_DESER_ERR_COUNT));
+    parts.add("output events: " + counterTotal(METRIC_NAME_SINK_OUTPUT_COUNT));
+    addIfPositive(parts, "skipped objects", METRIC_NAME_SKIPPED_OBJECT_COUNT);
+    addIfPositive(parts, "sink errors", METRIC_NAME_SINK_ERROR_COUNT);
+    addIfPositive(parts, "processing errors", METRIC_NAME_PIPELINE_ERROR_EVENT);
+    return String.join(", ", parts);
+  }
+
+  private void addIfPositive(List<String> parts, String label, String counterName) {
+    long total = counterTotal(counterName);
+    if (total > 0) {
+      parts.add(label + ": " + total);
+    }
+  }
+}

--- a/runner/src/main/java/io/fleak/zephflow/runner/RunSummaryMetricClientProvider.java
+++ b/runner/src/main/java/io/fleak/zephflow/runner/RunSummaryMetricClientProvider.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.runner;
+
+import io.fleak.zephflow.api.metric.FleakCounter;
+import io.fleak.zephflow.api.metric.FleakGauge;
+import io.fleak.zephflow.api.metric.FleakStopWatch;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.LongAdder;
+
+public final class RunSummaryMetricClientProvider implements MetricClientProvider {
+
+  private final MetricClientProvider delegate;
+  private final ConcurrentMap<String, LongAdder> counterTotals = new ConcurrentHashMap<>();
+
+  public RunSummaryMetricClientProvider(MetricClientProvider delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public FleakCounter counter(String name, Map<String, String> tags) {
+    FleakCounter delegateCounter = delegate.counter(name, tags);
+    LongAdder totalForName = counterTotals.computeIfAbsent(name, counterName -> new LongAdder());
+    return new FleakCounter() {
+      @Override
+      public void increase(Map<String, String> additionalTags) {
+        totalForName.increment();
+        delegateCounter.increase(additionalTags);
+      }
+
+      @Override
+      public void increase(long n, Map<String, String> additionalTags) {
+        totalForName.add(n);
+        delegateCounter.increase(n, additionalTags);
+      }
+    };
+  }
+
+  @Override
+  public <T> FleakGauge<T> gauge(String name, Map<String, String> tags, T monitoredValue) {
+    return delegate.gauge(name, tags, monitoredValue);
+  }
+
+  @Override
+  public FleakStopWatch stopWatch(String name, Map<String, String> tags) {
+    return delegate.stopWatch(name, tags);
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+  public RunSummary summarize() {
+    Map<String, Long> totals = new HashMap<>();
+    counterTotals.forEach((counterName, adder) -> totals.put(counterName, adder.sum()));
+    return new RunSummary(totals);
+  }
+}

--- a/runner/src/test/java/io/fleak/zephflow/runner/RunSummaryMetricClientProviderTest.java
+++ b/runner/src/test/java/io/fleak/zephflow/runner/RunSummaryMetricClientProviderTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.runner;
+
+import static io.fleak.zephflow.lib.utils.MiscUtils.*;
+import static io.fleak.zephflow.runner.Constants.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.fleak.zephflow.api.metric.FleakCounter;
+import io.fleak.zephflow.api.metric.FleakGauge;
+import io.fleak.zephflow.api.metric.FleakStopWatch;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RunSummaryMetricClientProviderTest {
+
+  @Test
+  void accumulatesCounterTotalsByNameAcrossTagsAndInstances() {
+    MetricClientProvider delegate = mock(MetricClientProvider.class);
+    FleakCounter delegateCounter = mock(FleakCounter.class);
+    when(delegate.counter(any(), any())).thenReturn(delegateCounter);
+
+    RunSummaryMetricClientProvider provider = new RunSummaryMetricClientProvider(delegate);
+
+    provider.counter("input_event_count", Map.of("node_id", "a")).increase(5, Map.of());
+    provider.counter("input_event_count", Map.of("node_id", "b")).increase(Map.of());
+    provider.counter("sink_output_count", Map.of()).increase(3, Map.of());
+
+    RunSummary summary = provider.summarize();
+    assertEquals(6L, summary.counterTotal("input_event_count"));
+    assertEquals(3L, summary.counterTotal("sink_output_count"));
+    assertEquals(0L, summary.counterTotal("nonexistent"));
+
+    verify(delegateCounter).increase(eq(5L), any());
+    verify(delegateCounter).increase(any());
+    verify(delegateCounter).increase(eq(3L), any());
+  }
+
+  @Test
+  void delegatesGaugeStopWatchAndClose() {
+    MetricClientProvider delegate = mock(MetricClientProvider.class);
+    @SuppressWarnings("unchecked")
+    FleakGauge<Long> gauge = mock(FleakGauge.class);
+    FleakStopWatch stopWatch = mock(FleakStopWatch.class);
+    when(delegate.gauge(eq("g"), any(), anyLong())).thenReturn(gauge);
+    when(delegate.stopWatch(eq("sw"), any())).thenReturn(stopWatch);
+
+    RunSummaryMetricClientProvider provider = new RunSummaryMetricClientProvider(delegate);
+
+    assertSame(gauge, provider.gauge("g", Map.of(), 1L));
+    assertSame(stopWatch, provider.stopWatch("sw", Map.of()));
+    provider.close();
+    verify(delegate).close();
+  }
+
+  @Test
+  void summaryTextReportsCoreCounters() {
+    RunSummary summary =
+        new RunSummary(
+            Map.of(
+                METRIC_NAME_PIPELINE_INPUT_EVENT, 0L,
+                METRIC_NAME_INPUT_DESER_ERR_COUNT, 2L,
+                METRIC_NAME_SINK_OUTPUT_COUNT, 0L));
+
+    assertEquals(
+        "input events: 0, deserialize failures: 2, output events: 0", summary.summaryText());
+  }
+
+  @Test
+  void summaryTextIncludesOptionalCountersOnlyWhenPositive() {
+    RunSummary summary =
+        new RunSummary(
+            Map.of(
+                METRIC_NAME_PIPELINE_INPUT_EVENT, 10L,
+                METRIC_NAME_SINK_OUTPUT_COUNT, 7L,
+                METRIC_NAME_SKIPPED_OBJECT_COUNT, 1L,
+                METRIC_NAME_SINK_ERROR_COUNT, 3L,
+                METRIC_NAME_PIPELINE_ERROR_EVENT, 4L));
+
+    assertEquals(
+        "input events: 10, deserialize failures: 0, output events: 7,"
+            + " skipped objects: 1, sink errors: 3, processing errors: 4",
+        summary.summaryText());
+  }
+}


### PR DESCRIPTION
## Why

A batch run whose source read nothing (or parsed nothing) exits 0 and is indistinguishable from a healthy run: its counters go to the metrics backend (or nowhere, on the NOOP fallback) and never reach the task status. This is the zephflow-core piece of FLE-2569; companion PRs in grid (reads the file, attaches the summary to the task's COMPLETED status) and dynamicapi (surfaces it in the run's status message).

## What

- `RunSummaryMetricClientProvider` (runner) decorates any `MetricClientProvider` and keeps in-memory whole-run totals per counter name; the wrapped provider still receives every increment.
- `RunSummary.summaryText()` builds a one-line human summary: `pipeline_input_event_count` for input events (plain `input_event_count` is also incremented by sinks and would double-count), `input_deser_err_count`, `sink_output_count`, plus skipped/sink-error/processing-error counts when nonzero.
- clistarter `Main` wraps the real provider and, when `ZEPHFLOW_RUN_SUMMARY_FILE` is set (system property `zephflow.run.summary.file` as the test hook), writes `{"counters": {...}, "summary": "..."}` to that path at exit — also on failure, so partial progress stays inspectable. Writing never fails the run.

## Testing

- Unit tests for accumulation/delegation and the summary line format.
- End-to-end `MainTest` case: a real `Main.main` run over the stdio DAG writes the file with `pipeline_input_event_count=10`, `sink_output_count=20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)