### PR TITLE
Make kafkasink wait for broker acks by default (FLE-2366)

### DIFF
--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkCommand.java
@@ -82,32 +82,25 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
     KafkaSinkDto.Config config = (KafkaSinkDto.Config) commandConfig;
     // A test run is an ephemeral, in-memory single shot; durable store-and-forward buffering is
     // meaningless there and would leave an orphaned, still-locked on-disk queue that blocks the
-    // next run. Force it off in test mode; delivery mode (ack-waiting by default) is unaffected.
+    // next run. Force it off in test mode.
     boolean storeAndForwardEnabled = config.isStoreAndForwardEnabled() && !isTestMode(jobContext);
 
-    // The source checkpoint advances as soon as the sink returns, so a flusher that returns while
-    // records are still in the producer's client-side accumulator silently loses them on a crash
-    // (FLE-2366). Waiting for broker acks is therefore the default; FIRE_AND_FORGET is an explicit
-    // opt-in. Store-and-forward always requires ack-waiting to detect failures at flush time.
-    boolean waitForAcks =
+    boolean waitForBrokerAcks =
         storeAndForwardEnabled
             || config.getDeliveryMode() != KafkaSinkDto.DeliveryMode.FIRE_AND_FORGET;
 
-    // Any ack-waiting flusher needs the classifier so its pre-send metadata probe can fail a whole
-    // batch after one bounded wait during an outage; only store-and-forward additionally uses it to
-    // throw mid-batch (see KafkaSinkFlusher).
-    KafkaConnectionFailureClassifier classifier =
-        waitForAcks ? new KafkaConnectionFailureClassifier() : null;
+    KafkaConnectionFailureClassifier connectionFailureClassifier =
+        waitForBrokerAcks ? new KafkaConnectionFailureClassifier() : null;
 
     SimpleSinkCommand.Flusher<RecordFleakData> flusher =
         createKafkaFlusher(
             config,
             storeAndForwardEnabled,
-            waitForAcks,
+            waitForBrokerAcks,
             counters.sinkOutputCounter(),
             counters.outputSizeCounter(),
             counters.sinkErrorCounter(),
-            classifier);
+            connectionFailureClassifier);
 
     SimpleSinkCommand.SinkMessagePreProcessor<RecordFleakData> messagePreProcessor =
         new PassThroughMessagePreProcessor();
@@ -121,7 +114,7 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
             nodeId,
             flusher,
             messagePreProcessor,
-            classifier);
+            connectionFailureClassifier);
 
     return new SinkExecutionContext<>(
         flusher,
@@ -137,12 +130,12 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
   private SimpleSinkCommand.Flusher<RecordFleakData> createKafkaFlusher(
       KafkaSinkDto.Config config,
       boolean storeAndForwardEnabled,
-      boolean waitForAcks,
+      boolean waitForBrokerAcks,
       FleakCounter asyncDeliveredCountCounter,
       FleakCounter asyncDeliveredSizeCounter,
       FleakCounter asyncErrorCounter,
-      KafkaConnectionFailureClassifier classifier) {
-    Properties props = getProperties(config, waitForAcks);
+      KafkaConnectionFailureClassifier connectionFailureClassifier) {
+    Properties props = getProperties(config, waitForBrokerAcks);
 
     boolean isTestMode = isTestMode(jobContext);
     if (isTestMode) {
@@ -151,9 +144,7 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
 
     if (storeAndForwardEnabled) {
       // Bounded timeouts so an outage surfaces quickly as a thrown failure (-> buffer) instead of
-      // blocking. delivery.timeout.ms must be >= request.timeout.ms + linger.ms. Note acks=all
-      // under these tight timeouts classifies slow ISR replication as a connectivity failure ->
-      // more buffer/replay cycles (still at-least-once; duplicates possible across replays).
+      // blocking. delivery.timeout.ms must be >= request.timeout.ms + linger.ms.
       props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "5000");
       props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, "2000");
       props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, "5000");
@@ -163,8 +154,8 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
       props.putAll(config.getProperties());
     }
 
-    if (waitForAcks) {
-      applyIdempotenceIfAcksAll(props);
+    if (waitForBrokerAcks) {
+      enableIdempotenceIfConfigurationAllows(props);
     }
 
     applyCredentialSasl(props, config);
@@ -194,8 +185,8 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
         asyncDeliveredCountCounter,
         asyncDeliveredSizeCounter,
         asyncErrorCounter,
-        waitForAcks,
-        classifier,
+        waitForBrokerAcks,
+        connectionFailureClassifier,
         storeAndForwardEnabled);
   }
 
@@ -285,7 +276,7 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
   }
 
   private static @NotNull Properties getProperties(
-      KafkaSinkDto.Config config, boolean waitForAcks) {
+      KafkaSinkDto.Config config, boolean waitForBrokerAcks) {
     Properties props = new Properties();
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBroker());
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
@@ -296,47 +287,38 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
     props.put(ProducerConfig.LINGER_MS_CONFIG, "10");
     props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, "67108864");
     props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "lz4");
-    // In the durable (default) mode the flusher already pays one broker round-trip per batch, so
-    // acks=all closes the residual leader-failure window at negligible extra cost. acks=1 is only
-    // for the explicit fire-and-forget opt-in.
-    props.put(ProducerConfig.ACKS_CONFIG, waitForAcks ? "all" : "1");
+    props.put(ProducerConfig.ACKS_CONFIG, waitForBrokerAcks ? "all" : "1");
     props.put(ProducerConfig.RETRIES_CONFIG, "3");
     props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "5");
     return props;
   }
 
   /**
-   * Turns on the idempotent producer for the durable path, but only when the effective (post user
-   * override) config still satisfies every constraint the producer enforces at construction time
-   * for enable.idempotence=true: acks=all/-1, retries > 0, max.in.flight <= 5, and the user hasn't
-   * set enable.idempotence themselves. A pre-existing config that pinned any of these to a weaker
-   * value must keep constructing a valid producer rather than fail on upgrade.
+   * The producer rejects {@code enable.idempotence=true} at construction time unless acks=all/-1,
+   * retries > 0 and max.in.flight <= 5, so a user property override weakening any of them must
+   * leave idempotence off instead of breaking producer construction.
    */
-  private static void applyIdempotenceIfAcksAll(Properties props) {
-    Object acks = props.get(ProducerConfig.ACKS_CONFIG);
-    boolean acksAll = "all".equals(acks) || "-1".equals(acks);
-    if (acksAll
-        && !props.containsKey(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)
-        && intPropAtLeast(props, ProducerConfig.RETRIES_CONFIG, 1)
-        && intPropAtMost(props, ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5)) {
-      props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+  private static void enableIdempotenceIfConfigurationAllows(Properties producerProperties) {
+    Object acks = producerProperties.get(ProducerConfig.ACKS_CONFIG);
+    Integer retries = producerPropertyAsInteger(producerProperties, ProducerConfig.RETRIES_CONFIG);
+    Integer maxInFlightRequests =
+        producerPropertyAsInteger(
+            producerProperties, ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION);
+    boolean idempotenceSupported =
+        ("all".equals(acks) || "-1".equals(acks))
+            && retries != null
+            && retries > 0
+            && maxInFlightRequests != null
+            && maxInFlightRequests <= 5
+            && !producerProperties.containsKey(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG);
+    if (idempotenceSupported) {
+      producerProperties.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
     }
   }
 
-  private static boolean intPropAtLeast(Properties props, String key, int min) {
-    Integer value = parseIntProp(props, key);
-    return value != null && value >= min;
-  }
-
-  private static boolean intPropAtMost(Properties props, String key, int max) {
-    Integer value = parseIntProp(props, key);
-    return value != null && value <= max;
-  }
-
-  /** Null on an unparseable value, so idempotence stays off and producer validation speaks. */
-  private static Integer parseIntProp(Properties props, String key) {
+  private static Integer producerPropertyAsInteger(Properties producerProperties, String key) {
     try {
-      return Integer.parseInt(String.valueOf(props.get(key)).trim());
+      return Integer.parseInt(String.valueOf(producerProperties.get(key)).trim());
     } catch (NumberFormatException e) {
       return null;
     }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkCommand.java
@@ -82,15 +82,24 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
     KafkaSinkDto.Config config = (KafkaSinkDto.Config) commandConfig;
     // A test run is an ephemeral, in-memory single shot; durable store-and-forward buffering is
     // meaningless there and would leave an orphaned, still-locked on-disk queue that blocks the
-    // next run. Force it off in test mode so the sink degrades to a plain async send.
+    // next run. Force it off in test mode; delivery mode (ack-waiting by default) is unaffected.
     boolean storeAndForwardEnabled = config.isStoreAndForwardEnabled() && !isTestMode(jobContext);
     KafkaConnectionFailureClassifier classifier =
         storeAndForwardEnabled ? new KafkaConnectionFailureClassifier() : null;
+
+    // The source checkpoint advances as soon as the sink returns, so a flusher that returns while
+    // records are still in the producer's client-side accumulator silently loses them on a crash
+    // (FLE-2366). Waiting for broker acks is therefore the default; FIRE_AND_FORGET is an explicit
+    // opt-in. Store-and-forward always requires ack-waiting to detect failures at flush time.
+    boolean waitForAcks =
+        storeAndForwardEnabled
+            || config.getDeliveryMode() != KafkaSinkDto.DeliveryMode.FIRE_AND_FORGET;
 
     SimpleSinkCommand.Flusher<RecordFleakData> flusher =
         createKafkaFlusher(
             config,
             storeAndForwardEnabled,
+            waitForAcks,
             counters.sinkOutputCounter(),
             counters.outputSizeCounter(),
             counters.sinkErrorCounter(),
@@ -124,11 +133,12 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
   private SimpleSinkCommand.Flusher<RecordFleakData> createKafkaFlusher(
       KafkaSinkDto.Config config,
       boolean storeAndForwardEnabled,
+      boolean waitForAcks,
       FleakCounter asyncDeliveredCountCounter,
       FleakCounter asyncDeliveredSizeCounter,
       FleakCounter asyncErrorCounter,
       KafkaConnectionFailureClassifier classifier) {
-    Properties props = getProperties(config);
+    Properties props = getProperties(config, waitForAcks);
 
     boolean isTestMode = isTestMode(jobContext);
     if (isTestMode) {
@@ -145,6 +155,10 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
 
     if (config.getProperties() != null) {
       props.putAll(config.getProperties());
+    }
+
+    if (waitForAcks) {
+      applyIdempotenceIfAcksAll(props);
     }
 
     applyCredentialSasl(props, config);
@@ -174,7 +188,7 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
         asyncDeliveredCountCounter,
         asyncDeliveredSizeCounter,
         asyncErrorCounter,
-        storeAndForwardEnabled,
+        waitForAcks,
         classifier);
   }
 
@@ -263,7 +277,8 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
     return v.replace("\\", "\\\\").replace("\"", "\\\"");
   }
 
-  private static @NotNull Properties getProperties(KafkaSinkDto.Config config) {
+  private static @NotNull Properties getProperties(
+      KafkaSinkDto.Config config, boolean waitForAcks) {
     Properties props = new Properties();
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBroker());
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
@@ -274,10 +289,26 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
     props.put(ProducerConfig.LINGER_MS_CONFIG, "10");
     props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, "67108864");
     props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "lz4");
-    props.put(ProducerConfig.ACKS_CONFIG, "1");
+    // In the durable (default) mode the flusher already pays one broker round-trip per batch, so
+    // acks=all closes the residual leader-failure window at negligible extra cost. acks=1 is only
+    // for the explicit fire-and-forget opt-in.
+    props.put(ProducerConfig.ACKS_CONFIG, waitForAcks ? "all" : "1");
     props.put(ProducerConfig.RETRIES_CONFIG, "3");
     props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "5");
     return props;
+  }
+
+  /**
+   * Turns on the idempotent producer for the durable path, but only when the effective (post user
+   * override) acks is still all/-1 and the user hasn't set enable.idempotence themselves — the
+   * producer rejects enable.idempotence=true with any weaker acks at construction time.
+   */
+  private static void applyIdempotenceIfAcksAll(Properties props) {
+    Object acks = props.get(ProducerConfig.ACKS_CONFIG);
+    boolean acksAll = "all".equals(acks) || "-1".equals(acks);
+    if (acksAll && !props.containsKey(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)) {
+      props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+    }
   }
 
   private static boolean isTestMode(JobContext jobContext) {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkCommand.java
@@ -84,8 +84,6 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
     // meaningless there and would leave an orphaned, still-locked on-disk queue that blocks the
     // next run. Force it off in test mode; delivery mode (ack-waiting by default) is unaffected.
     boolean storeAndForwardEnabled = config.isStoreAndForwardEnabled() && !isTestMode(jobContext);
-    KafkaConnectionFailureClassifier classifier =
-        storeAndForwardEnabled ? new KafkaConnectionFailureClassifier() : null;
 
     // The source checkpoint advances as soon as the sink returns, so a flusher that returns while
     // records are still in the producer's client-side accumulator silently loses them on a crash
@@ -94,6 +92,12 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
     boolean waitForAcks =
         storeAndForwardEnabled
             || config.getDeliveryMode() != KafkaSinkDto.DeliveryMode.FIRE_AND_FORGET;
+
+    // Any ack-waiting flusher needs the classifier so its pre-send metadata probe can fail a whole
+    // batch after one bounded wait during an outage; only store-and-forward additionally uses it to
+    // throw mid-batch (see KafkaSinkFlusher).
+    KafkaConnectionFailureClassifier classifier =
+        waitForAcks ? new KafkaConnectionFailureClassifier() : null;
 
     SimpleSinkCommand.Flusher<RecordFleakData> flusher =
         createKafkaFlusher(
@@ -147,7 +151,9 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
 
     if (storeAndForwardEnabled) {
       // Bounded timeouts so an outage surfaces quickly as a thrown failure (-> buffer) instead of
-      // blocking. delivery.timeout.ms must be >= request.timeout.ms + linger.ms.
+      // blocking. delivery.timeout.ms must be >= request.timeout.ms + linger.ms. Note acks=all
+      // under these tight timeouts classifies slow ISR replication as a connectivity failure ->
+      // more buffer/replay cycles (still at-least-once; duplicates possible across replays).
       props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "5000");
       props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, "2000");
       props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, "5000");
@@ -189,7 +195,8 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
         asyncDeliveredSizeCounter,
         asyncErrorCounter,
         waitForAcks,
-        classifier);
+        classifier,
+        storeAndForwardEnabled);
   }
 
   private static final int STORE_FORWARD_DRAIN_CHUNK = 1000;
@@ -300,14 +307,38 @@ public class KafkaSinkCommand extends SimpleSinkCommand<RecordFleakData> {
 
   /**
    * Turns on the idempotent producer for the durable path, but only when the effective (post user
-   * override) acks is still all/-1 and the user hasn't set enable.idempotence themselves — the
-   * producer rejects enable.idempotence=true with any weaker acks at construction time.
+   * override) config still satisfies every constraint the producer enforces at construction time
+   * for enable.idempotence=true: acks=all/-1, retries > 0, max.in.flight <= 5, and the user hasn't
+   * set enable.idempotence themselves. A pre-existing config that pinned any of these to a weaker
+   * value must keep constructing a valid producer rather than fail on upgrade.
    */
   private static void applyIdempotenceIfAcksAll(Properties props) {
     Object acks = props.get(ProducerConfig.ACKS_CONFIG);
     boolean acksAll = "all".equals(acks) || "-1".equals(acks);
-    if (acksAll && !props.containsKey(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)) {
+    if (acksAll
+        && !props.containsKey(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)
+        && intPropAtLeast(props, ProducerConfig.RETRIES_CONFIG, 1)
+        && intPropAtMost(props, ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5)) {
       props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+    }
+  }
+
+  private static boolean intPropAtLeast(Properties props, String key, int min) {
+    Integer value = parseIntProp(props, key);
+    return value != null && value >= min;
+  }
+
+  private static boolean intPropAtMost(Properties props, String key, int max) {
+    Integer value = parseIntProp(props, key);
+    return value != null && value <= max;
+  }
+
+  /** Null on an unparseable value, so idempotence stays off and producer validation speaks. */
+  private static Integer parseIntProp(Properties props, String key) {
+    try {
+      return Integer.parseInt(String.valueOf(props.get(key)).trim());
+    } catch (NumberFormatException e) {
+      return null;
     }
   }
 

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkConfigValidator.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkConfigValidator.java
@@ -57,6 +57,12 @@ public class KafkaSinkConfigValidator implements ConfigValidator {
     if (StringUtils.isNotBlank(config.getPartitionKeyFieldExpressionStr())) {
       PathExpression.fromString(config.getPartitionKeyFieldExpressionStr());
     }
+    if (config.isStoreAndForwardEnabled()
+        && config.getDeliveryMode() == KafkaSinkDto.DeliveryMode.FIRE_AND_FORGET) {
+      throw new IllegalArgumentException(
+          "storeAndForwardEnabled requires waiting for broker acks and cannot be combined with"
+              + " deliveryMode FIRE_AND_FORGET");
+    }
     if (config.isStoreAndForwardEnabled()) {
       if (config.getLocalStoreMaxBytes() <= 0) {
         throw new IllegalArgumentException(

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkConfigValidator.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkConfigValidator.java
@@ -57,13 +57,12 @@ public class KafkaSinkConfigValidator implements ConfigValidator {
     if (StringUtils.isNotBlank(config.getPartitionKeyFieldExpressionStr())) {
       PathExpression.fromString(config.getPartitionKeyFieldExpressionStr());
     }
-    if (config.isStoreAndForwardEnabled()
-        && config.getDeliveryMode() == KafkaSinkDto.DeliveryMode.FIRE_AND_FORGET) {
-      throw new IllegalArgumentException(
-          "storeAndForwardEnabled requires waiting for broker acks and cannot be combined with"
-              + " deliveryMode FIRE_AND_FORGET");
-    }
     if (config.isStoreAndForwardEnabled()) {
+      if (config.getDeliveryMode() == KafkaSinkDto.DeliveryMode.FIRE_AND_FORGET) {
+        throw new IllegalArgumentException(
+            "storeAndForwardEnabled requires waiting for broker acks and cannot be combined with"
+                + " deliveryMode FIRE_AND_FORGET");
+      }
       if (config.getLocalStoreMaxBytes() <= 0) {
         throw new IllegalArgumentException(
             "localStoreMaxBytes must be positive when storeAndForwardEnabled. Got: "

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDto.java
@@ -25,8 +25,10 @@ public interface KafkaSinkDto {
    */
   enum DeliveryMode {
     /**
-     * Default. Send the batch, then wait for a broker ack of every record before returning. One
-     * broker round-trip per batch (Kafka's native batching is preserved), no silent loss on crash.
+     * Default. Send the batch, then wait for a broker ack of every record before returning — no
+     * silent loss on crash. Costs one broker round-trip per flushed batch; since the source
+     * typically hands the sink one record per accept(), that usually means one round-trip per
+     * source record. Latency-sensitive users who have measured should consider FIRE_AND_FORGET.
      */
     WAIT_FOR_ACK,
     /**

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDto.java
@@ -19,13 +19,19 @@ import lombok.*;
 
 public interface KafkaSinkDto {
 
-  /** Controls when the sink reports a flushed batch as delivered. */
+  /**
+   * Controls when the sink reports a flushed batch as delivered. Defaults to {@link #WAIT_FOR_ACK}.
+   */
   enum DeliveryMode {
-    /** Wait for a broker acknowledgement of every record before returning. Default. */
+    /**
+     * The default: wait for a broker acknowledgement of every record before returning, so a crash
+     * cannot lose records the source has already checkpointed past.
+     */
     WAIT_FOR_ACK,
     /**
-     * Return once records are handed to the producer's client-side buffer; records still buffered
-     * when the process crashes are lost.
+     * Explicit opt-in for throughput over durability: return once records are handed to the
+     * producer's client-side buffer without waiting for broker acknowledgements. Records still
+     * buffered when the process crashes are lost.
      */
     FIRE_AND_FORGET
   }
@@ -45,7 +51,10 @@ public interface KafkaSinkDto {
     private String securityProtocol;
     private String saslMechanism;
 
-    /** Cannot be {@code FIRE_AND_FORGET} when {@link #storeAndForwardEnabled} is set. */
+    /**
+     * Defaults to {@link DeliveryMode#WAIT_FOR_ACK}. Cannot be {@code FIRE_AND_FORGET} when {@link
+     * #storeAndForwardEnabled} is set.
+     */
     @Builder.Default private DeliveryMode deliveryMode = DeliveryMode.WAIT_FOR_ACK;
 
     /**

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDto.java
@@ -18,6 +18,25 @@ import java.util.Map;
 import lombok.*;
 
 public interface KafkaSinkDto {
+
+  /**
+   * When the sink's flush is allowed to return. The source checkpoint advances as soon as the sink
+   * returns, so this is the pipeline's delivery guarantee.
+   */
+  enum DeliveryMode {
+    /**
+     * Default. Send the batch, then wait for a broker ack of every record before returning. One
+     * broker round-trip per batch (Kafka's native batching is preserved), no silent loss on crash.
+     */
+    WAIT_FOR_ACK,
+    /**
+     * Return as soon as records are handed to the Kafka producer's client-side buffer. Highest
+     * throughput, but records still buffered at crash time are silently lost even though the source
+     * checkpoint has already advanced past them.
+     */
+    FIRE_AND_FORGET
+  }
+
   @Data
   @Builder
   @NoArgsConstructor
@@ -32,6 +51,22 @@ public interface KafkaSinkDto {
     private String credentialId;
     private String securityProtocol;
     private String saslMechanism;
+
+    /**
+     * Delivery guarantee for the flush path; see {@link DeliveryMode}. {@code FIRE_AND_FORGET} is
+     * an explicit throughput-over-durability opt-in and cannot be combined with {@link
+     * #storeAndForwardEnabled}.
+     */
+    @Builder.Default private DeliveryMode deliveryMode = DeliveryMode.WAIT_FOR_ACK;
+
+    /**
+     * Never returns null: a config deserialized without the field (Jackson uses the no-args
+     * constructor, which skips {@code @Builder.Default} initializers) must still get the durable
+     * default.
+     */
+    public DeliveryMode getDeliveryMode() {
+      return deliveryMode == null ? DeliveryMode.WAIT_FOR_ACK : deliveryMode;
+    }
 
     /**
      * Store-and-forward: when enabled, a connectivity failure persists records to a local durable

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDto.java
@@ -19,22 +19,13 @@ import lombok.*;
 
 public interface KafkaSinkDto {
 
-  /**
-   * When the sink's flush is allowed to return. The source checkpoint advances as soon as the sink
-   * returns, so this is the pipeline's delivery guarantee.
-   */
+  /** Controls when the sink reports a flushed batch as delivered. */
   enum DeliveryMode {
-    /**
-     * Default. Send the batch, then wait for a broker ack of every record before returning — no
-     * silent loss on crash. Costs one broker round-trip per flushed batch; since the source
-     * typically hands the sink one record per accept(), that usually means one round-trip per
-     * source record. Latency-sensitive users who have measured should consider FIRE_AND_FORGET.
-     */
+    /** Wait for a broker acknowledgement of every record before returning. Default. */
     WAIT_FOR_ACK,
     /**
-     * Return as soon as records are handed to the Kafka producer's client-side buffer. Highest
-     * throughput, but records still buffered at crash time are silently lost even though the source
-     * checkpoint has already advanced past them.
+     * Return once records are handed to the producer's client-side buffer; records still buffered
+     * when the process crashes are lost.
      */
     FIRE_AND_FORGET
   }
@@ -54,17 +45,12 @@ public interface KafkaSinkDto {
     private String securityProtocol;
     private String saslMechanism;
 
-    /**
-     * Delivery guarantee for the flush path; see {@link DeliveryMode}. {@code FIRE_AND_FORGET} is
-     * an explicit throughput-over-durability opt-in and cannot be combined with {@link
-     * #storeAndForwardEnabled}.
-     */
+    /** Cannot be {@code FIRE_AND_FORGET} when {@link #storeAndForwardEnabled} is set. */
     @Builder.Default private DeliveryMode deliveryMode = DeliveryMode.WAIT_FOR_ACK;
 
     /**
-     * Never returns null: a config deserialized without the field (Jackson uses the no-args
-     * constructor, which skips {@code @Builder.Default} initializers) must still get the durable
-     * default.
+     * Jackson deserializes through the no-args constructor, which skips {@code @Builder.Default}
+     * initializers, so a config without the field must still resolve to the default here.
      */
     public DeliveryMode getDeliveryMode() {
       return deliveryMode == null ? DeliveryMode.WAIT_FOR_ACK : deliveryMode;

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDto.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDto.java
@@ -19,20 +19,8 @@ import lombok.*;
 
 public interface KafkaSinkDto {
 
-  /**
-   * Controls when the sink reports a flushed batch as delivered. Defaults to {@link #WAIT_FOR_ACK}.
-   */
   enum DeliveryMode {
-    /**
-     * The default: wait for a broker acknowledgement of every record before returning, so a crash
-     * cannot lose records the source has already checkpointed past.
-     */
     WAIT_FOR_ACK,
-    /**
-     * Explicit opt-in for throughput over durability: return once records are handed to the
-     * producer's client-side buffer without waiting for broker acknowledgements. Records still
-     * buffered when the process crashes are lost.
-     */
     FIRE_AND_FORGET
   }
 

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkFlusher.java
@@ -37,16 +37,14 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.PartitionInfo;
 
 /**
- * Kafka sink flusher with two delivery modes. In <b>synchronous</b> mode (the command default,
- * {@code deliveryMode: WAIT_FOR_ACK}; also always used by store-and-forward) it sends the batch,
- * flushes the producer, and waits for every broker ack before returning — one broker round-trip per
- * flushed batch (often per source record, since the upstream flushes once per accept()). This
- * matters because the source checkpoint advances as soon as flush returns (FLE-2366). With
- * store-and-forward it additionally <b>throws</b> a classified connectivity failure so {@link
- * SimpleSinkCommand} can buffer the batch locally and replay it once the broker is reachable again.
- * In <b>fire-and-forget</b> mode ({@code deliveryMode: FIRE_AND_FORGET}, explicit opt-in) it
- * returns as soon as records are in the producer's client-side buffer and reports delivery via
- * async callbacks; records still buffered when the process dies are silently lost.
+ * Kafka sink flusher with two delivery modes. In <b>synchronous</b> mode (the default, {@code
+ * deliveryMode: WAIT_FOR_ACK}; always used by store-and-forward) it sends the batch, flushes the
+ * producer, and waits for every broker acknowledgement before returning, because the source
+ * checkpoint advances as soon as the flush returns. With store-and-forward it additionally
+ * <b>throws</b> a classified connectivity failure so {@link SimpleSinkCommand} can buffer the batch
+ * locally and replay it once the broker is reachable again. In <b>fire-and-forget</b> mode ({@code
+ * deliveryMode: FIRE_AND_FORGET}) it returns as soon as records are in the producer's client-side
+ * buffer and reports delivery via async callbacks.
  */
 @Slf4j
 public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakData> {
@@ -59,14 +57,12 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
   private final FleakCounter asyncDeliveredSizeCounter;
   private final FleakCounter asyncErrorCounter;
 
-  // Synchronous delivery: when enabled the flusher waits for acks. The classifier (null in
-  // fire-and-forget mode) lets the pre-send metadata probe fail the whole batch after one bounded
-  // wait during an outage. Only with bufferBatchOnConnectivityFailure (store-and-forward enrolled)
-  // are connectivity failures ALSO rethrown mid-batch so the batch gets buffered and replayed;
-  // without it a mid-batch throw would misreport records whose acks already succeeded, so those
-  // failures stay per-record ErrorOutputs instead.
   private final boolean synchronousDelivery;
   private final ConnectionFailureClassifier connectionFailureClassifier;
+
+  // Mid-batch connectivity failures are rethrown only when store-and-forward can buffer and
+  // replay the whole batch; without that, records whose acks already succeeded would be
+  // misreported as failed.
   private final boolean bufferBatchOnConnectivityFailure;
 
   private volatile boolean closed = false;
@@ -192,11 +188,8 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
             producer.send(new ProducerRecord<>(topic, keyBytes(event), eventValue));
         inflight.add(new Inflight(event, eventValue.length, future));
       } catch (Exception e) {
-        // Mid-batch throws are for store-and-forward only: earlier records of this batch are
-        // already in flight and may be delivered, so without a buffer+replay path a batch-level
-        // failure would misreport them. S&F accepts that as at-least-once.
         if (bufferBatchOnConnectivityFailure) {
-          rethrowIfConnectivity(e); // this record never reached the broker
+          rethrowIfConnectivity(e);
         }
         errorOutputs.add(new ErrorOutput(event, e.getMessage()));
       }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkFlusher.java
@@ -37,11 +37,16 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.PartitionInfo;
 
 /**
- * Kafka sink flusher. By default it is fire-and-forget (relies on Kafka's native batching for
- * throughput and reports delivery via async callbacks). When constructed in <b>synchronous</b> mode
- * (used by store-and-forward), it instead waits for acks and <b>throws</b> a connectivity failure
- * when delivery fails, so {@link SimpleSinkCommand} can buffer the batch locally and replay it once
- * the broker is reachable again.
+ * Kafka sink flusher with two delivery modes. In <b>synchronous</b> mode (the command default,
+ * {@code deliveryMode: WAIT_FOR_ACK}; also always used by store-and-forward) it sends the batch,
+ * flushes the producer, and waits for every broker ack before returning — one broker round-trip per
+ * batch, preserving Kafka's native batching. This matters because the source checkpoint advances as
+ * soon as flush returns (FLE-2366). With store-and-forward it additionally <b>throws</b> a
+ * classified connectivity failure so {@link SimpleSinkCommand} can buffer the batch locally and
+ * replay it once the broker is reachable again. In <b>fire-and-forget</b> mode ({@code
+ * deliveryMode: FIRE_AND_FORGET}, explicit opt-in) it returns as soon as records are in the
+ * producer's client-side buffer and reports delivery via async callbacks; records still buffered
+ * when the process dies are silently lost.
  */
 @Slf4j
 public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakData> {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkFlusher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkFlusher.java
@@ -40,13 +40,13 @@ import org.apache.kafka.common.PartitionInfo;
  * Kafka sink flusher with two delivery modes. In <b>synchronous</b> mode (the command default,
  * {@code deliveryMode: WAIT_FOR_ACK}; also always used by store-and-forward) it sends the batch,
  * flushes the producer, and waits for every broker ack before returning — one broker round-trip per
- * batch, preserving Kafka's native batching. This matters because the source checkpoint advances as
- * soon as flush returns (FLE-2366). With store-and-forward it additionally <b>throws</b> a
- * classified connectivity failure so {@link SimpleSinkCommand} can buffer the batch locally and
- * replay it once the broker is reachable again. In <b>fire-and-forget</b> mode ({@code
- * deliveryMode: FIRE_AND_FORGET}, explicit opt-in) it returns as soon as records are in the
- * producer's client-side buffer and reports delivery via async callbacks; records still buffered
- * when the process dies are silently lost.
+ * flushed batch (often per source record, since the upstream flushes once per accept()). This
+ * matters because the source checkpoint advances as soon as flush returns (FLE-2366). With
+ * store-and-forward it additionally <b>throws</b> a classified connectivity failure so {@link
+ * SimpleSinkCommand} can buffer the batch locally and replay it once the broker is reachable again.
+ * In <b>fire-and-forget</b> mode ({@code deliveryMode: FIRE_AND_FORGET}, explicit opt-in) it
+ * returns as soon as records are in the producer's client-side buffer and reports delivery via
+ * async callbacks; records still buffered when the process dies are silently lost.
  */
 @Slf4j
 public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakData> {
@@ -59,10 +59,15 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
   private final FleakCounter asyncDeliveredSizeCounter;
   private final FleakCounter asyncErrorCounter;
 
-  // Synchronous delivery: when enabled the flusher waits for acks and throws connectivity failures
-  // (classified via this classifier) so store-and-forward can buffer + replay. Null in async mode.
+  // Synchronous delivery: when enabled the flusher waits for acks. The classifier (null in
+  // fire-and-forget mode) lets the pre-send metadata probe fail the whole batch after one bounded
+  // wait during an outage. Only with bufferBatchOnConnectivityFailure (store-and-forward enrolled)
+  // are connectivity failures ALSO rethrown mid-batch so the batch gets buffered and replayed;
+  // without it a mid-batch throw would misreport records whose acks already succeeded, so those
+  // failures stay per-record ErrorOutputs instead.
   private final boolean synchronousDelivery;
   private final ConnectionFailureClassifier connectionFailureClassifier;
+  private final boolean bufferBatchOnConnectivityFailure;
 
   private volatile boolean closed = false;
 
@@ -83,7 +88,8 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
         asyncDeliveredSizeCounter,
         asyncErrorCounter,
         false,
-        null);
+        null,
+        false);
   }
 
   public KafkaSinkFlusher(
@@ -95,7 +101,8 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
       @NonNull FleakCounter asyncDeliveredSizeCounter,
       @NonNull FleakCounter asyncErrorCounter,
       boolean synchronousDelivery,
-      ConnectionFailureClassifier connectionFailureClassifier) {
+      ConnectionFailureClassifier connectionFailureClassifier,
+      boolean bufferBatchOnConnectivityFailure) {
     this.producer = producer;
     this.topic = topic;
     this.fleakSerializer = fleakSerializer;
@@ -105,6 +112,7 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
     this.asyncErrorCounter = asyncErrorCounter;
     this.synchronousDelivery = synchronousDelivery;
     this.connectionFailureClassifier = connectionFailureClassifier;
+    this.bufferBatchOnConnectivityFailure = bufferBatchOnConnectivityFailure;
   }
 
   @Override
@@ -184,7 +192,12 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
             producer.send(new ProducerRecord<>(topic, keyBytes(event), eventValue));
         inflight.add(new Inflight(event, eventValue.length, future));
       } catch (Exception e) {
-        rethrowIfConnectivity(e); // never reached the broker
+        // Mid-batch throws are for store-and-forward only: earlier records of this batch are
+        // already in flight and may be delivered, so without a buffer+replay path a batch-level
+        // failure would misreport them. S&F accepts that as at-least-once.
+        if (bufferBatchOnConnectivityFailure) {
+          rethrowIfConnectivity(e); // this record never reached the broker
+        }
         errorOutputs.add(new ErrorOutput(event, e.getMessage()));
       }
     }
@@ -201,7 +214,9 @@ public class KafkaSinkFlusher implements SimpleSinkCommand.Flusher<RecordFleakDa
         asyncDeliveredCountCounter.increase(metricTags);
         asyncDeliveredSizeCounter.increase(item.size, metricTags);
       } catch (ExecutionException e) {
-        rethrowIfConnectivity(e.getCause());
+        if (bufferBatchOnConnectivityFailure) {
+          rethrowIfConnectivity(e.getCause());
+        }
         errorOutputs.add(new ErrorOutput(item.event, e.getCause().getMessage()));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkConfigValidatorTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkConfigValidatorTest.java
@@ -61,6 +61,27 @@ class KafkaSinkConfigValidatorTest {
   }
 
   @Test
+  void validateConfig_storeAndForwardWithFireAndForget_rejected() {
+    // storeAndForward requires synchronous delivery to detect failures at flush time; combining it
+    // with fire-and-forget is contradictory and must be rejected loudly.
+    KafkaSinkDto.Config config =
+        KafkaSinkDto.Config.builder()
+            .broker("localhost:9092")
+            .topic("test-topic")
+            .encodingType(EncodingType.JSON_OBJECT.name())
+            .storeAndForwardEnabled(true)
+            .deliveryMode(KafkaSinkDto.DeliveryMode.FIRE_AND_FORGET)
+            .build();
+
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> validator.validateConfig(config, "test-node", null));
+    assertTrue(exception.getMessage().contains("storeAndForwardEnabled"), exception.getMessage());
+    assertTrue(exception.getMessage().contains("FIRE_AND_FORGET"), exception.getMessage());
+  }
+
+  @Test
   void validateConfig_missingTopic() {
     KafkaSinkDto.Config config =
         KafkaSinkDto.Config.builder()

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkConfigValidatorTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkConfigValidatorTest.java
@@ -62,8 +62,6 @@ class KafkaSinkConfigValidatorTest {
 
   @Test
   void validateConfig_storeAndForwardWithFireAndForget_rejected() {
-    // storeAndForward requires synchronous delivery to detect failures at flush time; combining it
-    // with fire-and-forget is contradictory and must be rejected loudly.
     KafkaSinkDto.Config config =
         KafkaSinkDto.Config.builder()
             .broker("localhost:9092")

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDeliveryModeTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDeliveryModeTest.java
@@ -29,23 +29,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
-/**
- * FLE-2366: kafkasink's default delivery mode must wait for broker acks before {@code flush()}
- * returns. The source checkpoint advances as soon as the sink returns, so a flusher that returns
- * while records are still in the producer's client-side accumulator turns a crash (SIGKILL) into
- * silent, unrecoverable data loss. Fire-and-forget is throughput-over-durability and must be an
- * explicit opt-in, decoupled from store-and-forward.
- */
+/** Delivery-mode selection and producer configuration for {@link KafkaSinkCommand} (FLE-2366). */
 class KafkaSinkDeliveryModeTest {
 
   private static final String TOPIC = "delivery_mode_topic";
@@ -57,7 +53,7 @@ class KafkaSinkDeliveryModeTest {
           (RecordFleakData) FleakData.wrap(Map.of("num", 2)));
 
   private KafkaProducer<byte[], byte[]> mockProducer;
-  private Properties capturedProducerProps;
+  private Properties capturedProducerProperties;
 
   @BeforeEach
   @SuppressWarnings("unchecked")
@@ -65,33 +61,36 @@ class KafkaSinkDeliveryModeTest {
     mockProducer = mock(KafkaProducer.class);
     when(mockProducer.partitionsFor(TOPIC))
         .thenReturn(List.of(new PartitionInfo(TOPIC, 0, null, null, null)));
-    // Synchronous path: send(record) returns an already-acked future.
     when(mockProducer.send(any(ProducerRecord.class)))
-        .thenAnswer(inv -> CompletableFuture.completedFuture(mock(RecordMetadata.class)));
-    // Fire-and-forget path: send(record, callback) reports success via the callback.
+        .thenAnswer(invocation -> CompletableFuture.completedFuture(mock(RecordMetadata.class)));
     when(mockProducer.send(any(ProducerRecord.class), any(Callback.class)))
         .thenAnswer(
-            inv -> {
-              Callback callback = inv.getArgument(1);
+            invocation -> {
+              Callback callback = invocation.getArgument(1);
               callback.onCompletion(mock(RecordMetadata.class), null);
               return CompletableFuture.completedFuture(mock(RecordMetadata.class));
             });
   }
 
   private KafkaSinkCommand buildCommand(KafkaSinkDto.Config config) {
-    KafkaProducerClientFactory producerFactory =
+    Map<String, Object> configMap = OBJECT_MAPPER.convertValue(config, new TypeReference<>() {});
+    return buildCommandFromConfigMap(configMap);
+  }
+
+  private KafkaSinkCommand buildCommandFromConfigMap(Map<String, Object> configMap) {
+    KafkaProducerClientFactory producerClientFactory =
         new KafkaProducerClientFactory() {
           @Override
-          KafkaProducer<byte[], byte[]> createKafkaProducer(Properties props) {
-            capturedProducerProps = props;
+          KafkaProducer<byte[], byte[]> createKafkaProducer(Properties producerProperties) {
+            capturedProducerProperties = producerProperties;
             return mockProducer;
           }
         };
     KafkaSinkCommand command =
         (KafkaSinkCommand)
-            new KafkaSinkCommandFactory(producerFactory)
+            new KafkaSinkCommandFactory(producerClientFactory)
                 .createCommand("delivery_mode_node", TestUtils.JOB_CONTEXT);
-    command.parseAndValidateArg(OBJECT_MAPPER.convertValue(config, new TypeReference<>() {}));
+    command.parseAndValidateArg(configMap);
     command.initialize(new MetricClientProvider.NoopMetricClientProvider());
     return command;
   }
@@ -104,16 +103,13 @@ class KafkaSinkDeliveryModeTest {
   }
 
   @Test
-  void defaultDeliveryMode_waitsForBrokerAcks() {
+  void defaultDeliveryMode_sendsBatchThenFlushesAndWaitsForBrokerAcks() {
     KafkaSinkCommand command = buildCommand(baseConfig().build());
 
     ScalarSinkCommand.SinkResult result =
         command.writeToSink(EVENTS, "test_user", command.getExecutionContext());
 
     assertEquals(EVENTS.size(), result.getSuccessCount());
-    // Synchronous shape: every record sent without a callback, then one producer.flush(), then the
-    // per-record futures are awaited. Fire-and-forget would use send(record, callback) and never
-    // call flush().
     InOrder inOrder = inOrder(mockProducer);
     inOrder.verify(mockProducer, times(EVENTS.size())).send(any(ProducerRecord.class));
     inOrder.verify(mockProducer).flush();
@@ -121,11 +117,11 @@ class KafkaSinkDeliveryModeTest {
   }
 
   @Test
-  void defaultDeliveryMode_producerIsDurable() {
+  void defaultDeliveryMode_enablesAcksAllAndIdempotence() {
     buildCommand(baseConfig().build());
 
-    assertEquals("all", capturedProducerProps.get(ProducerConfig.ACKS_CONFIG));
-    assertEquals("true", capturedProducerProps.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
+    assertEquals("all", capturedProducerProperties.get(ProducerConfig.ACKS_CONFIG));
+    assertEquals("true", capturedProducerProperties.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
   }
 
   @Test
@@ -143,54 +139,46 @@ class KafkaSinkDeliveryModeTest {
   }
 
   @Test
-  void fireAndForgetOptIn_keepsThroughputProducerProps() {
+  void fireAndForgetOptIn_keepsAcksOneWithoutIdempotence() {
     buildCommand(baseConfig().deliveryMode(KafkaSinkDto.DeliveryMode.FIRE_AND_FORGET).build());
 
-    assertEquals("1", capturedProducerProps.get(ProducerConfig.ACKS_CONFIG));
-    assertNull(capturedProducerProps.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
+    assertEquals("1", capturedProducerProperties.get(ProducerConfig.ACKS_CONFIG));
+    assertNull(capturedProducerProperties.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
   }
 
   @Test
   void userAcksOverride_suppressesIdempotence() {
-    // A user explicitly weakening acks must not collide with enable.idempotence=true, which the
-    // producer rejects at construction time unless acks=all.
     buildCommand(baseConfig().properties(Map.of(ProducerConfig.ACKS_CONFIG, "1")).build());
 
-    assertEquals("1", capturedProducerProps.get(ProducerConfig.ACKS_CONFIG));
-    assertNull(capturedProducerProps.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
+    assertEquals("1", capturedProducerProperties.get(ProducerConfig.ACKS_CONFIG));
+    assertNull(capturedProducerProperties.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
   }
 
   @Test
   void userRetriesZeroOverride_suppressesIdempotence() {
-    // enable.idempotence=true also requires retries > 0; a pre-existing config that pinned
-    // retries=0 must keep constructing a valid producer.
     buildCommand(baseConfig().properties(Map.of(ProducerConfig.RETRIES_CONFIG, "0")).build());
 
-    assertEquals("0", capturedProducerProps.get(ProducerConfig.RETRIES_CONFIG));
-    assertNull(capturedProducerProps.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
+    assertEquals("0", capturedProducerProperties.get(ProducerConfig.RETRIES_CONFIG));
+    assertNull(capturedProducerProperties.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
   }
 
   @Test
   void userMaxInFlightOverride_suppressesIdempotence() {
-    // enable.idempotence=true requires max.in.flight <= 5; same backward-compat concern.
     buildCommand(
         baseConfig()
             .properties(Map.of(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "6"))
             .build());
 
-    assertNull(capturedProducerProps.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
+    assertNull(capturedProducerProperties.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
   }
 
   @Test
-  void waitForAck_failedAckBecomesErrorOutput_notSuccess() {
-    // The heart of FLE-2366: a record whose broker ack fails must never be reported as delivered,
-    // because the source checkpoint advances on the sink's word.
-    java.util.concurrent.atomic.AtomicInteger sendCount =
-        new java.util.concurrent.atomic.AtomicInteger();
+  void defaultDeliveryMode_failedBrokerAckBecomesErrorOutputNotSuccess() {
+    AtomicInteger sendInvocations = new AtomicInteger();
     when(mockProducer.send(any(ProducerRecord.class)))
         .thenAnswer(
-            inv ->
-                sendCount.incrementAndGet() == 2
+            invocation ->
+                sendInvocations.incrementAndGet() == 2
                     ? CompletableFuture.failedFuture(new RuntimeException("ack failed"))
                     : CompletableFuture.completedFuture(mock(RecordMetadata.class)));
 
@@ -203,11 +191,8 @@ class KafkaSinkDeliveryModeTest {
   }
 
   @Test
-  void waitForAck_brokerUnreachable_failsBatchBeforeAnySend() {
-    // During an outage the pre-send metadata probe must fail the whole batch after ONE bounded
-    // wait instead of silently proceeding into per-record max.block.ms waits.
-    when(mockProducer.partitionsFor(TOPIC))
-        .thenThrow(new org.apache.kafka.common.errors.TimeoutException("no metadata"));
+  void defaultDeliveryMode_unreachableBrokerFailsBatchBeforeAnySend() {
+    when(mockProducer.partitionsFor(TOPIC)).thenThrow(new TimeoutException("no metadata"));
 
     KafkaSinkCommand command = buildCommand(baseConfig().build());
     ScalarSinkCommand.SinkResult result =
@@ -220,38 +205,15 @@ class KafkaSinkDeliveryModeTest {
   }
 
   @Test
-  void legacyConfigWithoutDeliveryModeField_getsDurableDefault() {
-    // Configs written before this field existed arrive as raw maps with no deliveryMode key and
-    // are deserialized through the no-args constructor, which skips @Builder.Default. They must
-    // still get the ack-waiting default.
-    KafkaProducerClientFactory producerFactory =
-        new KafkaProducerClientFactory() {
-          @Override
-          KafkaProducer<byte[], byte[]> createKafkaProducer(Properties props) {
-            capturedProducerProps = props;
-            return mockProducer;
-          }
-        };
+  void configWithoutDeliveryModeField_defaultsToWaitForAck() {
     KafkaSinkCommand command =
-        (KafkaSinkCommand)
-            new KafkaSinkCommandFactory(producerFactory)
-                .createCommand("legacy_config_node", TestUtils.JOB_CONTEXT);
-    command.parseAndValidateArg(
-        Map.of("broker", "localhost:9092", "topic", TOPIC, "encodingType", "JSON_OBJECT"));
-    command.initialize(new MetricClientProvider.NoopMetricClientProvider());
+        buildCommandFromConfigMap(
+            Map.of("broker", "localhost:9092", "topic", TOPIC, "encodingType", "JSON_OBJECT"));
 
     command.writeToSink(EVENTS, "test_user", command.getExecutionContext());
 
-    assertEquals("all", capturedProducerProps.get(ProducerConfig.ACKS_CONFIG));
+    assertEquals("all", capturedProducerProperties.get(ProducerConfig.ACKS_CONFIG));
     verify(mockProducer).flush();
     verify(mockProducer, never()).send(any(ProducerRecord.class), any(Callback.class));
-  }
-
-  @Test
-  void storeAndForward_impliesWaitForAck() {
-    // storeAndForwardEnabled has always meant synchronous delivery; the new default must not
-    // change that, and the two knobs must agree.
-    KafkaSinkDto.Config config = baseConfig().storeAndForwardEnabled(true).build();
-    assertEquals(KafkaSinkDto.DeliveryMode.WAIT_FOR_ACK, config.getDeliveryMode());
   }
 }

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDeliveryModeTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDeliveryModeTest.java
@@ -161,6 +161,93 @@ class KafkaSinkDeliveryModeTest {
   }
 
   @Test
+  void userRetriesZeroOverride_suppressesIdempotence() {
+    // enable.idempotence=true also requires retries > 0; a pre-existing config that pinned
+    // retries=0 must keep constructing a valid producer.
+    buildCommand(baseConfig().properties(Map.of(ProducerConfig.RETRIES_CONFIG, "0")).build());
+
+    assertEquals("0", capturedProducerProps.get(ProducerConfig.RETRIES_CONFIG));
+    assertNull(capturedProducerProps.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
+  }
+
+  @Test
+  void userMaxInFlightOverride_suppressesIdempotence() {
+    // enable.idempotence=true requires max.in.flight <= 5; same backward-compat concern.
+    buildCommand(
+        baseConfig()
+            .properties(Map.of(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "6"))
+            .build());
+
+    assertNull(capturedProducerProps.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
+  }
+
+  @Test
+  void waitForAck_failedAckBecomesErrorOutput_notSuccess() {
+    // The heart of FLE-2366: a record whose broker ack fails must never be reported as delivered,
+    // because the source checkpoint advances on the sink's word.
+    java.util.concurrent.atomic.AtomicInteger sendCount =
+        new java.util.concurrent.atomic.AtomicInteger();
+    when(mockProducer.send(any(ProducerRecord.class)))
+        .thenAnswer(
+            inv ->
+                sendCount.incrementAndGet() == 2
+                    ? CompletableFuture.failedFuture(new RuntimeException("ack failed"))
+                    : CompletableFuture.completedFuture(mock(RecordMetadata.class)));
+
+    KafkaSinkCommand command = buildCommand(baseConfig().build());
+    ScalarSinkCommand.SinkResult result =
+        command.writeToSink(EVENTS, "test_user", command.getExecutionContext());
+
+    assertEquals(EVENTS.size() - 1, result.getSuccessCount());
+    assertEquals(1, result.errorCount());
+  }
+
+  @Test
+  void waitForAck_brokerUnreachable_failsBatchBeforeAnySend() {
+    // During an outage the pre-send metadata probe must fail the whole batch after ONE bounded
+    // wait instead of silently proceeding into per-record max.block.ms waits.
+    when(mockProducer.partitionsFor(TOPIC))
+        .thenThrow(new org.apache.kafka.common.errors.TimeoutException("no metadata"));
+
+    KafkaSinkCommand command = buildCommand(baseConfig().build());
+    ScalarSinkCommand.SinkResult result =
+        command.writeToSink(EVENTS, "test_user", command.getExecutionContext());
+
+    assertEquals(0, result.getSuccessCount());
+    assertEquals(EVENTS.size(), result.errorCount());
+    verify(mockProducer, never()).send(any(ProducerRecord.class));
+    verify(mockProducer, never()).send(any(ProducerRecord.class), any(Callback.class));
+  }
+
+  @Test
+  void legacyConfigWithoutDeliveryModeField_getsDurableDefault() {
+    // Configs written before this field existed arrive as raw maps with no deliveryMode key and
+    // are deserialized through the no-args constructor, which skips @Builder.Default. They must
+    // still get the ack-waiting default.
+    KafkaProducerClientFactory producerFactory =
+        new KafkaProducerClientFactory() {
+          @Override
+          KafkaProducer<byte[], byte[]> createKafkaProducer(Properties props) {
+            capturedProducerProps = props;
+            return mockProducer;
+          }
+        };
+    KafkaSinkCommand command =
+        (KafkaSinkCommand)
+            new KafkaSinkCommandFactory(producerFactory)
+                .createCommand("legacy_config_node", TestUtils.JOB_CONTEXT);
+    command.parseAndValidateArg(
+        Map.of("broker", "localhost:9092", "topic", TOPIC, "encodingType", "JSON_OBJECT"));
+    command.initialize(new MetricClientProvider.NoopMetricClientProvider());
+
+    command.writeToSink(EVENTS, "test_user", command.getExecutionContext());
+
+    assertEquals("all", capturedProducerProps.get(ProducerConfig.ACKS_CONFIG));
+    verify(mockProducer).flush();
+    verify(mockProducer, never()).send(any(ProducerRecord.class), any(Callback.class));
+  }
+
+  @Test
   void storeAndForward_impliesWaitForAck() {
     // storeAndForwardEnabled has always meant synchronous delivery; the new default must not
     // change that, and the two knobs must agree.

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDeliveryModeTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasink/KafkaSinkDeliveryModeTest.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.kafkasink;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.OBJECT_MAPPER;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.fleak.zephflow.api.ScalarSinkCommand;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.api.structure.FleakData;
+import io.fleak.zephflow.api.structure.RecordFleakData;
+import io.fleak.zephflow.lib.TestUtils;
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.PartitionInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+/**
+ * FLE-2366: kafkasink's default delivery mode must wait for broker acks before {@code flush()}
+ * returns. The source checkpoint advances as soon as the sink returns, so a flusher that returns
+ * while records are still in the producer's client-side accumulator turns a crash (SIGKILL) into
+ * silent, unrecoverable data loss. Fire-and-forget is throughput-over-durability and must be an
+ * explicit opt-in, decoupled from store-and-forward.
+ */
+class KafkaSinkDeliveryModeTest {
+
+  private static final String TOPIC = "delivery_mode_topic";
+
+  private static final List<RecordFleakData> EVENTS =
+      List.of(
+          (RecordFleakData) FleakData.wrap(Map.of("num", 0)),
+          (RecordFleakData) FleakData.wrap(Map.of("num", 1)),
+          (RecordFleakData) FleakData.wrap(Map.of("num", 2)));
+
+  private KafkaProducer<byte[], byte[]> mockProducer;
+  private Properties capturedProducerProps;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    mockProducer = mock(KafkaProducer.class);
+    when(mockProducer.partitionsFor(TOPIC))
+        .thenReturn(List.of(new PartitionInfo(TOPIC, 0, null, null, null)));
+    // Synchronous path: send(record) returns an already-acked future.
+    when(mockProducer.send(any(ProducerRecord.class)))
+        .thenAnswer(inv -> CompletableFuture.completedFuture(mock(RecordMetadata.class)));
+    // Fire-and-forget path: send(record, callback) reports success via the callback.
+    when(mockProducer.send(any(ProducerRecord.class), any(Callback.class)))
+        .thenAnswer(
+            inv -> {
+              Callback callback = inv.getArgument(1);
+              callback.onCompletion(mock(RecordMetadata.class), null);
+              return CompletableFuture.completedFuture(mock(RecordMetadata.class));
+            });
+  }
+
+  private KafkaSinkCommand buildCommand(KafkaSinkDto.Config config) {
+    KafkaProducerClientFactory producerFactory =
+        new KafkaProducerClientFactory() {
+          @Override
+          KafkaProducer<byte[], byte[]> createKafkaProducer(Properties props) {
+            capturedProducerProps = props;
+            return mockProducer;
+          }
+        };
+    KafkaSinkCommand command =
+        (KafkaSinkCommand)
+            new KafkaSinkCommandFactory(producerFactory)
+                .createCommand("delivery_mode_node", TestUtils.JOB_CONTEXT);
+    command.parseAndValidateArg(OBJECT_MAPPER.convertValue(config, new TypeReference<>() {}));
+    command.initialize(new MetricClientProvider.NoopMetricClientProvider());
+    return command;
+  }
+
+  private static KafkaSinkDto.Config.ConfigBuilder baseConfig() {
+    return KafkaSinkDto.Config.builder()
+        .topic(TOPIC)
+        .broker("localhost:9092")
+        .encodingType(EncodingType.JSON_OBJECT.toString());
+  }
+
+  @Test
+  void defaultDeliveryMode_waitsForBrokerAcks() {
+    KafkaSinkCommand command = buildCommand(baseConfig().build());
+
+    ScalarSinkCommand.SinkResult result =
+        command.writeToSink(EVENTS, "test_user", command.getExecutionContext());
+
+    assertEquals(EVENTS.size(), result.getSuccessCount());
+    // Synchronous shape: every record sent without a callback, then one producer.flush(), then the
+    // per-record futures are awaited. Fire-and-forget would use send(record, callback) and never
+    // call flush().
+    InOrder inOrder = inOrder(mockProducer);
+    inOrder.verify(mockProducer, times(EVENTS.size())).send(any(ProducerRecord.class));
+    inOrder.verify(mockProducer).flush();
+    verify(mockProducer, never()).send(any(ProducerRecord.class), any(Callback.class));
+  }
+
+  @Test
+  void defaultDeliveryMode_producerIsDurable() {
+    buildCommand(baseConfig().build());
+
+    assertEquals("all", capturedProducerProps.get(ProducerConfig.ACKS_CONFIG));
+    assertEquals("true", capturedProducerProps.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
+  }
+
+  @Test
+  void fireAndForgetOptIn_usesAsyncSendPath() {
+    KafkaSinkCommand command =
+        buildCommand(baseConfig().deliveryMode(KafkaSinkDto.DeliveryMode.FIRE_AND_FORGET).build());
+
+    ScalarSinkCommand.SinkResult result =
+        command.writeToSink(EVENTS, "test_user", command.getExecutionContext());
+
+    assertEquals(EVENTS.size(), result.getSuccessCount());
+    verify(mockProducer, times(EVENTS.size())).send(any(ProducerRecord.class), any(Callback.class));
+    verify(mockProducer, never()).send(any(ProducerRecord.class));
+    verify(mockProducer, never()).flush();
+  }
+
+  @Test
+  void fireAndForgetOptIn_keepsThroughputProducerProps() {
+    buildCommand(baseConfig().deliveryMode(KafkaSinkDto.DeliveryMode.FIRE_AND_FORGET).build());
+
+    assertEquals("1", capturedProducerProps.get(ProducerConfig.ACKS_CONFIG));
+    assertNull(capturedProducerProps.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
+  }
+
+  @Test
+  void userAcksOverride_suppressesIdempotence() {
+    // A user explicitly weakening acks must not collide with enable.idempotence=true, which the
+    // producer rejects at construction time unless acks=all.
+    buildCommand(baseConfig().properties(Map.of(ProducerConfig.ACKS_CONFIG, "1")).build());
+
+    assertEquals("1", capturedProducerProps.get(ProducerConfig.ACKS_CONFIG));
+    assertNull(capturedProducerProps.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
+  }
+
+  @Test
+  void storeAndForward_impliesWaitForAck() {
+    // storeAndForwardEnabled has always meant synchronous delivery; the new default must not
+    // change that, and the two knobs must agree.
+    KafkaSinkDto.Config config = baseConfig().storeAndForwardEnabled(true).build();
+    assertEquals(KafkaSinkDto.DeliveryMode.WAIT_FOR_ACK, config.getDeliveryMode());
+  }
+}

--- a/sdk/src/main/java/io/fleak/zephflow/sdk/ZephFlow.java
+++ b/sdk/src/main/java/io/fleak/zephflow/sdk/ZephFlow.java
@@ -488,13 +488,9 @@ public class ZephFlow {
   }
 
   /**
-   * Appends a Kafka sink node to the flow.
-   *
-   * <p>Delivery waits for broker acks by default ({@code deliveryMode: WAIT_FOR_ACK}, with {@code
-   * acks=all} and an idempotent producer), so a crash cannot silently lose records the source has
-   * already checkpointed past. To trade that guarantee for throughput, build a {@link
-   * KafkaSinkDto.Config} with {@link KafkaSinkDto.DeliveryMode#FIRE_AND_FORGET} and use {@link
-   * #appendNode(String, CommandConfig)} directly.
+   * Appends a Kafka sink node to the flow. Delivery waits for broker acknowledgements by default;
+   * to trade that guarantee for throughput, build a {@link KafkaSinkDto.Config} with {@link
+   * KafkaSinkDto.DeliveryMode#FIRE_AND_FORGET} and use {@link #appendNode(String, CommandConfig)}.
    *
    * @param broker The Kafka broker list (comma-separated).
    * @param topic The Kafka topic to produce to.

--- a/sdk/src/main/java/io/fleak/zephflow/sdk/ZephFlow.java
+++ b/sdk/src/main/java/io/fleak/zephflow/sdk/ZephFlow.java
@@ -490,6 +490,12 @@ public class ZephFlow {
   /**
    * Appends a Kafka sink node to the flow.
    *
+   * <p>Delivery waits for broker acks by default ({@code deliveryMode: WAIT_FOR_ACK}, with {@code
+   * acks=all} and an idempotent producer), so a crash cannot silently lose records the source has
+   * already checkpointed past. To trade that guarantee for throughput, build a {@link
+   * KafkaSinkDto.Config} with {@link KafkaSinkDto.DeliveryMode#FIRE_AND_FORGET} and use {@link
+   * #appendNode(String, CommandConfig)} directly.
+   *
    * @param broker The Kafka broker list (comma-separated).
    * @param topic The Kafka topic to produce to.
    * @param partitionKeyFieldExpressionStr Optional expression to determine the partition key field.


### PR DESCRIPTION
## Summary

On a hard kill (SIGKILL), a pipeline using kafkasink on default settings permanently lost every record still sitting in the Kafka producer's client-side accumulator — with **zero duplicates**, because the source checkpoint had already advanced past them. Reproduced against an Azure Event Hub source: the crash-time gap between checkpoint and sink predicted the loss exactly (9 lost with defaults, 1 with `maxEventsPerFetch=1`, 0 with synchronous delivery).

Root cause is the composition of two behaviors:

1. `SimpleSourceCommand.processFetchedData` commits the source checkpoint as soon as `sourceEventAcceptor.accept()` returns — and the whole DAG, sink flush included, runs synchronously inside `accept()`. The pipeline's durability guarantee is therefore exactly whatever a returned sink `flush()` promises.
2. kafkasink's default flush path (`flushFireAndForget`) called `producer.send(record, callback)` and returned without ever reading the send futures — records were only in the producer's in-heap accumulator (`linger.ms=10`, `batch.size=65536`). The only way to get the ack-waiting path was enabling `storeAndForwardEnabled` (the on-disk queue), which is not surfaced in the UI.

Setting `acks` in producer properties does **not** help this failure mode: it governs broker-side durability of a request that was sent, while these records died client-side before transmission.

## Changes

- **New `deliveryMode` config field** on kafkasink: `WAIT_FOR_ACK` (**new default**) routes to the existing synchronous path — send the batch, `producer.flush()`, then wait for every broker ack before returning. One broker round-trip per flushed batch; note the source flushes once per `accept()`, i.e. typically once per source record, so this is a real throughput trade (see behavior note below). `FIRE_AND_FORGET` is the old behavior as an explicit throughput-over-durability opt-in, now decoupled from the store-and-forward on-disk queue.
- **Durable path hardening**: `acks=all` + `enable.idempotence=true`, closing the residual leader-failure window. Idempotence is only applied when the effective (post user-override) properties still satisfy the producer's construction-time constraints (`acks=all/-1`, `retries>0`, `max.in.flight<=5`, no explicit `enable.idempotence`), so existing configs that pinned weaker values in `properties` keep constructing a valid producer. Fire-and-forget keeps `acks=1`.
- **Outage behavior**: every ack-waiting flusher now gets the connection-failure classifier, so the pre-send metadata probe fails an unreachable-broker batch after one bounded wait instead of paying `max.block.ms` per record. Mid-batch connectivity rethrows remain exclusive to store-and-forward (where buffer+replay makes a batch-level failure honest); without it, a mid-batch throw would misreport records whose acks already succeeded, so those stay per-record `ErrorOutput`s.
- **Validator** rejects `storeAndForwardEnabled: true` + `deliveryMode: FIRE_AND_FORGET` (store-and-forward requires flush-time failure detection).
- **Backward compatibility**: configs that don't mention `deliveryMode` get the durable default, including through Jackson's no-args-constructor path (which skips Lombok `@Builder.Default` initializers) — `getDeliveryMode()` normalizes `null` to `WAIT_FOR_ACK`. Store-and-forward semantics are unchanged (it always implied synchronous delivery). Test mode still only disables the on-disk queue, not ack-waiting.

## Behavior change note

Every existing kafkasink pipeline that doesn't opt into `FIRE_AND_FORGET` moves from `acks=1` fire-and-forget to ack-waiting with `acks=all` + idempotence — and because the source flushes per `accept()`, that wait usually happens per source record, not per fetch. That trades throughput for the delivery guarantee users almost certainly assumed they had; users who measured and want the old behavior set `deliveryMode: FIRE_AND_FORGET`. During a broker outage the default mode now fails each batch after one bounded metadata wait (records become error outputs / DLQ — reported, not silent); store-and-forward remains the no-drop answer for outages. Store-and-forward itself keeps its semantics but now runs `acks=all` under its bounded timeouts, so slow ISR replication can classify as connectivity → more buffer/replay cycles (still at-least-once). Worth a line in release notes.

Follow-ups tracked separately: surface `deliveryMode` in the UI (KafkaSinkNode) and fix the Additional Properties tooltip that presents `acks` as a durability knob; define the `Flusher` contract as "returns only when durable" and give the `AbstractBufferedFlusher` sinks (s3, databrickssink, deltalakesink) a durability barrier — they have the same accept-is-not-durable window in our own buffering code.

## Testing

- New `KafkaSinkDeliveryModeTest` (TDD; mocked producer through the `KafkaProducerClientFactory` seam), 10 cases: default config uses the synchronous send shape (`send(record)` xN → `producer.flush()`, no callback sends) and durable producer props; a failed broker ack becomes an `ErrorOutput` and is never counted as success; an unreachable broker fails the batch before any send; a legacy raw-map config without the `deliveryMode` key gets the durable default through the real Jackson parse path; `FIRE_AND_FORGET` opt-in keeps the async path and `acks=1`; user overrides of `acks`/`retries`/`max.in.flight` each suppress idempotence; store-and-forward implies `WAIT_FOR_ACK`.
- New validator case for the contradictory `storeAndForwardEnabled` + `FIRE_AND_FORGET` combo.
- Full `./gradlew test` suite (same as CI) green; kafkasink suite (61 tests incl. TestContainers integration tests against a real broker, now exercising the new default end-to-end, and the store-and-forward buffer/replay tests) and the SDK `KafkaIntegrationTest`: all pass, 0 skips.
- Reviewed by a code-review pass; all Critical/Important findings addressed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
