### PR TITLE
Quiet Kafka client retry log spam on unreachable broker

### DIFF
--- a/lib/src/main/resources/log4j2.xml
+++ b/lib/src/main/resources/log4j2.xml
@@ -11,6 +11,18 @@
       <AppenderRef ref="Console"/>
     </Logger>
 
+    <!-- Kafka clients retry indefinitely on an unreachable broker. Drop only the per-retry
+         chatter (INFO reconnect churn + the two repeating "could not connect" WARNs); real
+         diagnostics (auth/TLS failures, listener misconfig, version mismatches) still log at
+         WARN. Connectivity is also surfaced by ScheduledKafkaHealthMonitor's error log. -->
+    <Logger name="org.apache.kafka.clients.NetworkClient" level="warn">
+      <RegexFilter
+          regex=".*(Connection to node .* could not be established|Bootstrap broker .* disconnected).*"
+          onMatch="DENY" onMismatch="NEUTRAL" useRawMsg="false"/>
+    </Logger>
+    <Logger name="org.apache.kafka.clients.admin.internals.AdminMetadataManager" level="warn"/>
+    <Logger name="org.apache.kafka.clients.Metadata" level="warn"/>
+
     <Root level="info">
       <AppenderRef ref="Console"/>
     </Root>

--- a/runner/src/main/resources/log4j2-json.xml
+++ b/runner/src/main/resources/log4j2-json.xml
@@ -6,6 +6,18 @@
     </Console>
   </Appenders>
   <Loggers>
+    <!-- Kafka clients retry indefinitely on an unreachable broker. Drop only the per-retry
+         chatter (INFO reconnect churn + the two repeating "could not connect" WARNs); real
+         diagnostics (auth/TLS failures, listener misconfig, version mismatches) still log at
+         WARN. Connectivity is also surfaced by ScheduledKafkaHealthMonitor's error log. -->
+    <Logger name="org.apache.kafka.clients.NetworkClient" level="warn">
+      <RegexFilter
+          regex=".*(Connection to node .* could not be established|Bootstrap broker .* disconnected).*"
+          onMatch="DENY" onMismatch="NEUTRAL" useRawMsg="false"/>
+    </Logger>
+    <Logger name="org.apache.kafka.clients.admin.internals.AdminMetadataManager" level="warn"/>
+    <Logger name="org.apache.kafka.clients.Metadata" level="warn"/>
+
     <Root level="info">
       <AppenderRef ref="Console"/>
     </Root>

--- a/runner/src/main/resources/log4j2.xml
+++ b/runner/src/main/resources/log4j2.xml
@@ -6,6 +6,18 @@
     </Console>
   </Appenders>
   <Loggers>
+    <!-- Kafka clients retry indefinitely on an unreachable broker. Drop only the per-retry
+         chatter (INFO reconnect churn + the two repeating "could not connect" WARNs); real
+         diagnostics (auth/TLS failures, listener misconfig, version mismatches) still log at
+         WARN. Connectivity is also surfaced by ScheduledKafkaHealthMonitor's error log. -->
+    <Logger name="org.apache.kafka.clients.NetworkClient" level="warn">
+      <RegexFilter
+          regex=".*(Connection to node .* could not be established|Bootstrap broker .* disconnected).*"
+          onMatch="DENY" onMismatch="NEUTRAL" useRawMsg="false"/>
+    </Logger>
+    <Logger name="org.apache.kafka.clients.admin.internals.AdminMetadataManager" level="warn"/>
+    <Logger name="org.apache.kafka.clients.Metadata" level="warn"/>
+
     <Root level="info">
       <AppenderRef ref="Console"/>
     </Root>


### PR DESCRIPTION
Filter the two repeating NetworkClient reconnect WARNs and drop AdminMetadataManager/Metadata rebootstrap INFO chatter, while keeping auth/TLS, listener-misconfig and version-mismatch warnings.


Claude-Session: https://claude.ai/code/session_01MP3Kod5aKCyjiVDVk6w3Ff