### PR TITLE
FLE-2613: Scope the fs source resume checkpoint to the workflow

### DIFF
--- a/api/src/main/java/io/fleak/zephflow/api/JobContext.java
+++ b/api/src/main/java/io/fleak/zephflow/api/JobContext.java
@@ -34,6 +34,7 @@ public class JobContext implements Serializable {
   public static final String FLAG_TEST_MODE = "TEST_MODE";
   public static final String DATA_KEY_PREFIX = "DATA_KEY_PREFIX";
   public static final String CHECKPOINT_URL = "CHECKPOINT_URL";
+  public static final String CHECKPOINT_SCOPE = "CHECKPOINT_SCOPE";
   public static final String REPLICA_INDEX = "REPLICA_INDEX";
   public static final String REPLICA_COUNT = "REPLICA_COUNT";
   public static final String STORE_FORWARD_DIR = "STORE_FORWARD_DIR";

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/fssource/FsSourceCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/fssource/FsSourceCommand.java
@@ -49,6 +49,8 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 @Slf4j
 public final class FsSourceCommand extends SourceCommand {
 
+  static final String DEFAULT_CHECKPOINT_SCOPE = "local";
+
   private volatile boolean terminated = false;
 
   public FsSourceCommand(String nodeId, JobContext jobContext) {
@@ -79,6 +81,7 @@ public final class FsSourceCommand extends SourceCommand {
     executionContext.lister = executionContext.backend.createLister(backendConfig);
     executionContext.reader = executionContext.backend.createReader(backendConfig);
     executionContext.checkpointClient = buildCheckpointClient(jobContext);
+    executionContext.checkpointScope = checkpointScope(jobContext);
     executionContext.replicaIndex = parseIntProperty(jobContext, JobContext.REPLICA_INDEX, 0);
     executionContext.replicaCount = parseIntProperty(jobContext, JobContext.REPLICA_COUNT, 1);
 
@@ -129,6 +132,40 @@ public final class FsSourceCommand extends SourceCommand {
       log.warn("fs_source: unparseable {}={}; using default {}", key, value, defaultValue);
       return defaultValue;
     }
+  }
+
+  /**
+   * Resolves the identity the resume checkpoint belongs to. The scheduler-provided {@link
+   * JobContext#CHECKPOINT_SCOPE} keeps each workflow's progress separate over a shared folder;
+   * without it the checkpoint falls back to the current job, so a run re-reads the folder rather
+   * than inheriting another workflow's progress.
+   */
+  static String checkpointScope(JobContext jobContext) {
+    Object explicitScope =
+        jobContext.getOtherProperties() == null
+            ? null
+            : jobContext.getOtherProperties().get(JobContext.CHECKPOINT_SCOPE);
+    if (explicitScope != null && !explicitScope.toString().isBlank()) {
+      return explicitScope.toString().trim();
+    }
+    String jobId =
+        jobContext.getMetricTags() == null
+            ? null
+            : jobContext.getMetricTags().get(METRIC_TAG_JOB_ID);
+    if (jobId != null && !jobId.isBlank()) {
+      log.warn(
+          "fs_source: no {} in the job context; scoping the resume checkpoint to job_id={}, so this"
+              + " job cannot resume a previous job's progress",
+          JobContext.CHECKPOINT_SCOPE,
+          jobId);
+      return jobId.trim();
+    }
+    log.debug(
+        "fs_source: no {} and no {} in the job context; using checkpoint scope {}",
+        JobContext.CHECKPOINT_SCOPE,
+        METRIC_TAG_JOB_ID,
+        DEFAULT_CHECKPOINT_SCOPE);
+    return DEFAULT_CHECKPOINT_SCOPE;
   }
 
   private static CheckpointClient buildCheckpointClient(JobContext jobContext) {
@@ -205,6 +242,8 @@ public final class FsSourceCommand extends SourceCommand {
 
     String sourceId =
         SourceIdHasher.compute(
+            executionContext.checkpointScope,
+            nodeId,
             config.getBackend(),
             config.getRoot(),
             config.getFileNameRegex(),
@@ -212,7 +251,11 @@ public final class FsSourceCommand extends SourceCommand {
             executionContext.replicaIndex,
             executionContext.replicaCount);
     FsCheckpoint checkpoint = loadCheckpoint(executionContext.checkpointClient, sourceId);
-    log.info("fs_source open: sourceId={} watermark={}", sourceId, checkpoint.watermark());
+    log.info(
+        "fs_source open: sourceId={} checkpointScope={} watermark={}",
+        sourceId,
+        executionContext.checkpointScope,
+        checkpoint.watermark());
 
     Pattern fileNamePattern =
         config.getFileNameRegex() == null ? null : Pattern.compile(config.getFileNameRegex());

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/fssource/FsSourceExecutionContext.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/fssource/FsSourceExecutionContext.java
@@ -30,6 +30,7 @@ public final class FsSourceExecutionContext implements ExecutionContext {
   FileLister lister;
   FileReader reader;
   CheckpointClient checkpointClient;
+  String checkpointScope;
   int replicaIndex;
   int replicaCount = 1;
   FleakCounter dataSizeCounter;

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/fssource/util/SourceIdHasher.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/fssource/util/SourceIdHasher.java
@@ -20,41 +20,29 @@ public final class SourceIdHasher {
 
   private SourceIdHasher() {}
 
-  public static String compute(String backend, String root, String fileNameRegex) {
-    return hash16(canonical(backend, root, fileNameRegex));
-  }
-
   public static String compute(
-      String backend, String root, String fileNameRegex, int replicaIndex, int replicaCount) {
-    return compute(backend, root, fileNameRegex, null, replicaIndex, replicaCount);
-  }
-
-  public static String compute(
+      String checkpointScope,
+      String nodeId,
       String backend,
       String root,
       String fileNameRegex,
       String exactObjectKey,
       int replicaIndex,
       int replicaCount) {
-    String sourceIdentity = canonical(backend, root, fileNameRegex, exactObjectKey);
-    if (replicaCount <= 1) {
-      return hash16(sourceIdentity);
-    }
-    return hash16(sourceIdentity + "\n" + replicaIndex + "\n" + replicaCount);
-  }
-
-  private static String canonical(String backend, String root, String fileNameRegex) {
-    return canonical(backend, root, fileNameRegex, null);
-  }
-
-  private static String canonical(
-      String backend, String root, String fileNameRegex, String exactObjectKey) {
-    String legacyIdentity =
-        backend + "\n" + root + "\n" + (fileNameRegex == null ? "" : fileNameRegex);
-    return exactObjectKey == null ? legacyIdentity : legacyIdentity + "\n" + exactObjectKey;
-  }
-
-  private static String hash16(String value) {
-    return Hashing.sha256().hashString(value, StandardCharsets.UTF_8).toString().substring(0, 16);
+    String canonicalIdentity =
+        String.join(
+            "\n",
+            checkpointScope,
+            nodeId,
+            backend,
+            root,
+            fileNameRegex == null ? "" : fileNameRegex,
+            exactObjectKey == null ? "" : exactObjectKey,
+            String.valueOf(replicaIndex),
+            String.valueOf(replicaCount));
+    return Hashing.sha256()
+        .hashString(canonicalIdentity, StandardCharsets.UTF_8)
+        .toString()
+        .substring(0, 16);
   }
 }

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/StoreForwardPaths.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/sink/StoreForwardPaths.java
@@ -13,6 +13,8 @@
  */
 package io.fleak.zephflow.lib.commands.sink;
 
+import static io.fleak.zephflow.lib.utils.MiscUtils.METRIC_TAG_JOB_ID;
+
 import io.fleak.zephflow.api.JobContext;
 import java.io.Serializable;
 import java.nio.file.Path;
@@ -33,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 public final class StoreForwardPaths {
 
   static final String DEFAULT_BASE_DIR_NAME = "zephflow-store-forward";
-  static final String METRIC_TAG_JOB_ID = "job_id";
   static final String DEFAULT_JOB_ID = "local";
   static final String REPLICA_DIR_PREFIX = "replica-";
 

--- a/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/utils/MiscUtils.java
@@ -135,6 +135,7 @@ public interface MiscUtils {
   String METRIC_TAG_CALLING_USER = "calling_user";
   String METRIC_TAG_COMMAND_NAME = "command_name";
   String METRIC_TAG_NODE_ID = "node_id";
+  String METRIC_TAG_JOB_ID = "job_id";
   String METRIC_TAG_ENV = "env";
   String METRIC_TAG_SERVICE = "service";
   String REGEX_WINDOWS_LINE_SEPARATOR = "\\r\\n";

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/fssource/FsSourceCheckpointScopeTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/fssource/FsSourceCheckpointScopeTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.fssource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.fleak.zephflow.api.JobContext;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class FsSourceCheckpointScopeTest {
+
+  private static JobContext jobContext(String checkpointScope, String jobId) {
+    Map<String, java.io.Serializable> otherProperties = new HashMap<>();
+    if (checkpointScope != null) {
+      otherProperties.put(JobContext.CHECKPOINT_SCOPE, checkpointScope);
+    }
+    Map<String, String> metricTags = new HashMap<>();
+    if (jobId != null) {
+      metricTags.put("job_id", jobId);
+    }
+    return JobContext.builder().otherProperties(otherProperties).metricTags(metricTags).build();
+  }
+
+  @Test
+  void explicitScopeWinsOverJobId() {
+    assertEquals("pipeline-1", FsSourceCommand.checkpointScope(jobContext("pipeline-1", "job-9")));
+  }
+
+  @Test
+  void fallsBackToJobIdWhenNoExplicitScope() {
+    assertEquals("job-9", FsSourceCommand.checkpointScope(jobContext(null, "job-9")));
+  }
+
+  @Test
+  void blankExplicitScopeFallsBackToJobId() {
+    assertEquals("job-9", FsSourceCommand.checkpointScope(jobContext("   ", "job-9")));
+  }
+
+  @Test
+  void fallsBackToLocalWhenNothingIdentifiesTheJob() {
+    assertEquals("local", FsSourceCommand.checkpointScope(jobContext(null, null)));
+  }
+
+  @Test
+  void toleratesAbsentJobContextMaps() {
+    JobContext withoutMaps = JobContext.builder().otherProperties(null).metricTags(null).build();
+
+    assertEquals("local", FsSourceCommand.checkpointScope(withoutMaps));
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/fssource/FsSourceCommandResumeTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/fssource/FsSourceCommandResumeTest.java
@@ -140,4 +140,53 @@ class FsSourceCommandResumeTest {
     assertEquals(
         List.of("a", "b"), second.stream().map(record -> record.unwrap().get("v")).toList());
   }
+
+  private List<RecordFleakData> runWithCheckpointScope(Path tempDir, String checkpointScope)
+      throws Exception {
+    JobContext jobContext =
+        JobContext.builder()
+            .otherProperties(
+                new HashMap<>(
+                    Map.of(
+                        JobContext.CHECKPOINT_URL,
+                        baseUrl,
+                        JobContext.CHECKPOINT_SCOPE,
+                        checkpointScope)))
+            .build();
+    return run(tempDir, jobContext);
+  }
+
+  private static List<Object> emittedValues(List<RecordFleakData> records) {
+    return records.stream().map(record -> record.unwrap().get("v")).toList();
+  }
+
+  @Test
+  void aNewCheckpointScopeReadsTheWholeFolder(@TempDir Path tempDir) throws Exception {
+    Files.writeString(tempDir.resolve("evt_1.log"), "{\"v\":\"a\"}");
+    Files.writeString(tempDir.resolve("evt_2.log"), "{\"v\":\"b\"}");
+
+    assertEquals(List.of("a", "b"), emittedValues(runWithCheckpointScope(tempDir, "workflow-a")));
+
+    Files.writeString(tempDir.resolve("evt_3.log"), "{\"v\":\"c\"}");
+    Files.writeString(tempDir.resolve("evt_4.log"), "{\"v\":\"d\"}");
+
+    List<RecordFleakData> otherWorkflow = runWithCheckpointScope(tempDir, "workflow-b");
+
+    assertEquals(
+        List.of("a", "b", "c", "d"),
+        emittedValues(otherWorkflow),
+        "a workflow that has never read this folder must not inherit another workflow's progress");
+    assertEquals(2, store.size(), "each checkpoint scope keeps its own checkpoint entry");
+  }
+
+  @Test
+  void theSameCheckpointScopeResumesAfterItsOwnCheckpoint(@TempDir Path tempDir) throws Exception {
+    Files.writeString(tempDir.resolve("evt_1.log"), "{\"v\":\"a\"}");
+
+    assertEquals(List.of("a"), emittedValues(runWithCheckpointScope(tempDir, "workflow-a")));
+
+    Files.writeString(tempDir.resolve("evt_2.log"), "{\"v\":\"b\"}");
+
+    assertEquals(List.of("b"), emittedValues(runWithCheckpointScope(tempDir, "workflow-a")));
+  }
 }

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/fssource/util/SourceIdHasherTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/fssource/util/SourceIdHasherTest.java
@@ -19,77 +19,71 @@ import org.junit.jupiter.api.Test;
 
 class SourceIdHasherTest {
 
+  private static final String SCOPE = "11111111-1111-4111-8111-111111111111";
+  private static final String OTHER_SCOPE = "22222222-2222-4222-8222-222222222222";
+  private static final String NODE_ID = "s3_source";
+  private static final String ROOT = "s3://bkt/data/";
+  private static final String FILE_NAME_REGEX = "invoice_(?<ts>\\d+)\\.json";
+
+  private static String computeForRoot(String checkpointScope, String nodeId, String root) {
+    return SourceIdHasher.compute(checkpointScope, nodeId, "s3", root, FILE_NAME_REGEX, null, 0, 1);
+  }
+
   @Test
   void stableAcrossCalls() {
-    String a = SourceIdHasher.compute("s3", "s3://bkt/data/", "invoice_(?<ts>\\d+)\\.json");
-    String b = SourceIdHasher.compute("s3", "s3://bkt/data/", "invoice_(?<ts>\\d+)\\.json");
-    assertEquals(a, b);
+    assertEquals(computeForRoot(SCOPE, NODE_ID, ROOT), computeForRoot(SCOPE, NODE_ID, ROOT));
+  }
+
+  @Test
+  void differentCheckpointScopesDiffer() {
+    assertNotEquals(
+        computeForRoot(SCOPE, NODE_ID, ROOT), computeForRoot(OTHER_SCOPE, NODE_ID, ROOT));
+  }
+
+  @Test
+  void differentNodeIdsDiffer() {
+    assertNotEquals(
+        computeForRoot(SCOPE, "first_source", ROOT), computeForRoot(SCOPE, "second_source", ROOT));
   }
 
   @Test
   void differentRootsDiffer() {
-    String a = SourceIdHasher.compute("s3", "s3://bkt/data1/", null);
-    String b = SourceIdHasher.compute("s3", "s3://bkt/data2/", null);
-    assertNotEquals(a, b);
+    assertNotEquals(
+        computeForRoot(SCOPE, NODE_ID, "s3://bkt/data1/"),
+        computeForRoot(SCOPE, NODE_ID, "s3://bkt/data2/"));
   }
 
   @Test
   void length16Hex() {
-    String a = SourceIdHasher.compute("file", "/tmp/x", null);
-    assertEquals(16, a.length());
-    assertTrue(a.matches("[0-9a-f]{16}"));
+    String id = computeForRoot(SCOPE, NODE_ID, ROOT);
+    assertEquals(16, id.length());
+    assertTrue(id.matches("[0-9a-f]{16}"));
   }
 
   @Test
   void nullRegexAllowed() {
-    assertDoesNotThrow(() -> SourceIdHasher.compute("file", "/tmp/x", null));
+    assertDoesNotThrow(
+        () -> SourceIdHasher.compute(SCOPE, NODE_ID, "file", "/tmp/x", null, null, 0, 1));
   }
 
   @Test
-  void singleReplicaOverloadMatchesLegacyThreeArg() {
-    String legacy = SourceIdHasher.compute("s3", "s3://bucket/root", "evt_(?<ts>\\d+)\\.log");
-    String shardedCount1 =
-        SourceIdHasher.compute("s3", "s3://bucket/root", "evt_(?<ts>\\d+)\\.log", 0, 1);
-    assertEquals(legacy, shardedCount1);
-  }
+  void distinctIdsPerReplica() {
+    String replica0 = SourceIdHasher.compute(SCOPE, NODE_ID, "s3", ROOT, null, null, 0, 3);
+    String replica1 = SourceIdHasher.compute(SCOPE, NODE_ID, "s3", ROOT, null, null, 1, 3);
+    String replica2 = SourceIdHasher.compute(SCOPE, NODE_ID, "s3", ROOT, null, null, 2, 3);
 
-  @Test
-  void countZeroAlsoMatchesLegacy() {
-    String legacy = SourceIdHasher.compute("file", "file:///data", null);
-    assertEquals(legacy, SourceIdHasher.compute("file", "file:///data", null, 0, 0));
-  }
-
-  @Test
-  void distinctIdsPerReplicaWhenCountGreaterThanOne() {
-    String r0 = SourceIdHasher.compute("s3", "s3://bucket/root", null, 0, 3);
-    String r1 = SourceIdHasher.compute("s3", "s3://bucket/root", null, 1, 3);
-    String r2 = SourceIdHasher.compute("s3", "s3://bucket/root", null, 2, 3);
-    assertNotEquals(r0, r1);
-    assertNotEquals(r1, r2);
-    assertNotEquals(r0, r2);
-  }
-
-  @Test
-  void shardedIdDiffersFromLegacyWhenCountGreaterThanOne() {
-    String legacy = SourceIdHasher.compute("s3", "s3://bucket/root", null);
-    assertNotEquals(legacy, SourceIdHasher.compute("s3", "s3://bucket/root", null, 0, 3));
+    assertNotEquals(replica0, replica1);
+    assertNotEquals(replica1, replica2);
+    assertNotEquals(replica0, replica2);
   }
 
   @Test
   void exactObjectKeyChangesCheckpointIdentity() {
     String first =
-        SourceIdHasher.compute("s3", "s3://bucket/root/", null, "root/a/events.jsonl", 0, 1);
+        SourceIdHasher.compute(SCOPE, NODE_ID, "s3", ROOT, null, "root/a/events.jsonl", 0, 1);
     String second =
-        SourceIdHasher.compute("s3", "s3://bucket/root/", null, "root/b/events.jsonl", 0, 1);
+        SourceIdHasher.compute(SCOPE, NODE_ID, "s3", ROOT, null, "root/b/events.jsonl", 0, 1);
 
     assertNotEquals(first, second);
-  }
-
-  @Test
-  void nullExactObjectKeyPreservesLegacyCheckpointIdentity() {
-    String legacy = SourceIdHasher.compute("s3", "s3://bucket/root/", null, 0, 3);
-    String withNullExactKey = SourceIdHasher.compute("s3", "s3://bucket/root/", null, null, 0, 3);
-
-    assertEquals(legacy, withNullExactKey);
   }
 }


### PR DESCRIPTION
## Problem

`fssource` derived its resume checkpoint key from the source shape alone — `backend`, `root`, `fileNameRegex`, `exactObjectKey`, plus the replica shard. Two workflows pointed at the same folder produced the same key and therefore shared one checkpoint entry.

Reported from QA on dev: workflow A read a folder; a brand-new workflow B on the same folder read only the files newer than A's watermark and reported success, with nothing indicating that the older files had been skipped.

## Fix

The key now also covers a scheduler-provided `CHECKPOINT_SCOPE` and the node id (two source nodes over one folder collided as well).

Scope resolution, in order:

1. `jobContext.otherProperties.CHECKPOINT_SCOPE` — the workflow id, set by the control plane.
2. the `job_id` metric tag, with a warning — a run re-reads the folder instead of inheriting another workflow's progress.
3. `local`, for SDK and local runs, which checkpoint in memory anyway.

The fallback never widens the scope, so an unscoped job re-reads rather than silently skipping.

`SourceIdHasher` collapses to one `compute` method; the previous overloads only existed to keep pre-sharding keys stable, and this change re-keys them regardless. `METRIC_TAG_JOB_ID` moves to `MiscUtils` next to the other metric tag names, replacing the private copy in `StoreForwardPaths`.

## Migration

Existing checkpoint entries keep the old identity and are not migrated, so the first run after this ships re-reads the whole folder for each existing deployment. A "fall back to the legacy key" shim would reintroduce the bug — for a new workflow the legacy key is exactly the entry it must not inherit.

## Tests

- `FsSourceCommandResumeTest.aNewCheckpointScopeReadsTheWholeFolder` reproduces the report against the HTTP-backed checkpoint store: it failed with `expected: <[a, b, c, d]> but was: <[c, d]>` before the fix.
- `theSameCheckpointScopeResumesAfterItsOwnCheckpoint` guards the resume path a per-run scope would break.
- `FsSourceCheckpointScopeTest` covers the fallback chain, blank scopes, and absent job-context maps.
- `SourceIdHasherTest` covers scope, node id, root, replica and exact-key separation.

`./gradlew build` passes (lib: 1787 tests).

## Requires

The control plane must set `CHECKPOINT_SCOPE`. Until it does, the `job_id` fallback applies.