### PR TITLE
Fail fast on a missing or unreadable Kafka source topic instead of auto-creating it (FLE-2625)

### DIFF
--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaConsumerClientFactory.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaConsumerClientFactory.java
@@ -16,17 +16,84 @@ package io.fleak.zephflow.lib.commands.kafkasource;
 import io.fleak.zephflow.lib.kafka.KafkaHealthMonitor;
 import io.fleak.zephflow.lib.kafka.ScheduledKafkaHealthMonitor;
 import java.io.Serializable;
+import java.time.Duration;
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 
 /** Created by bolei on 9/24/24 Created for unit test purpose */
 @Slf4j
 public class KafkaConsumerClientFactory implements Serializable {
+  private static final long TOPIC_CHECK_TIMEOUT_MS = 30_000;
+  private static final Duration ADMIN_CLOSE_TIMEOUT = Duration.ofSeconds(5);
+
   public KafkaConsumer<byte[], byte[]> createKafkaConsumer(Properties consumerProps) {
     return new KafkaConsumer<>(consumerProps);
+  }
+
+  /**
+   * Fails when the topic does not exist on the broker, or when the principal is not allowed to
+   * describe it. describeTopics never triggers broker-side auto-creation, so this is safe to call
+   * before subscribing. Connectivity problems are only logged: the consumer keeps its existing
+   * retry behaviour for those.
+   *
+   * <p>An authorization failure is treated like a missing topic on purpose: Kafka answers
+   * TOPIC_AUTHORIZATION_FAILED for any topic the principal cannot describe instead of revealing
+   * whether it exists, and every principal that can read a topic can also describe it, so a denial
+   * here means the consumer could not have read the topic either.
+   *
+   * @throws IllegalArgumentException if the broker reports the topic as unknown or unauthorized
+   */
+  public void verifyTopicExists(Properties consumerProps, String topic) {
+    Object bootstrapServers = consumerProps.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG);
+    AdminClient adminClient = AdminClient.create(consumerProps);
+    try {
+      verifyTopicExists(adminClient, bootstrapServers, topic);
+    } finally {
+      adminClient.close(ADMIN_CLOSE_TIMEOUT);
+    }
+  }
+
+  static void verifyTopicExists(AdminClient adminClient, Object bootstrapServers, String topic) {
+    try {
+      adminClient
+          .describeTopics(List.of(topic))
+          .topicNameValues()
+          .get(topic)
+          .get(TOPIC_CHECK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof UnknownTopicOrPartitionException) {
+        throw new IllegalArgumentException(
+            String.format("Kafka topic '%s' was not found on broker %s", topic, bootstrapServers),
+            cause);
+      }
+      if (cause instanceof TopicAuthorizationException) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Not authorized to describe Kafka topic '%s' on broker %s; a consumer that can"
+                    + " read a topic can also describe it, so check the topic name and the"
+                    + " principal's permissions",
+                topic, bootstrapServers),
+            cause);
+      }
+      log.warn(
+          "Could not verify Kafka topic {} on broker {}; continuing", topic, bootstrapServers, e);
+    } catch (TimeoutException e) {
+      log.warn(
+          "Timed out verifying Kafka topic {} on broker {}; continuing", topic, bootstrapServers);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while verifying Kafka topic " + topic, e);
+    }
   }
 
   public KafkaHealthMonitor createAndStartHealthMonitor(Properties consumerProps) {

--- a/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaSourceCommand.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaSourceCommand.java
@@ -91,6 +91,15 @@ public class KafkaSourceCommand extends SimpleSourceCommand<SerializedEvent> {
   private Fetcher<SerializedEvent> createKafkaFetcher(KafkaSourceDto.Config config) {
     Properties consumerProps = KafkaClientProperties.source(config);
     log.debug("Using consumer: {}", consumerProps.get(ConsumerConfig.GROUP_ID_CONFIG));
+    // Kafka trims boolean config values before parsing them; mirror that so the gate and the
+    // consumer agree on what the user configured.
+    if (!Boolean.parseBoolean(
+        consumerProps.getProperty(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG).trim())) {
+      // Subscribing can no longer create the topic, so a missing topic would otherwise leave the
+      // consumer polling an empty assignment forever while the job looks healthy. Fail here,
+      // before any consumer thread starts, so the process exits with a clear error instead.
+      kafkaConsumerClientFactory.verifyTopicExists(consumerProps, config.getTopic());
+    }
     KafkaConsumer<byte[], byte[]> consumer =
         kafkaConsumerClientFactory.createKafkaConsumer(consumerProps);
     initializeKafkaConsumer(consumer, config.getTopic());

--- a/lib/src/main/java/io/fleak/zephflow/lib/kafka/KafkaClientProperties.java
+++ b/lib/src/main/java/io/fleak/zephflow/lib/kafka/KafkaClientProperties.java
@@ -48,6 +48,9 @@ public final class KafkaClientProperties {
     props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "10000");
     props.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "10485760");
     props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    // Never create topics on the broker as a side effect of subscribing (KIP-361). A node that
+    // relies on auto-creation can opt back in with allow.auto.create.topics=true in properties.
+    props.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "false");
 
     if (config.getProperties() != null) {
       props.putAll(config.getProperties());

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaConsumerClientFactoryTopicCheckTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaConsumerClientFactoryTopicCheckTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.kafkasource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.junit.jupiter.api.Test;
+
+/** How the topic check interprets the broker's describeTopics answer. */
+class KafkaConsumerClientFactoryTopicCheckTest {
+
+  private static final String TOPIC = "orders";
+  private static final String BROKER = "broker:9092";
+
+  @Test
+  void unknownTopicFailsWithTheTopicName() {
+    var cause = new UnknownTopicOrPartitionException("Topic orders not found.");
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> KafkaConsumerClientFactory.verifyTopicExists(failing(cause), BROKER, TOPIC));
+    assertTrue(
+        e.getMessage().contains("'orders' was not found on broker broker:9092"), e.getMessage());
+    assertSame(cause, e.getCause());
+  }
+
+  // Brokers answer TOPIC_AUTHORIZATION_FAILED for any topic the principal cannot describe, whether
+  // or not it exists, so a mistyped topic on an ACL-protected cluster arrives here.
+  @Test
+  void unauthorizedTopicFailsLikeAMissingOne() {
+    var cause = new TopicAuthorizationException(Set.of(TOPIC));
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> KafkaConsumerClientFactory.verifyTopicExists(failing(cause), BROKER, TOPIC));
+    assertTrue(
+        e.getMessage().contains("Not authorized to describe Kafka topic 'orders'"), e.getMessage());
+    assertTrue(e.getMessage().contains("topic name"), e.getMessage());
+    assertSame(cause, e.getCause());
+  }
+
+  // Anything else (broker unreachable, request timed out, ...) keeps the consumer's existing
+  // connection-retry behaviour instead of failing the job.
+  @Test
+  void otherFailuresAreLoggedAndIgnored() {
+    var cause = new org.apache.kafka.common.errors.TimeoutException("no response");
+    assertDoesNotThrow(
+        () -> KafkaConsumerClientFactory.verifyTopicExists(failing(cause), BROKER, TOPIC));
+  }
+
+  @Test
+  void existingTopicPasses() {
+    KafkaFutureImpl<TopicDescription> future = new KafkaFutureImpl<>();
+    future.complete(new TopicDescription(TOPIC, false, List.of()));
+    assertDoesNotThrow(
+        () -> KafkaConsumerClientFactory.verifyTopicExists(describing(future), BROKER, TOPIC));
+  }
+
+  private static AdminClient failing(Throwable cause) {
+    KafkaFutureImpl<TopicDescription> future = new KafkaFutureImpl<>();
+    future.completeExceptionally(cause);
+    return describing(future);
+  }
+
+  private static AdminClient describing(KafkaFuture<TopicDescription> future) {
+    DescribeTopicsResult result = mock();
+    when(result.topicNameValues()).thenReturn(Map.of(TOPIC, future));
+    AdminClient adminClient = mock();
+    when(adminClient.describeTopics(anyCollection())).thenReturn(result);
+    return adminClient;
+  }
+}

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaSourceCommandTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaSourceCommandTest.java
@@ -15,6 +15,9 @@ package io.fleak.zephflow.lib.commands.kafkasource;
 
 import static io.fleak.zephflow.lib.utils.JsonUtils.OBJECT_MAPPER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.fleak.zephflow.api.SourceEventAcceptor;
@@ -152,6 +155,74 @@ public class KafkaSourceCommandTest {
       //noinspection ResultOfMethodCallIgnored
       executor.awaitTermination(5, TimeUnit.SECONDS);
     }
+  }
+
+  // A mistyped topic must not be created on the broker as a side effect of subscribing, and the
+  // command must fail at initialization instead of polling an empty assignment forever.
+  @Test
+  public void testMissingTopicFailsFastWithoutCreatingIt() throws Exception {
+    String missingTopic = "missing_topic_" + System.currentTimeMillis();
+    KafkaSourceCommand kafkaSourceCommand = createCommand(missingTopic, Map.of());
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                kafkaSourceCommand.initialize(new MetricClientProvider.NoopMetricClientProvider()));
+
+    assertTrue(e.getMessage().contains(missingTopic), e.getMessage());
+    assertFalse(adminClient.listTopics().names().get(30, TimeUnit.SECONDS).contains(missingTopic));
+  }
+
+  // Explicit opt-in keeps the old behaviour: no existence check, and the broker creates the topic
+  // when the consumer subscribes (the test broker runs with auto.create.topics.enable=true).
+  @Test
+  public void testMissingTopicIsCreatedWhenAutoCreateExplicitlyAllowed() throws Exception {
+    String topic = "opt_in_topic_" + System.currentTimeMillis();
+    KafkaSourceCommand kafkaSourceCommand =
+        createCommand(topic, Map.of("allow.auto.create.topics", "true"));
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> future =
+          executor.submit(
+              () -> {
+                kafkaSourceCommand.initialize(new MetricClientProvider.NoopMetricClientProvider());
+                kafkaSourceCommand.execute("test_user", new TestSourceEventAcceptor());
+                return null;
+              });
+      try {
+        long deadline = System.currentTimeMillis() + 30_000;
+        boolean created = false;
+        while (!created && System.currentTimeMillis() < deadline) {
+          Thread.sleep(500);
+          created = adminClient.listTopics().names().get(10, TimeUnit.SECONDS).contains(topic);
+        }
+        assertTrue(created, "expected the broker to auto-create " + topic);
+      } finally {
+        future.cancel(true);
+      }
+    } finally {
+      executor.shutdownNow();
+      //noinspection ResultOfMethodCallIgnored
+      executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private static KafkaSourceCommand createCommand(String topic, Map<String, String> properties) {
+    KafkaSourceCommand kafkaSourceCommand =
+        new KafkaSourceCommandFactory().createCommand("my_node", TestUtils.JOB_CONTEXT);
+    KafkaSourceDto.Config config =
+        KafkaSourceDto.Config.builder()
+            .broker(KAFKA_CONTAINER.getBootstrapServers())
+            .topic(topic)
+            .encodingType(EncodingType.JSON_OBJECT)
+            .groupId("test-group-" + System.currentTimeMillis())
+            .properties(properties)
+            .build();
+    kafkaSourceCommand.parseAndValidateArg(
+        OBJECT_MAPPER.convertValue(config, new TypeReference<>() {}));
+    return kafkaSourceCommand;
   }
 
   private void sendTestMessages(int batchCount) {

--- a/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaSourceCommandTopicCheckTest.java
+++ b/lib/src/test/java/io/fleak/zephflow/lib/commands/kafkasource/KafkaSourceCommandTopicCheckTest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2025 Fleak Tech Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fleak.zephflow.lib.commands.kafkasource;
+
+import static io.fleak.zephflow.lib.utils.JsonUtils.OBJECT_MAPPER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.fleak.zephflow.api.metric.MetricClientProvider;
+import io.fleak.zephflow.lib.TestUtils;
+import io.fleak.zephflow.lib.commands.JsonConfigParser;
+import io.fleak.zephflow.lib.serdes.EncodingType;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/** Consumer-property defaults and the topic existence check, without a real broker. */
+class KafkaSourceCommandTopicCheckTest {
+
+  private static final String TOPIC = "my_topic";
+
+  private final KafkaConsumerClientFactory factory = mock();
+
+  @Test
+  void autoCreateIsOffByDefaultAndTopicIsVerified() {
+    when(factory.createKafkaConsumer(any())).thenReturn(mock());
+    when(factory.createAndStartHealthMonitor(any())).thenReturn(mock());
+
+    initialize(createCommand(null));
+
+    ArgumentCaptor<Properties> props = ArgumentCaptor.forClass(Properties.class);
+    verify(factory).verifyTopicExists(props.capture(), eq(TOPIC));
+    assertEquals(
+        "false", props.getValue().getProperty(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG));
+    verify(factory).createKafkaConsumer(props.getValue());
+  }
+
+  @Test
+  void explicitOptInSkipsTheCheckAndKeepsAutoCreateOn() {
+    when(factory.createKafkaConsumer(any())).thenReturn(mock());
+    when(factory.createAndStartHealthMonitor(any())).thenReturn(mock());
+
+    // Surrounding whitespace is what a hand-written config may contain; Kafka trims it, so the
+    // gate must treat it as opted in too.
+    initialize(createCommand(Map.of(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, " true ")));
+
+    verify(factory, never()).verifyTopicExists(any(), any());
+    ArgumentCaptor<Properties> props = ArgumentCaptor.forClass(Properties.class);
+    verify(factory).createKafkaConsumer(props.capture());
+    assertEquals(
+        " true ", props.getValue().getProperty(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG));
+  }
+
+  @Test
+  void missingTopicAbortsBeforeAnyConsumerIsCreated() {
+    doThrow(new IllegalArgumentException("topic not found"))
+        .when(factory)
+        .verifyTopicExists(any(), eq(TOPIC));
+
+    KafkaSourceCommand command = createCommand(null);
+    assertThrows(IllegalArgumentException.class, () -> initialize(command));
+
+    verify(factory, never()).createKafkaConsumer(any());
+    verify(factory, never()).createAndStartHealthMonitor(any());
+  }
+
+  private KafkaSourceCommand createCommand(Map<String, String> properties) {
+    KafkaSourceCommand command =
+        new KafkaSourceCommand(
+            "my_node",
+            TestUtils.JOB_CONTEXT,
+            new JsonConfigParser<>(KafkaSourceDto.Config.class),
+            new KafkaSourceConfigValidator(),
+            factory);
+    KafkaSourceDto.Config config =
+        KafkaSourceDto.Config.builder()
+            .broker("localhost:9092")
+            .topic(TOPIC)
+            .groupId("test-group")
+            .encodingType(EncodingType.JSON_OBJECT)
+            .properties(properties)
+            .build();
+    command.parseAndValidateArg(OBJECT_MAPPER.convertValue(config, new TypeReference<>() {}));
+    return command;
+  }
+
+  private static void initialize(KafkaSourceCommand command) {
+    command.initialize(new MetricClientProvider.NoopMetricClientProvider());
+  }
+}


### PR DESCRIPTION
## Why

Deploying a Kafka source with a topic that does not exist used to create that topic on the broker as a side effect of subscribing, and the deployment then looked healthy while consuming nothing. Reported in https://linear.app/fleak/issue/FLE-2625.

## What

- The consumer defaults `allow.auto.create.topics` to `false`. A node that relies on auto-creation can set it back to `true` in its `properties`; that value is also what turns the new check off.
- Before the consumer is created, the source asks the broker for the topic with `describeTopics`, which never triggers auto-creation. An unknown topic fails initialization with `Kafka topic 'x' was not found on broker y`. A topic the principal may not describe fails with a message pointing at both the name and the permissions, since Kafka reports unauthorized topics instead of revealing whether they exist, and any principal that can read a topic can also describe it. The process exits non-zero, so the platform records a failed task instead of a green idle deployment.
- Connectivity problems (timeout, unreachable broker) only log a warning and fall through to the consumer's existing retry behaviour. Startup may wait up to 30 s in that case.
- The AdminClient is built from the consumer properties, so it logs the same "unknown config" warnings the existing health monitor already does. A topic deleted while the job is running is not detected by this change.

## Testing

- Unit tests (Mockito): property default, opt-in with surrounding whitespace, check skipped when opted in, no consumer created on failure; the check's four outcomes on the broker's answer (unknown, unauthorized, other failure, existing).
- Integration tests (Testcontainers, `apache/kafka-native:3.8.0`): a missing topic fails initialization and is not created on the broker; explicit opt-in lets the broker create it.
- Full `kafkasource` test suite (28 tests) and the SDK `KafkaIntegrationTest` pass on a Docker host.